### PR TITLE
remove question general/topic-research_field/name

### DIFF
--- a/rdmorganiser/questions/rdmo.xml
+++ b/rdmorganiser/questions/rdmo.xml
@@ -158,36 +158,6 @@
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://rdmorganiser.github.io/terms/questions/rdmo/general/topic-research_field/name">
-		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
-		<key>name</key>
-		<path>rdmo/general/topic-research_field/name</path>
-		<dc:comment/>
-		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/coordination/name"/>
-		<questionset dc:uri="https://rdmorganiser.github.io/terms/questions/rdmo/general/topic-research_field"/>
-		<is_collection>True</is_collection>
-		<order>2</order>
-		<help lang="en"/>
-		<text lang="en">Which persons or institutions are responsible for the project coordination?</text>
-		<verbose_name lang="en"/>
-		<verbose_name_plural lang="en"/>
-		<help lang="de"/>
-		<text lang="de">Welche Personen oder Institutionen sind verantwortlich für die Projektkoordination?</text>
-		<verbose_name lang="de"/>
-		<verbose_name_plural lang="de"/>
-		<help lang="fr"/>
-		<text lang="fr">Quelles personnes ou institutions sont responsables de la coordination du projet?</text>
-		<verbose_name lang="fr"/>
-		<verbose_name_plural lang="fr"/>
-		<widget_type>text</widget_type>
-		<value_type>text</value_type>
-		<maximum/>
-		<minimum/>
-		<step/>
-		<unit/>
-		<optionsets/>
-		<conditions/>
-	</question>
 	<questionset dc:uri="https://rdmorganiser.github.io/terms/questions/rdmo/general/project-schedule-schedule">
 		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
 		<key>project-schedule-schedule</key>


### PR DESCRIPTION
This PR proposes to remove a question `general/topic-research_field/name`

This question is an artifact introduced  via c5fe7d1abbc8ce2a19cc6ba24a7ca796428cd908

The question is replicating question `general/project-partners-name/name` but using a different path `general/topic-research_field/name`

