### PR TITLE
Use https://rdmo.fodako.nrw as uri prefix for fodako catalogs

### DIFF
--- a/shared/fodako/101_dfg.xml
+++ b/shared/fodako/101_dfg.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <rdmo xmlns:dc="http://purl.org/dc/elements/1.1/">
-	<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<catalog dc:uri="https://rdmo.fodako.nrw/questions/101_dfg">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>101_dfg</key>
 		<dc:comment>Dieser Fragenkatalog ist eine Teilmenge des Katalogs &quot;Alle Fragen&quot; (eine Überarbeitung des Katalogs &quot;RDMO&quot;) und enthält nur die Fragen, die die Anforderungen in  
 
@@ -16,23 +16,23 @@ abdecken. Die Ausfüllhilfen sind zum großen Teil Hinweise aus der oben genannt
 		<title lang="en">DFG 101 Ancient Cultures</title>
 		<title lang="de">DFG 101 Alte Kulturen</title>
 	</catalog>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/general">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/general">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>general</key>
 		<path>101_dfg/general</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/101_dfg"/>
 		<order>0</order>
 		<title lang="en">General</title>
 		<title lang="de">Allgemein</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/general/project-partners-name">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/general/project-partners-name">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>project-partners-name</key>
 		<path>101_dfg/general/project-partners-name</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/general"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/general"/>
 		<is_collection>False</is_collection>
 		<order>20</order>
 		<title lang="en">Project coordination</title>
@@ -45,13 +45,13 @@ abdecken. Die Ausfüllhilfen sind zum großen Teil Hinweise aus der oben genannt
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/general/project-partners-name/name">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/general/project-partners-name/name">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>name</key>
 		<path>101_dfg/general/project-partners-name/name</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/coordination/name"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/general/project-partners-name"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/general/project-partners-name"/>
 		<is_collection>True</is_collection>
 		<order>0</order>
 		<help lang="en"/>
@@ -71,13 +71,13 @@ abdecken. Die Ausfüllhilfen sind zum großen Teil Hinweise aus der oben genannt
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/general/project-partners-partner">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/general/project-partners-partner">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>project-partners-partner</key>
 		<path>101_dfg/general/project-partners-partner</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/partner"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/general"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/general"/>
 		<is_collection>True</is_collection>
 		<order>21</order>
 		<title lang="en">Project partners</title>
@@ -90,13 +90,13 @@ abdecken. Die Ausfüllhilfen sind zum großen Teil Hinweise aus der oben genannt
 		<verbose_name_plural lang="de">Projektpartner</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/general/project-partners-partner/name">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/general/project-partners-partner/name">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>name</key>
 		<path>101_dfg/general/project-partners-partner/name</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/partner/name"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/general/project-partners-partner"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/general/project-partners-partner"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<help lang="en"/>
@@ -116,13 +116,13 @@ abdecken. Die Ausfüllhilfen sind zum großen Teil Hinweise aus der oben genannt
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/general/project-partners-partner/contact">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/general/project-partners-partner/contact">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>contact</key>
 		<path>101_dfg/general/project-partners-partner/contact</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/partner/contact_person/name"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/general/project-partners-partner"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/general/project-partners-partner"/>
 		<is_collection>True</is_collection>
 		<order>3</order>
 		<help lang="en">Please give the name and an email address. If not yet clarified, please explain briefly when and how this question will be clarified.</help>
@@ -142,13 +142,13 @@ abdecken. Die Ausfüllhilfen sind zum großen Teil Hinweise aus der oben genannt
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/general/other-requirements-yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/general/other-requirements-yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>other-requirements-yesno</key>
 		<path>101_dfg/general/other-requirements-yesno</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/general"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/general"/>
 		<is_collection>False</is_collection>
 		<order>50</order>
 		<title lang="en">Requirements I</title>
@@ -161,13 +161,13 @@ abdecken. Die Ausfüllhilfen sind zum großen Teil Hinweise aus der oben genannt
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/general/other-requirements-yesno/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/general/other-requirements-yesno/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>101_dfg/general/other-requirements-yesno/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/additional_rdm_policy/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/general/other-requirements-yesno"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/general/other-requirements-yesno"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<help lang="en">At least the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/handreichung_fachkollegium_101_forschungsdaten.pdf&quot; target=_blank&gt; Manual on handling research data &lt;/a&gt; of the DFG review board &quot;Ancient Cultures&quot; (in German) and the sources used in it should be considered.</help>
@@ -185,17 +185,17 @@ abdecken. Die Ausfüllhilfen sind zum großen Teil Hinweise aus der oben genannt
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/other_requirements_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/other_requirements_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/general/other-requirements-requirements">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/general/other-requirements-requirements">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>other-requirements-requirements</key>
 		<path>101_dfg/general/other-requirements-requirements</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/general"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/general"/>
 		<is_collection>False</is_collection>
 		<order>51</order>
 		<title lang="en">Requirements II</title>
@@ -207,16 +207,16 @@ abdecken. Die Ausfüllhilfen sind zum großen Teil Hinweise aus der oben genannt
 		<verbose_name lang="de"/>
 		<verbose_name_plural lang="de"/>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/additional_rdm_policy"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/additional_rdm_policy"/>
 		</conditions>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/general/other-requirements-requirements/requirements">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/general/other-requirements-requirements/requirements">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>requirements</key>
 		<path>101_dfg/general/other-requirements-requirements/requirements</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/additional_rdm_policy/requirements"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/general/other-requirements-requirements"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/general/other-requirements-requirements"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<help lang="en">Amongst others, the following requirements and recommendations of the German Research Foundation must be observed:
@@ -260,13 +260,13 @@ Die Orientierung an einschlägigen Standards und best practices ist ausdrücklic
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/general/support">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/general/support">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>support</key>
 		<path>101_dfg/general/support</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/general"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/general"/>
 		<is_collection>False</is_collection>
 		<order>61</order>
 		<title lang="en">Support</title>
@@ -279,13 +279,13 @@ Die Orientierung an einschlägigen Standards und best practices ist ausdrücklic
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/general/support/datamanagement">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/general/support/datamanagement">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>datamanagement</key>
 		<path>101_dfg/general/support/datamanagement</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/support"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/general/support"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/general/support"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">From the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/handlassung_fachkollegium_101_forschungsdaten.pdf&quot; target=_blank&gt; Manual on handling research data &lt;/a&gt; of the DFG review board &quot;Ancient Cultures&quot; (in German):
@@ -309,23 +309,23 @@ Es wird empfohlen, frühzeitig Kontakt zu Serviceeinrichtungen (Rechenzentren, B
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/content-classification">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/content-classification">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>content-classification</key>
 		<path>101_dfg/content-classification</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/101_dfg"/>
 		<order>1</order>
 		<title lang="en">Content classification</title>
 		<title lang="de">Inhaltliche Einordnung</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/content-classification/data-dataset">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/content-classification/data-dataset">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-dataset</key>
 		<path>101_dfg/content-classification/data-dataset</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/content-classification"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/content-classification"/>
 		<is_collection>True</is_collection>
 		<order>1</order>
 		<title lang="en">Datasets</title>
@@ -338,13 +338,13 @@ Es wird empfohlen, frühzeitig Kontakt zu Serviceeinrichtungen (Rechenzentren, B
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/content-classification/data-dataset/description">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/content-classification/data-dataset/description">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>description</key>
 		<path>101_dfg/content-classification/data-dataset/description</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/description"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/content-classification/data-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/content-classification/data-dataset"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">From the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/handreichung_fachkollegium_101_forschungsdaten.pdf&quot; target=_blank&gt; Manual on handling research data &lt;/a&gt; of the DFG review board &quot;Ancient Cultures&quot; (in German):
@@ -372,13 +372,13 @@ Zur Beurteilung des Aufwands und ggf. beantragter Kosten für das Datenmanagemen
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/content-classification/data-reuse">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/content-classification/data-reuse">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-reuse</key>
 		<path>101_dfg/content-classification/data-reuse</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/content-classification"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/content-classification"/>
 		<is_collection>True</is_collection>
 		<order>3</order>
 		<title lang="en">Reuse</title>
@@ -391,13 +391,13 @@ Zur Beurteilung des Aufwands und ggf. beantragter Kosten für das Datenmanagemen
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/content-classification/data-reuse/scenario">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/content-classification/data-reuse/scenario">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>scenario</key>
 		<path>101_dfg/content-classification/data-reuse/scenario</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/reuse_scenario"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/content-classification/data-reuse"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/content-classification/data-reuse"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">It is important to set the fundamental course as to whether or not the data will be permitted for reuse. Of course, the potential for subsequent use can not be the sole decision criterion, but legal impediments, such as privacy, copyright and business secrets must be taken into account. Otherwise, consider the re-use potential against the disadvantages, e.g. a decrease in the readiness to participate and the expected extra effort of a data publication.</help>
@@ -417,23 +417,23 @@ Zur Beurteilung des Aufwands und ggf. beantragter Kosten für das Datenmanagemen
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/technical-classification">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/technical-classification">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>technical-classification</key>
 		<path>101_dfg/technical-classification</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/101_dfg"/>
 		<order>2</order>
 		<title lang="en">Technical classification</title>
 		<title lang="de">Technische Einordnung</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/technical-classification/data-volume">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/technical-classification/data-volume">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-volume</key>
 		<path>101_dfg/technical-classification/data-volume</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/technical-classification"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/technical-classification"/>
 		<is_collection>True</is_collection>
 		<order>2</order>
 		<title lang="en">Data size</title>
@@ -446,13 +446,13 @@ Zur Beurteilung des Aufwands und ggf. beantragter Kosten für das Datenmanagemen
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/technical-classification/data-volume/volume">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/technical-classification/data-volume/volume">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>volume</key>
 		<path>101_dfg/technical-classification/data-volume/volume</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/size/volume"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/technical-classification/data-volume"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/technical-classification/data-volume"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en"/>
@@ -470,17 +470,17 @@ Zur Beurteilung des Aufwands und ggf. beantragter Kosten für das Datenmanagemen
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_size_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_size_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/technical-classification/data-formats">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/technical-classification/data-formats">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-formats</key>
 		<path>101_dfg/technical-classification/data-formats</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/technical-classification"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/technical-classification"/>
 		<is_collection>True</is_collection>
 		<order>3</order>
 		<title lang="en">Formats</title>
@@ -493,13 +493,13 @@ Zur Beurteilung des Aufwands und ggf. beantragter Kosten für das Datenmanagemen
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/technical-classification/data-formats/format">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/technical-classification/data-formats/format">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>format</key>
 		<path>101_dfg/technical-classification/data-formats/format</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/format"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/technical-classification/data-formats"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/technical-classification/data-formats"/>
 		<is_collection>False</is_collection>
 		<order>4</order>
 		<help lang="en">It is advisable to prefer formats that are standardised, open, non-proprietary and well-established in the respective scholarly community. A table with recommended file formats can be found in Kristin Briney, &lt;i&gt;Data Management for Researchers&lt;/i&gt;, Pelargic, 2015, pages 133-134.
@@ -525,13 +525,13 @@ Um eine spätere Nutzung der Daten zu ermöglichen, sind archivfähige Formate z
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/technical-classification/data-tools">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/technical-classification/data-tools">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-tools</key>
 		<path>101_dfg/technical-classification/data-tools</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/technical-classification"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/technical-classification"/>
 		<is_collection>True</is_collection>
 		<order>4</order>
 		<title lang="en">Tools</title>
@@ -544,13 +544,13 @@ Um eine spätere Nutzung der Daten zu ermöglichen, sind archivfähige Formate z
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/technical-classification/data-tools/creation_methods">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/technical-classification/data-tools/creation_methods">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>creation_methods</key>
 		<path>101_dfg/technical-classification/data-tools/creation_methods</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/creation_methods"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/technical-classification/data-tools"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/technical-classification/data-tools"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">This information is necessary to be able to reconstruct the process by which the data was generated. It is also a prerequisite to judge the objectivity, reliability and validity of the dataset. For reproducible data, it is also required to re-generate the data if need be.
@@ -574,23 +574,23 @@ Falls diese Frage noch ungeklärt ist, erläutern Sie bitte kurz, wann und wie d
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/data-usage">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/data-usage">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-usage</key>
 		<path>101_dfg/data-usage</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/101_dfg"/>
 		<order>3</order>
 		<title lang="en">Data usage</title>
 		<title lang="de">Datennutzung</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/data-usage/data-storage-and-security-storage">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/data-usage/data-storage-and-security-storage">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-storage-and-security-storage</key>
 		<path>101_dfg/data-usage/data-storage-and-security-storage</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/data-usage"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/data-usage"/>
 		<is_collection>True</is_collection>
 		<order>11</order>
 		<title lang="en">Data organisation</title>
@@ -603,13 +603,13 @@ Falls diese Frage noch ungeklärt ist, erläutern Sie bitte kurz, wann und wie d
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/data-usage/data-storage-and-security-storage/type">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/data-usage/data-storage-and-security-storage/type">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>type</key>
 		<path>101_dfg/data-usage/data-storage-and-security-storage/type</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/storage/type"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/data-usage/data-storage-and-security-storage"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/data-usage/data-storage-and-security-storage"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">If parts of the documentation or related software (custom development) are not stored with the data, also indicate where they are stored. This applies to the documentation of the software too.
@@ -633,13 +633,13 @@ Falls in diesem Zusammenhang noch Fragen ungeklärt sind, erläutern Sie bitte k
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/data-usage/data-sharing-and-re-use-publication">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/data-usage/data-sharing-and-re-use-publication">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-sharing-and-re-use-publication</key>
 		<path>101_dfg/data-usage/data-sharing-and-re-use-publication</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/data-usage"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/data-usage"/>
 		<is_collection>True</is_collection>
 		<order>52</order>
 		<title lang="en">Data sharing and re-use</title>
@@ -652,13 +652,13 @@ Falls in diesem Zusammenhang noch Fragen ungeklärt sind, erläutern Sie bitte k
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/data-usage/data-sharing-and-re-use-publication/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/data-usage/data-sharing-and-re-use-publication/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>101_dfg/data-usage/data-sharing-and-re-use-publication/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sharing/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/data-usage/data-sharing-and-re-use-publication"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/data-usage/data-sharing-and-re-use-publication"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">From the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/handreichung_fachkollegium_101_forschungsdaten.pdf&quot; target=_blank&gt; Manual on handling research data &lt;/a&gt; of the DFG review board &quot;Ancient Cultures&quot; (in German):
@@ -680,17 +680,17 @@ Die Zugangs- und Nutzungsbedingungen (zu analogen wie digitalen Daten) sollten v
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_sharing_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_sharing_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/data-usage/data-sharing-and-re-use-publication/explanation">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/data-usage/data-sharing-and-re-use-publication/explanation">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>explanation</key>
 		<path>101_dfg/data-usage/data-sharing-and-re-use-publication/explanation</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sharing/explanation"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/data-usage/data-sharing-and-re-use-publication"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/data-usage/data-sharing-and-re-use-publication"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en">From the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/handreichung_fachkollegium_101_forschungsdaten.pdf&quot; target=_blank&gt; Manual on handling research data &lt;/a&gt; of the DFG review board &quot;Ancient Cultures&quot; (in German):
@@ -714,13 +714,13 @@ Wenn ausnahmsweise kein Zugang zur Nachnutzung gewährt werden soll oder der Zug
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/data-usage/data-sharing-and-re-use-publication/conditions">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/data-usage/data-sharing-and-re-use-publication/conditions">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>conditions</key>
 		<path>101_dfg/data-usage/data-sharing-and-re-use-publication/conditions</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sharing/conditions"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/data-usage/data-sharing-and-re-use-publication"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/data-usage/data-sharing-and-re-use-publication"/>
 		<is_collection>True</is_collection>
 		<order>3</order>
 		<help lang="en">The options refer to the licenses of the &lt;a href=&quot;https://creativecommons.org/share-your-work/licensing-types-examples/&quot; target=_blank&quot;&gt;Creative Commons family&lt;/a&gt;.</help>
@@ -738,17 +738,17 @@ Wenn ausnahmsweise kein Zugang zur Nachnutzung gewährt werden soll oder der Zug
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_license_types"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_license_types"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/data-usage/data-sharing-and-re-use-publication/data_publication_date">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/data-usage/data-sharing-and-re-use-publication/data_publication_date">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data_publication_date</key>
 		<path>101_dfg/data-usage/data-sharing-and-re-use-publication/data_publication_date</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/data_publication_date"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/data-usage/data-sharing-and-re-use-publication"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/data-usage/data-sharing-and-re-use-publication"/>
 		<is_collection>False</is_collection>
 		<order>6</order>
 		<help lang="en">From the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/handreichung_fachkollegium_101_forschungsdaten.pdf&quot; target=_blank&gt; Manual on handling research data &lt;/a&gt; of the DFG review board &quot;Ancient Cultures&quot; (in German):
@@ -771,16 +771,16 @@ Bei Projekten, die eine Vorlage von archäologischen Befunden, Artefakten oder d
 		<unit/>
 		<optionsets/>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/data_sharing"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/data_sharing"/>
 		</conditions>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/data-usage/quality-assurance-dataset">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/data-usage/quality-assurance-dataset">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>quality-assurance-dataset</key>
 		<path>101_dfg/data-usage/quality-assurance-dataset</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/data-usage"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/data-usage"/>
 		<is_collection>True</is_collection>
 		<order>61</order>
 		<title lang="en">Quality assurance</title>
@@ -793,13 +793,13 @@ Bei Projekten, die eine Vorlage von archäologischen Befunden, Artefakten oder d
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/data-usage/quality-assurance-dataset/measures">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/data-usage/quality-assurance-dataset/measures">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>measures</key>
 		<path>101_dfg/data-usage/quality-assurance-dataset/measures</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/quality_assurance"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/data-usage/quality-assurance-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/data-usage/quality-assurance-dataset"/>
 		<is_collection>False</is_collection>
 		<order>7</order>
 		<help lang="en">If not yet clarified, please explain briefly when and how this question will be clarified.</help>
@@ -819,23 +819,23 @@ Bei Projekten, die eine Vorlage von archäologischen Befunden, Artefakten oder d
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/doc">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/doc">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>doc</key>
 		<path>101_dfg/doc</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/101_dfg"/>
 		<order>4</order>
 		<title lang="en">Documentation</title>
 		<title lang="de">Dokumentation</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/doc/metadata-dataset">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/doc/metadata-dataset">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>metadata-dataset</key>
 		<path>101_dfg/doc/metadata-dataset</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/doc"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/doc"/>
 		<is_collection>True</is_collection>
 		<order>10</order>
 		<title lang="en">Data documentation</title>
@@ -848,13 +848,13 @@ Bei Projekten, die eine Vorlage von archäologischen Befunden, Artefakten oder d
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/doc/metadata-dataset/documentation">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/doc/metadata-dataset/documentation">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>documentation</key>
 		<path>101_dfg/doc/metadata-dataset/documentation</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/documentation"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/doc/metadata-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/doc/metadata-dataset"/>
 		<is_collection>False</is_collection>
 		<order>4</order>
 		<help lang="en">If not yet clarified, please explain briefly when and how this question will be clarified.</help>
@@ -874,23 +874,23 @@ Bei Projekten, die eine Vorlage von archäologischen Befunden, Artefakten oder d
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/referencing">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/referencing">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>referencing</key>
 		<path>101_dfg/referencing</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/101_dfg"/>
 		<order>5</order>
 		<title lang="en">Referencing</title>
 		<title lang="de">Referenzierung</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/referencing/structure-granularity-and-referencing-pids">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/referencing/structure-granularity-and-referencing-pids">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>structure-granularity-and-referencing-pids</key>
 		<path>101_dfg/referencing/structure-granularity-and-referencing-pids</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/referencing"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/referencing"/>
 		<is_collection>True</is_collection>
 		<order>21</order>
 		<title lang="en">Persistent Identifiers (PIDs)</title>
@@ -903,13 +903,13 @@ Bei Projekten, die eine Vorlage von archäologischen Befunden, Artefakten oder d
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/referencing/structure-granularity-and-referencing-pids/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/referencing/structure-granularity-and-referencing-pids/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>101_dfg/referencing/structure-granularity-and-referencing-pids/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/pids/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/referencing/structure-granularity-and-referencing-pids"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/referencing/structure-granularity-and-referencing-pids"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<help lang="en"/>
@@ -929,13 +929,13 @@ Bei Projekten, die eine Vorlage von archäologischen Befunden, Artefakten oder d
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/referencing/structure-granularity-and-referencing-pids/system">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/referencing/structure-granularity-and-referencing-pids/system">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>system</key>
 		<path>101_dfg/referencing/structure-granularity-and-referencing-pids/system</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/pids/system"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/referencing/structure-granularity-and-referencing-pids"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/referencing/structure-granularity-and-referencing-pids"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -953,17 +953,17 @@ Bei Projekten, die eine Vorlage von archäologischen Befunden, Artefakten oder d
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/pid_types"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/pid_types"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/referencing/structure-granularity-and-referencing-pids/subentities">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/referencing/structure-granularity-and-referencing-pids/subentities">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>subentities</key>
 		<path>101_dfg/referencing/structure-granularity-and-referencing-pids/subentities</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/pids/subentities"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/referencing/structure-granularity-and-referencing-pids"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/referencing/structure-granularity-and-referencing-pids"/>
 		<is_collection>False</is_collection>
 		<order>3</order>
 		<help lang="en"/>
@@ -983,13 +983,13 @@ Bei Projekten, die eine Vorlage von archäologischen Befunden, Artefakten oder d
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/referencing/structure-granularity-and-referencing-pids/name">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/referencing/structure-granularity-and-referencing-pids/name">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>name</key>
 		<path>101_dfg/referencing/structure-granularity-and-referencing-pids/name</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/pids/responsible_person/name"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/referencing/structure-granularity-and-referencing-pids"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/referencing/structure-granularity-and-referencing-pids"/>
 		<is_collection>True</is_collection>
 		<order>4</order>
 		<help lang="en">A prerequisite for PIDs to work as promised is that they - as well as the objects they refer to - are maintained in a continuous and reliable way. This means, for example, that if the object location changes, this information is updated. When the data are stored in a data centre or repository, these tasks are usually taken care of by the data centre / repository. However, to be sure, the responsibilities should be checked beforehand.</help>
@@ -1011,23 +1011,23 @@ Bei Projekten, die eine Vorlage von archäologischen Befunden, Artefakten oder d
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/legal-and-ethics">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/legal-and-ethics">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>legal-and-ethics</key>
 		<path>101_dfg/legal-and-ethics</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/101_dfg"/>
 		<order>6</order>
 		<title lang="en">Legal and ethics</title>
 		<title lang="de">Rechtliche und ethische Fragen</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/legal-and-ethics/sensitive-data-personal_data_yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/legal-and-ethics/sensitive-data-personal_data_yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>sensitive-data-personal_data_yesno</key>
 		<path>101_dfg/legal-and-ethics/sensitive-data-personal_data_yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/legal-and-ethics"/>
 		<is_collection>True</is_collection>
 		<order>21</order>
 		<title lang="en">Personal data</title>
@@ -1040,13 +1040,13 @@ Bei Projekten, die eine Vorlage von archäologischen Befunden, Artefakten oder d
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/legal-and-ethics/sensitive-data-personal_data_yesno/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/legal-and-ethics/sensitive-data-personal_data_yesno/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>101_dfg/legal-and-ethics/sensitive-data-personal_data_yesno/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sensitive_data/personal_data_yesno/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/legal-and-ethics/sensitive-data-personal_data_yesno"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/legal-and-ethics/sensitive-data-personal_data_yesno"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">The EU General Data Protection Regulation (GDPR) defines in Art. 4 personal data as &quot;any information relating to an identified or identifiable natural person&quot;. An identifiable natural person is &quot;one who can be identified, directly or indirectly, in particular by reference to an identifier such as a name, an identification number, location data, an online identifier or to one or more factors specific to the physical, physiological, genetic, mental, economic, cultural or social identity of that natural person&quot;.</help>
@@ -1066,13 +1066,13 @@ Bei Projekten, die eine Vorlage von archäologischen Befunden, Artefakten oder d
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/legal-and-ethics/sensitive-data-personal_data">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/legal-and-ethics/sensitive-data-personal_data">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>sensitive-data-personal_data</key>
 		<path>101_dfg/legal-and-ethics/sensitive-data-personal_data</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/legal-and-ethics"/>
 		<is_collection>True</is_collection>
 		<order>24</order>
 		<title lang="en">Sensitive data</title>
@@ -1084,16 +1084,16 @@ Bei Projekten, die eine Vorlage von archäologischen Befunden, Artefakten oder d
 		<verbose_name lang="de">Datensatz</verbose_name>
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/personal_data"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/personal_data"/>
 		</conditions>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/legal-and-ethics/sensitive-data-personal_data/anonymization">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/legal-and-ethics/sensitive-data-personal_data/anonymization">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>anonymization</key>
 		<path>101_dfg/legal-and-ethics/sensitive-data-personal_data/anonymization</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sensitive_data/personal_data/anonymization"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/legal-and-ethics/sensitive-data-personal_data"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/legal-and-ethics/sensitive-data-personal_data"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -1111,17 +1111,17 @@ Bei Projekten, die eine Vorlage von archäologischen Befunden, Artefakten oder d
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_anonymisation"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_anonymisation"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/legal-and-ethics/sensitive-data-official_approval">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/legal-and-ethics/sensitive-data-official_approval">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>sensitive-data-official_approval</key>
 		<path>101_dfg/legal-and-ethics/sensitive-data-official_approval</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/legal-and-ethics"/>
 		<is_collection>False</is_collection>
 		<order>28</order>
 		<title lang="en">Official approval</title>
@@ -1134,13 +1134,13 @@ Bei Projekten, die eine Vorlage von archäologischen Befunden, Artefakten oder d
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/legal-and-ethics/sensitive-data-official_approval/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/legal-and-ethics/sensitive-data-official_approval/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>101_dfg/legal-and-ethics/sensitive-data-official_approval/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/legal_aspects/official_approval/statutatory_approval/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/legal-and-ethics/sensitive-data-official_approval"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/legal-and-ethics/sensitive-data-official_approval"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -1158,17 +1158,17 @@ Bei Projekten, die eine Vorlage von archäologischen Befunden, Artefakten oder d
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/ethics_permit_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/ethics_permit_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/legal-and-ethics/sensitive-data-official_approval/title">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/legal-and-ethics/sensitive-data-official_approval/title">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>title</key>
 		<path>101_dfg/legal-and-ethics/sensitive-data-official_approval/title</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/legal_aspects/official_approval/statutatory_approval/title"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/legal-and-ethics/sensitive-data-official_approval"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/legal-and-ethics/sensitive-data-official_approval"/>
 		<is_collection>False</is_collection>
 		<order>3</order>
 		<help lang="en"/>
@@ -1188,13 +1188,13 @@ Bei Projekten, die eine Vorlage von archäologischen Befunden, Artefakten oder d
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/legal-and-ethics/sensitive-data-official_approval/agency">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/legal-and-ethics/sensitive-data-official_approval/agency">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>agency</key>
 		<path>101_dfg/legal-and-ethics/sensitive-data-official_approval/agency</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/legal_aspects/official_approval/statutatory_approval/agency"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/legal-and-ethics/sensitive-data-official_approval"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/legal-and-ethics/sensitive-data-official_approval"/>
 		<is_collection>False</is_collection>
 		<order>4</order>
 		<help lang="en"/>
@@ -1214,13 +1214,13 @@ Bei Projekten, die eine Vorlage von archäologischen Befunden, Artefakten oder d
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/legal-and-ethics/sensitive-data-official_approval/status">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/legal-and-ethics/sensitive-data-official_approval/status">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>status</key>
 		<path>101_dfg/legal-and-ethics/sensitive-data-official_approval/status</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/legal_aspects/official_approval/statutatory_approval/status"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/legal-and-ethics/sensitive-data-official_approval"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/legal-and-ethics/sensitive-data-official_approval"/>
 		<is_collection>False</is_collection>
 		<order>5</order>
 		<help lang="en">From the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/handreichung_fachkollegium_101_forschungsdaten.pdf&quot; target=_blank&gt; Manual on handling research data &lt;/a&gt; of the DFG review board &quot;Ancient Cultures&quot; (in German):
@@ -1244,13 +1244,13 @@ Offene Fragen oder besondere Herausforderungen müssen ausdrücklich erläutert 
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/legal-and-ethics/intellectual-property-rights-yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/legal-and-ethics/intellectual-property-rights-yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>intellectual-property-rights-yesno</key>
 		<path>101_dfg/legal-and-ethics/intellectual-property-rights-yesno</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/legal-and-ethics"/>
 		<is_collection>False</is_collection>
 		<order>30</order>
 		<title lang="en">Intellectual property rights I</title>
@@ -1263,13 +1263,13 @@ Offene Fragen oder besondere Herausforderungen müssen ausdrücklich erläutert 
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/legal-and-ethics/intellectual-property-rights-yesno/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/legal-and-ethics/intellectual-property-rights-yesno/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>101_dfg/legal-and-ethics/intellectual-property-rights-yesno/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/legal_aspects/ipr/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/legal-and-ethics/intellectual-property-rights-yesno"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/legal-and-ethics/intellectual-property-rights-yesno"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<help lang="en">Data or software can be subject to intellectual or industrial property rights. Applicable laws differ broadly even within EU. According to the German copyright law (UrhG) works of literature, scholarship and the arts that can be regarded as a “personal intellectual creation” are protected by copyright. Copyright protection expires 70 years after the death of the copyright holder. Mere data, e.g. measured data or survey data, and metadata (except in some cases descriptive metadata) are not protected by copyright. § 2 of the UrhG lists the following kinds of protected works (list is not concluded): 
@@ -1317,13 +1317,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/legal-and-ethics/intellectual-property-rights-dataset">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/legal-and-ethics/intellectual-property-rights-dataset">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>intellectual-property-rights-dataset</key>
 		<path>101_dfg/legal-and-ethics/intellectual-property-rights-dataset</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/legal-and-ethics"/>
 		<is_collection>True</is_collection>
 		<order>31</order>
 		<title lang="en">Intellectual property rights II</title>
@@ -1335,16 +1335,16 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<verbose_name lang="de">Datensatz</verbose_name>
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/intellectual_property_rights"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/intellectual_property_rights"/>
 		</conditions>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/legal-and-ethics/intellectual-property-rights-dataset/copyrights">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/legal-and-ethics/intellectual-property-rights-dataset/copyrights">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>copyrights</key>
 		<path>101_dfg/legal-and-ethics/intellectual-property-rights-dataset/copyrights</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/ipr/copyrights"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
 		<is_collection>True</is_collection>
 		<order>0</order>
 		<help lang="en"/>
@@ -1362,17 +1362,17 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_copyright_laws"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_copyright_laws"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/legal-and-ethics/intellectual-property-rights-dataset/other_rights">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/legal-and-ethics/intellectual-property-rights-dataset/other_rights">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>other_rights</key>
 		<path>101_dfg/legal-and-ethics/intellectual-property-rights-dataset/other_rights</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/ipr/other_rights"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
 		<is_collection>True</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -1390,17 +1390,17 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_other_rights"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_other_rights"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/legal-and-ethics/intellectual-property-rights-dataset/owner">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/legal-and-ethics/intellectual-property-rights-dataset/owner">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>owner</key>
 		<path>101_dfg/legal-and-ethics/intellectual-property-rights-dataset/owner</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/ipr/owner/name"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
 		<is_collection>False</is_collection>
 		<order>3</order>
 		<help lang="en"/>
@@ -1418,17 +1418,17 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/yes_with_text_no"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/yes_with_text_no"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/legal-and-ethics/intellectual-property-rights-dataset/status">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/legal-and-ethics/intellectual-property-rights-dataset/status">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>status</key>
 		<path>101_dfg/legal-and-ethics/intellectual-property-rights-dataset/status</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/ipr/status"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
 		<is_collection>False</is_collection>
 		<order>4</order>
 		<help lang="en"/>
@@ -1448,23 +1448,23 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/storage-and-long-term-preservation">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/storage-and-long-term-preservation">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>storage-and-long-term-preservation</key>
 		<path>101_dfg/storage-and-long-term-preservation</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/101_dfg"/>
 		<order>10</order>
 		<title lang="en">Storage and long-term preservation</title>
 		<title lang="de">Speicherung und Langzeitarchivierung</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/storage-and-long-term-preservation/selection-criteria">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/storage-and-long-term-preservation/selection-criteria">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>selection-criteria</key>
 		<path>101_dfg/storage-and-long-term-preservation/selection-criteria</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/storage-and-long-term-preservation"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/storage-and-long-term-preservation"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<title lang="en">Selection</title>
@@ -1477,13 +1477,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/storage-and-long-term-preservation/selection-criteria/selection_criteria">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/storage-and-long-term-preservation/selection-criteria/selection_criteria">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>selection_criteria</key>
 		<path>101_dfg/storage-and-long-term-preservation/selection-criteria/selection_criteria</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/preservation/selection_criteria"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/storage-and-long-term-preservation/selection-criteria"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/storage-and-long-term-preservation/selection-criteria"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<help lang="en"/>
@@ -1503,13 +1503,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/storage-and-long-term-preservation/long-term-preservation-datasets">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/storage-and-long-term-preservation/long-term-preservation-datasets">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>long-term-preservation-datasets</key>
 		<path>101_dfg/storage-and-long-term-preservation/long-term-preservation-datasets</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/storage-and-long-term-preservation"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/storage-and-long-term-preservation"/>
 		<is_collection>True</is_collection>
 		<order>11</order>
 		<title lang="en">Long-term preservation</title>
@@ -1522,13 +1522,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>101_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en"/>
@@ -1548,13 +1548,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/purpose">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/purpose">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>purpose</key>
 		<path>101_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/purpose</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/purpose"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>True</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -1572,17 +1572,17 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/preservation_motivation_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/preservation_motivation_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/duration">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/duration">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>duration</key>
 		<path>101_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/duration</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/duration"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>False</is_collection>
 		<order>3</order>
 		<help lang="en">From the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/handreichung_fachkollegium_101_forschungsdaten.pdf&quot; target=_blank&gt; Manual on handling research data &lt;/a&gt; of the DFG review board &quot;Ancient Cultures&quot; (in German):
@@ -1614,13 +1614,13 @@ Darüber hinaus ist für Daten aus altertumswissenschaftlichen Forschungsvorhabe
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/repository">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/repository">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>repository</key>
 		<path>101_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/repository</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/repository"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>True</is_collection>
 		<order>5</order>
 		<help lang="en">From the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/handreichung_fachkollegium_101_forschungsdaten.pdf&quot; target=_blank&gt; Manual on handling research data &lt;/a&gt; of the DFG review board &quot;Ancient Cultures&quot; (in German):
@@ -1642,17 +1642,17 @@ Solange im Rahmen der Nationalen Forschungsdaten-Infrastruktur (NFDI) kein fachl
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/preservation_repository_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/preservation_repository_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/certification">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/certification">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>certification</key>
 		<path>101_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/certification</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/certification"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>False</is_collection>
 		<order>6</order>
 		<help lang="en">From the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/handreichung_fachkollegium_101_forschungsdaten.pdf&quot; target=_blank&gt; Manual on handling research data &lt;/a&gt; of the DFG review board &quot;Ancient Cultures&quot; (in German):
@@ -1676,13 +1676,13 @@ Die Archivierung der digitalen Daten sollte in zertifizierten Repositorien oder 
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/repository_arrangements">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/repository_arrangements">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>repository_arrangements</key>
 		<path>101_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/repository_arrangements</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/repository_arrangements"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>False</is_collection>
 		<order>7</order>
 		<help lang="en">From the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/handreichung_fachkollegium_101_forschungsdaten.pdf&quot; target=_blank&gt; Manual on handling research data &lt;/a&gt; of the DFG review board &quot;Ancient Cultures&quot; (in German):
@@ -1706,13 +1706,13 @@ Im Antrag sollte benannt sein, wer im Projekt für den Umgang mit Forschungsdate
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/responsible">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/responsible">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>responsible</key>
 		<path>101_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/responsible</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/pids/responsible_person/name"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/101_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/101_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>True</is_collection>
 		<order>8</order>
 		<help lang="en"/>

--- a/shared/fodako/106_dfg.xml
+++ b/shared/fodako/106_dfg.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <rdmo xmlns:dc="http://purl.org/dc/elements/1.1/">
-	<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<catalog dc:uri="https://rdmo.fodako.nrw/questions/106_dfg">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>106_dfg</key>
 		<dc:comment>Dieser Fragenkatalog ist eine Teilmenge des Katalogs &quot;Alle Fragen&quot; (eine Überarbeitung des Katalogs &quot;RDMO&quot;) und enthält nur die Fragen, die die Anforderungen in  
 
@@ -16,23 +16,23 @@ abdecken. Die Ausfüllhilfen geben Hinweise für Forschungsprojekte der Fächer 
 		<title lang="en">DFG 106  	Social and Cultural Anthropology, Non-Europ. Cultures, Jewish Studies, Religious Studies</title>
 		<title lang="de">DFG 106 Sozial- u. Kulturanthropologie, Außereurop. Kulturen, Judaistik u. Religionswiss.</title>
 	</catalog>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/general">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/general">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>general</key>
 		<path>106_dfg/general</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/106_dfg"/>
 		<order>0</order>
 		<title lang="en">General</title>
 		<title lang="de">Allgemein</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/general/other-requirements-yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/general/other-requirements-yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>other-requirements-yesno</key>
 		<path>106_dfg/general/other-requirements-yesno</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/general"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/general"/>
 		<is_collection>False</is_collection>
 		<order>50</order>
 		<title lang="en">Requirements I</title>
@@ -45,13 +45,13 @@ abdecken. Die Ausfüllhilfen geben Hinweise für Forschungsprojekte der Fächer 
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/general/other-requirements-yesno/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/general/other-requirements-yesno/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>106_dfg/general/other-requirements-yesno/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/additional_rdm_policy/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/general/other-requirements-yesno"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/general/other-requirements-yesno"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<help lang="en">Research projects in the subjects Social and Cultural Anthropology, Non-European Cultures, Jewish Studies and Religious Studies funded by the DFG should always observe the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/foerderkriterien_editionen_literaturwissenschaft.pdf&quot; target=_blank&gt; Handout from the Review Board 106  Social and Cultural Anthropology, Non-European Cultures, Jewish Studies and Religious Studies on handling research data &lt;/a&gt; (in German). This questionnaire takes into account this handout and the interdisplinary &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/guidelines_research_data.pdf&quot; target=_blank&gt;DFG Guidelines on the Handling of Research Data&lt;/a&gt;.</help>
@@ -69,17 +69,17 @@ abdecken. Die Ausfüllhilfen geben Hinweise für Forschungsprojekte der Fächer 
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/other_requirements_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/other_requirements_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/general/other-requirements-requirements">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/general/other-requirements-requirements">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>other-requirements-requirements</key>
 		<path>106_dfg/general/other-requirements-requirements</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/general"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/general"/>
 		<is_collection>False</is_collection>
 		<order>51</order>
 		<title lang="en">Requirements II</title>
@@ -91,16 +91,16 @@ abdecken. Die Ausfüllhilfen geben Hinweise für Forschungsprojekte der Fächer 
 		<verbose_name lang="de"/>
 		<verbose_name_plural lang="de"/>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/additional_rdm_policy"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/additional_rdm_policy"/>
 		</conditions>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/general/other-requirements-requirements/requirements">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/general/other-requirements-requirements/requirements">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>requirements</key>
 		<path>106_dfg/general/other-requirements-requirements/requirements</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/additional_rdm_policy/requirements"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/general/other-requirements-requirements"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/general/other-requirements-requirements"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<help lang="en">Amongst others, the following requirements and recommendations of the German Research Foundation must be observed:
@@ -136,23 +136,23 @@ Der Umgang mit Forschungsdaten und Materialien soll im Einklang mit der jeweilig
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/content-classification">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/content-classification">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>content-classification</key>
 		<path>106_dfg/content-classification</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/106_dfg"/>
 		<order>1</order>
 		<title lang="en">Content classification</title>
 		<title lang="de">Inhaltliche Einordnung</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/content-classification/data-dataset">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/content-classification/data-dataset">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-dataset</key>
 		<path>106_dfg/content-classification/data-dataset</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/content-classification"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/content-classification"/>
 		<is_collection>True</is_collection>
 		<order>1</order>
 		<title lang="en">Datasets</title>
@@ -165,13 +165,13 @@ Der Umgang mit Forschungsdaten und Materialien soll im Einklang mit der jeweilig
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/content-classification/data-dataset/description">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/content-classification/data-dataset/description">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>description</key>
 		<path>106_dfg/content-classification/data-dataset/description</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/description"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/content-classification/data-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/content-classification/data-dataset"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">Please briefly describe the data type and / or the method used to create or collect the data, for example: 
@@ -203,13 +203,13 @@ Der Umgang mit Forschungsdaten und Materialien soll im Einklang mit der jeweilig
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/content-classification/data-reuse">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/content-classification/data-reuse">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-reuse</key>
 		<path>106_dfg/content-classification/data-reuse</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/content-classification"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/content-classification"/>
 		<is_collection>True</is_collection>
 		<order>3</order>
 		<title lang="en">Reuse</title>
@@ -222,13 +222,13 @@ Der Umgang mit Forschungsdaten und Materialien soll im Einklang mit der jeweilig
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/content-classification/data-reuse/scenario">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/content-classification/data-reuse/scenario">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>scenario</key>
 		<path>106_dfg/content-classification/data-reuse/scenario</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/reuse_scenario"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/content-classification/data-reuse"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/content-classification/data-reuse"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">From the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/foerderkriterien_editionen_literaturwissenschaft.pdf&quot; target=_blank&gt; Handout from the Review Board 106  Social and Cultural Anthropology, Non-European Cultures, Jewish Studies and Religious Studies on handling research data &lt;/a&gt; (in German):
@@ -252,23 +252,23 @@ Im Antrag soll dargelegt werden, ob zusätzlich zur Sicherung von Forschungsdate
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/technical-classification">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/technical-classification">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>technical-classification</key>
 		<path>106_dfg/technical-classification</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/106_dfg"/>
 		<order>2</order>
 		<title lang="en">Technical classification</title>
 		<title lang="de">Technische Einordnung</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/technical-classification/data-formats">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/technical-classification/data-formats">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-formats</key>
 		<path>106_dfg/technical-classification/data-formats</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/technical-classification"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/technical-classification"/>
 		<is_collection>True</is_collection>
 		<order>3</order>
 		<title lang="en">Formats</title>
@@ -281,13 +281,13 @@ Im Antrag soll dargelegt werden, ob zusätzlich zur Sicherung von Forschungsdate
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/technical-classification/data-formats/format">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/technical-classification/data-formats/format">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>format</key>
 		<path>106_dfg/technical-classification/data-formats/format</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/format"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/technical-classification/data-formats"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/technical-classification/data-formats"/>
 		<is_collection>False</is_collection>
 		<order>4</order>
 		<help lang="en">When choosing a data format, one should consider the consequences for collaborative use, long-term preservation as well as re-use. It is advisable to prefer formats that are standardised, open, non-proprietary and well-established in the respective scholarly community. A table with recommended file formats can be found in Kristin Briney, &lt;i&gt;Data Management for Researchers&lt;/i&gt;, Pelargic, 2015, pages 133-134.
@@ -315,23 +315,23 @@ Im Falle von digitalen Daten wird empfohlen, sie so aufzubereiten, dass sie unab
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/data-usage">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/data-usage">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-usage</key>
 		<path>106_dfg/data-usage</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/106_dfg"/>
 		<order>3</order>
 		<title lang="en">Data usage</title>
 		<title lang="de">Datennutzung</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/data-usage/data-storage-and-security-storage">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/data-usage/data-storage-and-security-storage">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-storage-and-security-storage</key>
 		<path>106_dfg/data-usage/data-storage-and-security-storage</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/data-usage"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/data-usage"/>
 		<is_collection>True</is_collection>
 		<order>11</order>
 		<title lang="en">Data organisation</title>
@@ -344,13 +344,13 @@ Im Falle von digitalen Daten wird empfohlen, sie so aufzubereiten, dass sie unab
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/data-usage/data-storage-and-security-storage/type">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/data-usage/data-storage-and-security-storage/type">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>type</key>
 		<path>106_dfg/data-usage/data-storage-and-security-storage/type</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/storage/type"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/data-usage/data-storage-and-security-storage"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/data-usage/data-storage-and-security-storage"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">If parts of the documentation or related software (custom development) are not stored with the data, also indicate where they are stored. This applies to the documentation of the software too.</help>
@@ -370,13 +370,13 @@ Im Falle von digitalen Daten wird empfohlen, sie so aufzubereiten, dass sie unab
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/data-usage/data-sharing-and-re-use-publication">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/data-usage/data-sharing-and-re-use-publication">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-sharing-and-re-use-publication</key>
 		<path>106_dfg/data-usage/data-sharing-and-re-use-publication</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/data-usage"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/data-usage"/>
 		<is_collection>True</is_collection>
 		<order>52</order>
 		<title lang="en">Data sharing and re-use</title>
@@ -389,13 +389,13 @@ Im Falle von digitalen Daten wird empfohlen, sie so aufzubereiten, dass sie unab
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/data-usage/data-sharing-and-re-use-publication/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/data-usage/data-sharing-and-re-use-publication/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>106_dfg/data-usage/data-sharing-and-re-use-publication/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sharing/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/data-usage/data-sharing-and-re-use-publication"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/data-usage/data-sharing-and-re-use-publication"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">From the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/foerderkriterien_editionen_literaturwissenschaft.pdf&quot; target=_blank&gt; Handout from the Review Board 106  Social and Cultural Anthropology, Non-European Cultures, Jewish Studies and Religious Studies on handling research data &lt;/a&gt; (in German):
@@ -417,17 +417,17 @@ Sollte sich im Forschungsprozess herausstellen, dass eine besondere Schutzbedür
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_sharing_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_sharing_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/data-usage/data-sharing-and-re-use-publication/explanation">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/data-usage/data-sharing-and-re-use-publication/explanation">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>explanation</key>
 		<path>106_dfg/data-usage/data-sharing-and-re-use-publication/explanation</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sharing/explanation"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/data-usage/data-sharing-and-re-use-publication"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/data-usage/data-sharing-and-re-use-publication"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -447,13 +447,13 @@ Sollte sich im Forschungsprozess herausstellen, dass eine besondere Schutzbedür
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/data-usage/data-sharing-and-re-use-publication/conditions">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/data-usage/data-sharing-and-re-use-publication/conditions">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>conditions</key>
 		<path>106_dfg/data-usage/data-sharing-and-re-use-publication/conditions</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sharing/conditions"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/data-usage/data-sharing-and-re-use-publication"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/data-usage/data-sharing-and-re-use-publication"/>
 		<is_collection>True</is_collection>
 		<order>3</order>
 		<help lang="en">The options refer to the licenses of the &lt;a href=&quot;https://creativecommons.org/share-your-work/licensing-types-examples/&quot; target=_blank&quot;&gt;Creative Commons family&lt;/a&gt;. From the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/foerderkriterien_editionen_literaturwissenschaft.pdf&quot; target=_blank&gt; Handout from the Review Board 106  Social and Cultural Anthropology, Non-European Cultures, Jewish Studies and Religious Studies on handling research data &lt;/a&gt; (in German):
@@ -475,17 +475,17 @@ Im Falle offener digitaler Bereitstellung von Artefakten und Veröffentlichungen
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_license_types"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_license_types"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/data-usage/data-sharing-and-re-use-publication/restrictions_explanation">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/data-usage/data-sharing-and-re-use-publication/restrictions_explanation">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>restrictions_explanation</key>
 		<path>106_dfg/data-usage/data-sharing-and-re-use-publication/restrictions_explanation</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sharing/restrictions_explanation"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/data-usage/data-sharing-and-re-use-publication"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/data-usage/data-sharing-and-re-use-publication"/>
 		<is_collection>False</is_collection>
 		<order>4</order>
 		<help lang="en">From the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/foerderkriterien_editionen_literaturwissenschaft.pdf&quot; target=_blank&gt; Handout from the Review Board 106  Social and Cultural Anthropology, Non-European Cultures, Jewish Studies and Religious Studies on handling research data &lt;/a&gt; (in German):
@@ -509,13 +509,13 @@ Verfahren für die Gewährung von Zugangsmöglichkeiten für Dritte</help>
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/data-usage/data-sharing-and-re-use-publication/data_publication_date">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/data-usage/data-sharing-and-re-use-publication/data_publication_date">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data_publication_date</key>
 		<path>106_dfg/data-usage/data-sharing-and-re-use-publication/data_publication_date</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/data_publication_date"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/data-usage/data-sharing-and-re-use-publication"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/data-usage/data-sharing-and-re-use-publication"/>
 		<is_collection>False</is_collection>
 		<order>6</order>
 		<help lang="en"/>
@@ -534,16 +534,16 @@ Verfahren für die Gewährung von Zugangsmöglichkeiten für Dritte</help>
 		<unit/>
 		<optionsets/>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/data_sharing"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/data_sharing"/>
 		</conditions>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/data-usage/quality-assurance-dataset">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/data-usage/quality-assurance-dataset">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>quality-assurance-dataset</key>
 		<path>106_dfg/data-usage/quality-assurance-dataset</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/data-usage"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/data-usage"/>
 		<is_collection>True</is_collection>
 		<order>61</order>
 		<title lang="en">Quality assurance</title>
@@ -556,13 +556,13 @@ Verfahren für die Gewährung von Zugangsmöglichkeiten für Dritte</help>
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/data-usage/quality-assurance-dataset/measures">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/data-usage/quality-assurance-dataset/measures">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>measures</key>
 		<path>106_dfg/data-usage/quality-assurance-dataset/measures</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/quality_assurance"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/data-usage/quality-assurance-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/data-usage/quality-assurance-dataset"/>
 		<is_collection>False</is_collection>
 		<order>7</order>
 		<help lang="en"/>
@@ -582,23 +582,23 @@ Verfahren für die Gewährung von Zugangsmöglichkeiten für Dritte</help>
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/doc">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/doc">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>doc</key>
 		<path>106_dfg/doc</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/106_dfg"/>
 		<order>4</order>
 		<title lang="en">Documentation</title>
 		<title lang="de">Dokumentation</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/doc/metadata-dataset">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/doc/metadata-dataset">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>metadata-dataset</key>
 		<path>106_dfg/doc/metadata-dataset</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/doc"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/doc"/>
 		<is_collection>True</is_collection>
 		<order>10</order>
 		<title lang="en">Data documentation</title>
@@ -611,13 +611,13 @@ Verfahren für die Gewährung von Zugangsmöglichkeiten für Dritte</help>
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/doc/metadata-dataset/documentation">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/doc/metadata-dataset/documentation">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>documentation</key>
 		<path>106_dfg/doc/metadata-dataset/documentation</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/documentation"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/doc/metadata-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/doc/metadata-dataset"/>
 		<is_collection>False</is_collection>
 		<order>4</order>
 		<help lang="en">From the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/foerderkriterien_editionen_literaturwissenschaft.pdf&quot; target=_blank&gt; Handout from the Review Board 106  Social and Cultural Anthropology, Non-European Cultures, Jewish Studies and Religious Studies on handling research data &lt;/a&gt; (in German):
@@ -641,23 +641,23 @@ Bei Veröffentlichungen, die die Edition, digitale Bereitstellung und Sichtbarma
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/legal-and-ethics">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/legal-and-ethics">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>legal-and-ethics</key>
 		<path>106_dfg/legal-and-ethics</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/106_dfg"/>
 		<order>5</order>
 		<title lang="en">Legal and ethics</title>
 		<title lang="de">Rechtliche und ethische Fragen</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/legal-and-ethics/sensitive-data-personal_data_yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/legal-and-ethics/sensitive-data-personal_data_yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>sensitive-data-personal_data_yesno</key>
 		<path>106_dfg/legal-and-ethics/sensitive-data-personal_data_yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/legal-and-ethics"/>
 		<is_collection>True</is_collection>
 		<order>21</order>
 		<title lang="en">Personal data</title>
@@ -670,13 +670,13 @@ Bei Veröffentlichungen, die die Edition, digitale Bereitstellung und Sichtbarma
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/legal-and-ethics/sensitive-data-personal_data_yesno/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/legal-and-ethics/sensitive-data-personal_data_yesno/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>106_dfg/legal-and-ethics/sensitive-data-personal_data_yesno/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sensitive_data/personal_data_yesno/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/legal-and-ethics/sensitive-data-personal_data_yesno"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/legal-and-ethics/sensitive-data-personal_data_yesno"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">The EU General Data Protection Regulation (GDPR) defines in Art. 4 personal data as &quot;any information relating to an identified or identifiable natural person&quot;. An identifiable natural person is &quot;one who can be identified, directly or indirectly, in particular by reference to an identifier such as a name, an identification number, location data, an online identifier or to one or more factors specific to the physical, physiological, genetic, mental, economic, cultural or social identity of that natural person&quot;.</help>
@@ -696,13 +696,13 @@ Bei Veröffentlichungen, die die Edition, digitale Bereitstellung und Sichtbarma
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/legal-and-ethics/sensitive-data-personal_data">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/legal-and-ethics/sensitive-data-personal_data">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>sensitive-data-personal_data</key>
 		<path>106_dfg/legal-and-ethics/sensitive-data-personal_data</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/legal-and-ethics"/>
 		<is_collection>True</is_collection>
 		<order>24</order>
 		<title lang="en">Sensitive data</title>
@@ -714,16 +714,16 @@ Bei Veröffentlichungen, die die Edition, digitale Bereitstellung und Sichtbarma
 		<verbose_name lang="de">Datensatz</verbose_name>
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/personal_data"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/personal_data"/>
 		</conditions>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/legal-and-ethics/sensitive-data-personal_data/anonymization">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/legal-and-ethics/sensitive-data-personal_data/anonymization">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>anonymization</key>
 		<path>106_dfg/legal-and-ethics/sensitive-data-personal_data/anonymization</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sensitive_data/personal_data/anonymization"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/legal-and-ethics/sensitive-data-personal_data"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/legal-and-ethics/sensitive-data-personal_data"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -741,17 +741,17 @@ Bei Veröffentlichungen, die die Edition, digitale Bereitstellung und Sichtbarma
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_anonymisation"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_anonymisation"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/legal-and-ethics/sensitive-data-personal_data/extent">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/legal-and-ethics/sensitive-data-personal_data/extent">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>extent</key>
 		<path>106_dfg/legal-and-ethics/sensitive-data-personal_data/extent</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sensitive_data/personal_data/consent/extent"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/legal-and-ethics/sensitive-data-personal_data"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/legal-and-ethics/sensitive-data-personal_data"/>
 		<is_collection>False</is_collection>
 		<order>3</order>
 		<help lang="en">From the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/foerderkriterien_editionen_literaturwissenschaft.pdf&quot; target=_blank&gt; Handout from the Review Board 106  Social and Cultural Anthropology, Non-European Cultures, Jewish Studies and Religious Studies on handling research data &lt;/a&gt; (in German):
@@ -773,17 +773,17 @@ Bei Vorhaben, die personenbezogene Daten erheben oder auswerten, sollte der Antr
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/informed_consent_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/informed_consent_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/legal-and-ethics/sensitive-data-personal_data/statement">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/legal-and-ethics/sensitive-data-personal_data/statement">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>statement</key>
 		<path>106_dfg/legal-and-ethics/sensitive-data-personal_data/statement</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sensitive_data/personal_data/consent/statement"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/legal-and-ethics/sensitive-data-personal_data"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/legal-and-ethics/sensitive-data-personal_data"/>
 		<is_collection>False</is_collection>
 		<order>4</order>
 		<help lang="en">From the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/foerderkriterien_editionen_literaturwissenschaft.pdf&quot; target=_blank&gt; Handout from the Review Board 106  Social and Cultural Anthropology, Non-European Cultures, Jewish Studies and Religious Studies on handling research data &lt;/a&gt; (in German):
@@ -807,13 +807,13 @@ Falls auf eine informierte Einwilligung verzichtet werden soll (z.B. wegen Frist
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/legal-and-ethics/sensitive-data-official_approval">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/legal-and-ethics/sensitive-data-official_approval">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>sensitive-data-official_approval</key>
 		<path>106_dfg/legal-and-ethics/sensitive-data-official_approval</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/legal-and-ethics"/>
 		<is_collection>False</is_collection>
 		<order>28</order>
 		<title lang="en">Official approval</title>
@@ -826,13 +826,13 @@ Falls auf eine informierte Einwilligung verzichtet werden soll (z.B. wegen Frist
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/legal-and-ethics/sensitive-data-official_approval/ethics_committee">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/legal-and-ethics/sensitive-data-official_approval/ethics_committee">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>ethics_committee</key>
 		<path>106_dfg/legal-and-ethics/sensitive-data-official_approval/ethics_committee</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/legal_aspects/official_approval/ethics_committee"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/legal-and-ethics/sensitive-data-official_approval"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/legal-and-ethics/sensitive-data-official_approval"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">See also DFG &lt;a href=&quot;https://www.dfg.de/foerderung/faq/geistes_sozialwissenschaften/index.html&quot; target=_blank&gt; Notes for the humanities and social sciences&lt;/a&gt;: When do I need an ethics vote? (in German)</help>
@@ -850,17 +850,17 @@ Falls auf eine informierte Einwilligung verzichtet werden soll (z.B. wegen Frist
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/ethics_committee_approval_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/ethics_committee_approval_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/legal-and-ethics/intellectual-property-rights-yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/legal-and-ethics/intellectual-property-rights-yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>intellectual-property-rights-yesno</key>
 		<path>106_dfg/legal-and-ethics/intellectual-property-rights-yesno</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/legal-and-ethics"/>
 		<is_collection>False</is_collection>
 		<order>30</order>
 		<title lang="en">Intellectual property rights I</title>
@@ -873,13 +873,13 @@ Falls auf eine informierte Einwilligung verzichtet werden soll (z.B. wegen Frist
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/legal-and-ethics/intellectual-property-rights-yesno/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/legal-and-ethics/intellectual-property-rights-yesno/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>106_dfg/legal-and-ethics/intellectual-property-rights-yesno/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/legal_aspects/ipr/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/legal-and-ethics/intellectual-property-rights-yesno"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/legal-and-ethics/intellectual-property-rights-yesno"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<help lang="en">Data or software can be subject to intellectual or industrial property rights. Applicable laws differ broadly even within EU. According to the German copyright law (UrhG) works of literature, scholarship and the arts that can be regarded as a “personal intellectual creation” are protected by copyright. Copyright protection expires 70 years after the death of the copyright holder. Mere data, e.g. measured data or survey data, and metadata (except in some cases descriptive metadata) are not protected by copyright. § 2 of the UrhG lists the following kinds of protected works (list is not concluded): 
@@ -927,13 +927,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/legal-and-ethics/intellectual-property-rights-dataset">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/legal-and-ethics/intellectual-property-rights-dataset">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>intellectual-property-rights-dataset</key>
 		<path>106_dfg/legal-and-ethics/intellectual-property-rights-dataset</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/legal-and-ethics"/>
 		<is_collection>True</is_collection>
 		<order>31</order>
 		<title lang="en">Intellectual property rights II</title>
@@ -945,16 +945,16 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<verbose_name lang="de">Datensatz</verbose_name>
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/intellectual_property_rights"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/intellectual_property_rights"/>
 		</conditions>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/legal-and-ethics/intellectual-property-rights-dataset/copyrights">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/legal-and-ethics/intellectual-property-rights-dataset/copyrights">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>copyrights</key>
 		<path>106_dfg/legal-and-ethics/intellectual-property-rights-dataset/copyrights</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/ipr/copyrights"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
 		<is_collection>True</is_collection>
 		<order>0</order>
 		<help lang="en"/>
@@ -972,17 +972,17 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_copyright_laws"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_copyright_laws"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/legal-and-ethics/intellectual-property-rights-dataset/other_rights">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/legal-and-ethics/intellectual-property-rights-dataset/other_rights">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>other_rights</key>
 		<path>106_dfg/legal-and-ethics/intellectual-property-rights-dataset/other_rights</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/ipr/other_rights"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
 		<is_collection>True</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -1000,27 +1000,27 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_other_rights"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_other_rights"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/storage-and-long-term-preservation">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/storage-and-long-term-preservation">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>storage-and-long-term-preservation</key>
 		<path>106_dfg/storage-and-long-term-preservation</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/106_dfg"/>
 		<order>10</order>
 		<title lang="en">Storage and long-term preservation</title>
 		<title lang="de">Speicherung und Langzeitarchivierung</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/storage-and-long-term-preservation/long-term-preservation-datasets">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/storage-and-long-term-preservation/long-term-preservation-datasets">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>long-term-preservation-datasets</key>
 		<path>106_dfg/storage-and-long-term-preservation/long-term-preservation-datasets</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/storage-and-long-term-preservation"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/storage-and-long-term-preservation"/>
 		<is_collection>True</is_collection>
 		<order>11</order>
 		<title lang="en">Long-term preservation</title>
@@ -1033,13 +1033,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>106_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en"/>
@@ -1059,13 +1059,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/purpose">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/purpose">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>purpose</key>
 		<path>106_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/purpose</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/purpose"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>True</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -1083,17 +1083,17 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/preservation_motivation_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/preservation_motivation_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/duration">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/duration">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>duration</key>
 		<path>106_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/duration</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/duration"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>False</is_collection>
 		<order>3</order>
 		<help lang="en">From the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/foerderkriterien_editionen_literaturwissenschaft.pdf&quot; target=_blank&gt; Handout from the Review Board 106  Social and Cultural Anthropology, Non-European Cultures, Jewish Studies and Religious Studies on handling research data &lt;/a&gt; (in German):
@@ -1117,13 +1117,13 @@ Den Regeln der Guten Wissenschaftlichen Praxis folgend sollen Forschungsdaten in
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/repository">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/repository">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>repository</key>
 		<path>106_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/repository</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/repository"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/106_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/106_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>True</is_collection>
 		<order>5</order>
 		<help lang="en">From the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/foerderkriterien_editionen_literaturwissenschaft.pdf&quot; target=_blank&gt; Handout from the Review Board 106  Social and Cultural Anthropology, Non-European Cultures, Jewish Studies and Religious Studies on handling research data &lt;/a&gt; (in German):
@@ -1145,7 +1145,7 @@ Die Archivierung kann digital oder in analoger Form erfolgen. Im Antrag ist anzu
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/preservation_repository_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/preservation_repository_options"/>
 		</optionsets>
 		<conditions/>
 	</question>

--- a/shared/fodako/all.xml
+++ b/shared/fodako/all.xml
@@ -1,30 +1,30 @@
 <?xml version="1.0" ?>
 <rdmo xmlns:dc="http://purl.org/dc/elements/1.1/">
-	<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<catalog dc:uri="https://rdmo.fodako.nrw/questions/all">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>all</key>
 		<dc:comment/>
 		<order>99</order>
 		<title lang="en">All questions</title>
 		<title lang="de">Alle Fragen</title>
 	</catalog>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/general">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/all/general">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>general</key>
 		<path>all/general</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/all"/>
 		<order>0</order>
 		<title lang="en">General</title>
 		<title lang="de">Allgemein</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/general/topic-research_question">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/general/topic-research_question">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>topic-research_question</key>
 		<path>all/general/topic-research_question</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/general"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/all/general"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<title lang="en">Topic</title>
@@ -37,13 +37,13 @@
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/general/topic-research_question/title">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/general/topic-research_question/title">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>title</key>
 		<path>all/general/topic-research_question/title</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/research_question/title"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/general/topic-research_question"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/general/topic-research_question"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en"/>
@@ -63,13 +63,13 @@
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/general/topic-research_question/keywords">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/general/topic-research_question/keywords">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>keywords</key>
 		<path>all/general/topic-research_question/keywords</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/research_question/keywords"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/general/topic-research_question"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/general/topic-research_question"/>
 		<is_collection>True</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -89,13 +89,13 @@
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/general/topic-research_field">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/general/topic-research_field">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>topic-research_field</key>
 		<path>all/general/topic-research_field</path>
 		<dc:comment>for Germany, the classification works, but we might consider also DDC as an option</dc:comment>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/general"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/all/general"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<title lang="en">Research field</title>
@@ -108,13 +108,13 @@
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/general/topic-research_field/research_field">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/general/topic-research_field/research_field">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>research_field</key>
 		<path>all/general/topic-research_field/research_field</path>
 		<dc:comment>for Germany, the classification works, but we might consider also DDC as an option</dc:comment>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/research_field/title"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/general/topic-research_field"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/general/topic-research_field"/>
 		<is_collection>True</is_collection>
 		<order>0</order>
 		<help lang="en">The list of disciplines follows the &lt;a href=&quot;http://www.dfg.de/en/dfg_profile/statutory_bodies/review_boards/subject_areas/index.jsp&quot; target=_blank&quot;&gt;subject classification of the DFG (German Research Foundation)&lt;/a&gt;.</help>
@@ -132,17 +132,17 @@
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/research_fields"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/research_fields"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/general/project-schedule-schedule">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/general/project-schedule-schedule">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>project-schedule-schedule</key>
 		<path>all/general/project-schedule-schedule</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/general"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/all/general"/>
 		<is_collection>False</is_collection>
 		<order>10</order>
 		<title lang="en">Project schedule</title>
@@ -155,13 +155,13 @@
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/general/project-schedule-schedule/project_start">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/general/project-schedule-schedule/project_start">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>project_start</key>
 		<path>all/general/project-schedule-schedule/project_start</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/schedule/project_start"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/general/project-schedule-schedule"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/general/project-schedule-schedule"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<help lang="en"/>
@@ -181,13 +181,13 @@
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/general/project-schedule-schedule/project_end">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/general/project-schedule-schedule/project_end">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>project_end</key>
 		<path>all/general/project-schedule-schedule/project_end</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/schedule/project_end"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/general/project-schedule-schedule"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/general/project-schedule-schedule"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -207,13 +207,13 @@
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/general/project-partners-name">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/general/project-partners-name">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>project-partners-name</key>
 		<path>all/general/project-partners-name</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/general"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/all/general"/>
 		<is_collection>False</is_collection>
 		<order>20</order>
 		<title lang="en">Project coordination</title>
@@ -226,13 +226,13 @@
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/general/project-partners-name/name">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/general/project-partners-name/name">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>name</key>
 		<path>all/general/project-partners-name/name</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/coordination/name"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/general/project-partners-name"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/general/project-partners-name"/>
 		<is_collection>True</is_collection>
 		<order>0</order>
 		<help lang="en"/>
@@ -252,13 +252,13 @@
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/general/project-partners-partner">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/general/project-partners-partner">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>project-partners-partner</key>
 		<path>all/general/project-partners-partner</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/partner"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/general"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/all/general"/>
 		<is_collection>True</is_collection>
 		<order>21</order>
 		<title lang="en">Project partners</title>
@@ -271,13 +271,13 @@
 		<verbose_name_plural lang="de">Projektpartner</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/general/project-partners-partner/name">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/general/project-partners-partner/name">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>name</key>
 		<path>all/general/project-partners-partner/name</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/partner/name"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/general/project-partners-partner"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/general/project-partners-partner"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<help lang="en"/>
@@ -297,13 +297,13 @@
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/general/project-partners-partner/rdm_policy">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/general/project-partners-partner/rdm_policy">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>rdm_policy</key>
 		<path>all/general/project-partners-partner/rdm_policy</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/partner/rdm_policy"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/general/project-partners-partner"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/general/project-partners-partner"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">More and more universities and scientific institutions adopt research data management policies. These contain, among other things, recommendations and / or demands concerning the handling of research data by researchers of the institution. &lt;a href=&quot;https://www.fodako.de/policies.html&quot; target=_blank&quot;&gt;Principles and guidelines on handling research data at the Universities of Düsseldorf, Siegen and Wuppertal&lt;/a&gt; or the &lt;a href=&quot;http://www.uni-goettingen.de/en/488918.html&quot; target=_blank&quot;&gt;Research data policy of the Georg-August University Goettingen&lt;/a&gt;.</help>
@@ -325,13 +325,13 @@
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/general/project-partners-partner/contact">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/general/project-partners-partner/contact">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>contact</key>
 		<path>all/general/project-partners-partner/contact</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/partner/contact_person/name"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/general/project-partners-partner"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/general/project-partners-partner"/>
 		<is_collection>True</is_collection>
 		<order>3</order>
 		<help lang="en">Please give the name and an email address.</help>
@@ -351,13 +351,13 @@
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/general/funding-funder">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/general/funding-funder">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>funding-funder</key>
 		<path>all/general/funding-funder</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/funder"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/general"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/all/general"/>
 		<is_collection>True</is_collection>
 		<order>40</order>
 		<title lang="en">Funding</title>
@@ -370,13 +370,13 @@
 		<verbose_name_plural lang="de">Förderer</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/general/funding-funder/name">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/general/funding-funder/name">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>name</key>
 		<path>all/general/funding-funder/name</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/funder/name"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/general/funding-funder"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/general/funding-funder"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<help lang="en"/>
@@ -396,13 +396,13 @@
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/general/funding-funder/title">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/general/funding-funder/title">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>title</key>
 		<path>all/general/funding-funder/title</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/funder/programme/title"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/general/funding-funder"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/general/funding-funder"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en"/>
@@ -422,13 +422,13 @@
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/general/funding-funder/funder_policy">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/general/funding-funder/funder_policy">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>funder_policy</key>
 		<path>all/general/funding-funder/funder_policy</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/funder/rdm_policy"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/general/funding-funder"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/general/funding-funder"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en">Funders of research also increasingly specify requirements regarding the management of research data in funded projects. Examples are the &lt;a
@@ -453,13 +453,13 @@
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/general/other-requirements-yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/general/other-requirements-yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>other-requirements-yesno</key>
 		<path>all/general/other-requirements-yesno</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/general"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/all/general"/>
 		<is_collection>False</is_collection>
 		<order>50</order>
 		<title lang="en">Other requirements I</title>
@@ -472,13 +472,13 @@
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/general/other-requirements-yesno/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/general/other-requirements-yesno/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>all/general/other-requirements-yesno/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/additional_rdm_policy/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/general/other-requirements-yesno"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/general/other-requirements-yesno"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<help lang="en">Examples of discipline-specific requirements are: - &lt;a href=&quot;http://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/guidelines_biodiversity_research.pdf&quot; target=_blank&quot;&gt;Guidelines on the Handling of Research
@@ -506,17 +506,17 @@
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/other_requirements_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/other_requirements_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/general/other-requirements-requirements">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/general/other-requirements-requirements">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>other-requirements-requirements</key>
 		<path>all/general/other-requirements-requirements</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/general"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/all/general"/>
 		<is_collection>False</is_collection>
 		<order>51</order>
 		<title lang="en">Other requirements II</title>
@@ -528,16 +528,16 @@
 		<verbose_name lang="de"/>
 		<verbose_name_plural lang="de"/>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/additional_rdm_policy"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/additional_rdm_policy"/>
 		</conditions>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/general/other-requirements-requirements/requirements">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/general/other-requirements-requirements/requirements">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>requirements</key>
 		<path>all/general/other-requirements-requirements/requirements</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/additional_rdm_policy/requirements"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/general/other-requirements-requirements"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/general/other-requirements-requirements"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<help lang="en">Please briefly outline them and refer to more detailed sources of information if necessary. Please also indicate, if the rules / guidelines are mandatory or optional.</help>
@@ -557,13 +557,13 @@
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/general/support">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/general/support">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>support</key>
 		<path>all/general/support</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/general"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/all/general"/>
 		<is_collection>False</is_collection>
 		<order>61</order>
 		<title lang="en">Support</title>
@@ -576,13 +576,13 @@
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/general/support/datamanagement">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/general/support/datamanagement">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>datamanagement</key>
 		<path>all/general/support/datamanagement</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/support"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/general/support"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/general/support"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en"/>
@@ -602,23 +602,23 @@
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/content-classification">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/all/content-classification">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>content-classification</key>
 		<path>all/content-classification</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/all"/>
 		<order>1</order>
 		<title lang="en">Content classification</title>
 		<title lang="de">Inhaltliche Einordnung</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/content-classification/data-dataset">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/content-classification/data-dataset">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-dataset</key>
 		<path>all/content-classification/data-dataset</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/content-classification"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/all/content-classification"/>
 		<is_collection>True</is_collection>
 		<order>1</order>
 		<title lang="en">Datasets</title>
@@ -631,13 +631,13 @@
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/content-classification/data-dataset/description">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/content-classification/data-dataset/description">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>description</key>
 		<path>all/content-classification/data-dataset/description</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/description"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/content-classification/data-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/content-classification/data-dataset"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">Please briefly describe the data type and / or the method used to create or collect the data, for example: 
@@ -669,13 +669,13 @@
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/content-classification/data-existing_data">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/content-classification/data-existing_data">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-existing_data</key>
 		<path>all/content-classification/data-existing_data</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/content-classification"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/all/content-classification"/>
 		<is_collection>True</is_collection>
 		<order>2</order>
 		<title lang="en">Data origin</title>
@@ -688,13 +688,13 @@
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/content-classification/data-existing_data/origin">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/content-classification/data-existing_data/origin">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>origin</key>
 		<path>all/content-classification/data-existing_data/origin</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/origin"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/content-classification/data-existing_data"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/content-classification/data-existing_data"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en"/>
@@ -712,17 +712,17 @@
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_origin_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_origin_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/content-classification/data-existing_data/creator_name">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/content-classification/data-existing_data/creator_name">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>creator_name</key>
 		<path>all/content-classification/data-existing_data/creator_name</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/creator/name"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/content-classification/data-existing_data"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/content-classification/data-existing_data"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -742,13 +742,13 @@
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/content-classification/data-existing_data/uri">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/content-classification/data-existing_data/uri">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>uri</key>
 		<path>all/content-classification/data-existing_data/uri</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/uri"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/content-classification/data-existing_data"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/content-classification/data-existing_data"/>
 		<is_collection>False</is_collection>
 		<order>3</order>
 		<help lang="en"/>
@@ -768,13 +768,13 @@
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/content-classification/data-reuse">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/content-classification/data-reuse">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-reuse</key>
 		<path>all/content-classification/data-reuse</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/content-classification"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/all/content-classification"/>
 		<is_collection>True</is_collection>
 		<order>3</order>
 		<title lang="en">Reuse</title>
@@ -787,13 +787,13 @@
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/content-classification/data-reuse/scenario">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/content-classification/data-reuse/scenario">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>scenario</key>
 		<path>all/content-classification/data-reuse/scenario</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/reuse_scenario"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/content-classification/data-reuse"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/content-classification/data-reuse"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">It is important to set the fundamental course as to whether or not the data will be permitted for reuse. Of course, the potential for subsequent use can not be the sole decision criterion, but legal impediments, such as privacy, copyright and business secrets must be taken into account. Otherwise, consider the re-use potential against the disadvantages, e.g. a decrease in the readiness to participate and the expected extra effort of a data publication.</help>
@@ -813,13 +813,13 @@
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/content-classification/data-reuse/existing">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/content-classification/data-reuse/existing">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>existing</key>
 		<path>all/content-classification/data-reuse/existing</path>
 		<dc:comment>Neue, noch nicht im Katalog RDMO enthaltene Frage, die aufgrund einer Anforderung in 'Bereitstellung und Nutzung quantitativer Forschungsdaten in der Bildungsforschung: Memorandum des Fachkollegiums „Erziehungswissenschaft“ der DFG' aufgenommen wurde</dc:comment>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/reuse_existing"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/content-classification/data-reuse"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/content-classification/data-reuse"/>
 		<is_collection>False</is_collection>
 		<order>3</order>
 		<help lang="en">From &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/richtlinien_forschungsdaten_bildungsforschung.pdf&quot;
@@ -845,13 +845,13 @@ For project applications that involve the collection of new data, it should alwa
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/content-classification/data-reproducibility">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/content-classification/data-reproducibility">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-reproducibility</key>
 		<path>all/content-classification/data-reproducibility</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/content-classification"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/all/content-classification"/>
 		<is_collection>True</is_collection>
 		<order>4</order>
 		<title lang="en">Reproducibility</title>
@@ -864,13 +864,13 @@ For project applications that involve the collection of new data, it should alwa
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/content-classification/data-reproducibility/reproducibility">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/content-classification/data-reproducibility/reproducibility">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>reproducibility</key>
 		<path>all/content-classification/data-reproducibility/reproducibility</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/reproducibility"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/content-classification/data-reproducibility"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/content-classification/data-reproducibility"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en">Some data can, technically, be created anew at any time, as is the case with scientific experiments or digitised versions of analog objects (as long as the originals are still there and in good shape). However, this can consume a
@@ -895,27 +895,27 @@ For project applications that involve the collection of new data, it should alwa
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_reproducible_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_reproducible_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/technical-classification">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/all/technical-classification">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>technical-classification</key>
 		<path>all/technical-classification</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/all"/>
 		<order>2</order>
 		<title lang="en">Technical classification</title>
 		<title lang="de">Technische Einordnung</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/technical-classification/data-dates">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/technical-classification/data-dates">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-dates</key>
 		<path>all/technical-classification/data-dates</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/technical-classification"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/all/technical-classification"/>
 		<is_collection>True</is_collection>
 		<order>1</order>
 		<title lang="en">Date collection</title>
@@ -928,13 +928,13 @@ For project applications that involve the collection of new data, it should alwa
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/technical-classification/data-dates/data_collection_start">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/technical-classification/data-dates/data_collection_start">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data_collection_start</key>
 		<path>all/technical-classification/data-dates/data_collection_start</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/data_collection_start"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/technical-classification/data-dates"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/technical-classification/data-dates"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en"/>
@@ -954,13 +954,13 @@ For project applications that involve the collection of new data, it should alwa
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/technical-classification/data-dates/data_collection_end">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/technical-classification/data-dates/data_collection_end">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data_collection_end</key>
 		<path>all/technical-classification/data-dates/data_collection_end</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/data_collection_end"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/technical-classification/data-dates"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/technical-classification/data-dates"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -980,13 +980,13 @@ For project applications that involve the collection of new data, it should alwa
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/technical-classification/data-dates/data_cleansing_start">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/technical-classification/data-dates/data_cleansing_start">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data_cleansing_start</key>
 		<path>all/technical-classification/data-dates/data_cleansing_start</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/data_cleansing_start"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/technical-classification/data-dates"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/technical-classification/data-dates"/>
 		<is_collection>False</is_collection>
 		<order>3</order>
 		<help lang="en"/>
@@ -1006,13 +1006,13 @@ For project applications that involve the collection of new data, it should alwa
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/technical-classification/data-dates/data_cleansing_end">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/technical-classification/data-dates/data_cleansing_end">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data_cleansing_end</key>
 		<path>all/technical-classification/data-dates/data_cleansing_end</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/data_cleansing_end"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/technical-classification/data-dates"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/technical-classification/data-dates"/>
 		<is_collection>False</is_collection>
 		<order>4</order>
 		<help lang="en"/>
@@ -1032,13 +1032,13 @@ For project applications that involve the collection of new data, it should alwa
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/technical-classification/data-dates/data_analysis_start">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/technical-classification/data-dates/data_analysis_start">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data_analysis_start</key>
 		<path>all/technical-classification/data-dates/data_analysis_start</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/data_analysis_start"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/technical-classification/data-dates"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/technical-classification/data-dates"/>
 		<is_collection>False</is_collection>
 		<order>5</order>
 		<help lang="en"/>
@@ -1058,13 +1058,13 @@ For project applications that involve the collection of new data, it should alwa
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/technical-classification/data-dates/data_analysis_end">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/technical-classification/data-dates/data_analysis_end">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data_analysis_end</key>
 		<path>all/technical-classification/data-dates/data_analysis_end</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/data_analysis_end"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/technical-classification/data-dates"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/technical-classification/data-dates"/>
 		<is_collection>False</is_collection>
 		<order>6</order>
 		<help lang="en"/>
@@ -1084,13 +1084,13 @@ For project applications that involve the collection of new data, it should alwa
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/technical-classification/data-volume">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/technical-classification/data-volume">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-volume</key>
 		<path>all/technical-classification/data-volume</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/technical-classification"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/all/technical-classification"/>
 		<is_collection>True</is_collection>
 		<order>2</order>
 		<title lang="en">Data size</title>
@@ -1103,13 +1103,13 @@ For project applications that involve the collection of new data, it should alwa
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/technical-classification/data-volume/volume">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/technical-classification/data-volume/volume">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>volume</key>
 		<path>all/technical-classification/data-volume/volume</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/size/volume"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/technical-classification/data-volume"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/technical-classification/data-volume"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en"/>
@@ -1127,17 +1127,17 @@ For project applications that involve the collection of new data, it should alwa
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_size_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_size_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/technical-classification/data-volume/rate">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/technical-classification/data-volume/rate">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>rate</key>
 		<path>all/technical-classification/data-volume/rate</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/rate"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/technical-classification/data-volume"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/technical-classification/data-volume"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en">Optional. This is only of concern if the data production rate reaches TB scale.</help>
@@ -1157,13 +1157,13 @@ For project applications that involve the collection of new data, it should alwa
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/technical-classification/data-formats">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/technical-classification/data-formats">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-formats</key>
 		<path>all/technical-classification/data-formats</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/technical-classification"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/all/technical-classification"/>
 		<is_collection>True</is_collection>
 		<order>3</order>
 		<title lang="en">Formats</title>
@@ -1176,13 +1176,13 @@ For project applications that involve the collection of new data, it should alwa
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/technical-classification/data-formats/format">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/technical-classification/data-formats/format">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>format</key>
 		<path>all/technical-classification/data-formats/format</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/format"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/technical-classification/data-formats"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/technical-classification/data-formats"/>
 		<is_collection>False</is_collection>
 		<order>4</order>
 		<help lang="en">When choosing a data format, one should consider the consequences for collaborative use, long-term preservation as well as re-use. It is advisable to prefer formats that are standardised, open, non-proprietary and well-established in the respective scholarly community. A table with recommended file formats can be found in Kristin Briney, &lt;i&gt;Data Management for Researchers&lt;/i&gt;, Pelargic, 2015, pages 133-134.</help>
@@ -1202,13 +1202,13 @@ For project applications that involve the collection of new data, it should alwa
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/technical-classification/data-tools">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/technical-classification/data-tools">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-tools</key>
 		<path>all/technical-classification/data-tools</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/technical-classification"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/all/technical-classification"/>
 		<is_collection>True</is_collection>
 		<order>4</order>
 		<title lang="en">Tools</title>
@@ -1221,13 +1221,13 @@ For project applications that involve the collection of new data, it should alwa
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/technical-classification/data-tools/creation_methods">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/technical-classification/data-tools/creation_methods">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>creation_methods</key>
 		<path>all/technical-classification/data-tools/creation_methods</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/creation_methods"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/technical-classification/data-tools"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/technical-classification/data-tools"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">This information is necessary to be able to reconstruct the process by which the data was generated. It is also a prerequisite to judge the objectivity, reliability and validity of the dataset. For reproducible data, it is also
@@ -1249,13 +1249,13 @@ For project applications that involve the collection of new data, it should alwa
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/technical-classification/data-tools/usage_technology">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/technical-classification/data-tools/usage_technology">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>usage_technology</key>
 		<path>all/technical-classification/data-tools/usage_technology</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/usage_technology"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/technical-classification/data-tools"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/technical-classification/data-tools"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en">To be able to re-use data (e.g. to replicate studies, for meta analysis or to solve new research questions), along with the data the software, equipment and knowledge about special methods to use the data are required. Just as with
@@ -1277,13 +1277,13 @@ For project applications that involve the collection of new data, it should alwa
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/technical-classification/data-tools/documentation">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/technical-classification/data-tools/documentation">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>documentation</key>
 		<path>all/technical-classification/data-tools/documentation</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/software_documentation"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/technical-classification/data-tools"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/technical-classification/data-tools"/>
 		<is_collection>False</is_collection>
 		<order>3</order>
 		<help lang="en"/>
@@ -1303,13 +1303,13 @@ For project applications that involve the collection of new data, it should alwa
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/technical-classification/data-versioning">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/technical-classification/data-versioning">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-versioning</key>
 		<path>all/technical-classification/data-versioning</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/technical-classification"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/all/technical-classification"/>
 		<is_collection>True</is_collection>
 		<order>5</order>
 		<title lang="en">Versioning</title>
@@ -1322,13 +1322,13 @@ For project applications that involve the collection of new data, it should alwa
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/technical-classification/data-versioning/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/technical-classification/data-versioning/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>all/technical-classification/data-versioning/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/versioning_yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/technical-classification/data-versioning"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/technical-classification/data-versioning"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en"/>
@@ -1348,13 +1348,13 @@ For project applications that involve the collection of new data, it should alwa
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/technical-classification/data-versioning/strategy">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/technical-classification/data-versioning/strategy">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>strategy</key>
 		<path>all/technical-classification/data-versioning/strategy</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/versioning_strategy"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/technical-classification/data-versioning"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/technical-classification/data-versioning"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en">Please briefly describe the project-internal regulations for the versioning of data sets (e.g.: What kind of changes require a new version? How are changes documented? What are the naming rules for different versions?)</help>
@@ -1374,13 +1374,13 @@ For project applications that involve the collection of new data, it should alwa
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/technical-classification/data-versioning/tool">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/technical-classification/data-versioning/tool">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>tool</key>
 		<path>all/technical-classification/data-versioning/tool</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/versioning_tool"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/technical-classification/data-versioning"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/technical-classification/data-versioning"/>
 		<is_collection>False</is_collection>
 		<order>3</order>
 		<help lang="en"/>
@@ -1398,27 +1398,27 @@ For project applications that involve the collection of new data, it should alwa
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/software_versioning_technology_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/software_versioning_technology_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-usage</key>
 		<path>all/data-usage</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/all"/>
 		<order>3</order>
 		<title lang="en">Data usage</title>
 		<title lang="de">Datennutzung</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/scenarios-usage">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/scenarios-usage">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>scenarios-usage</key>
 		<path>all/data-usage/scenarios-usage</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage"/>
 		<is_collection>True</is_collection>
 		<order>0</order>
 		<title lang="en">Usage scenarios</title>
@@ -1433,13 +1433,13 @@ For project applications that involve the collection of new data, it should alwa
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/scenarios-usage/description">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/scenarios-usage/description">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>description</key>
 		<path>all/data-usage/scenarios-usage/description</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/usage_description"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/scenarios-usage"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/scenarios-usage"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<help lang="en"/>
@@ -1459,13 +1459,13 @@ For project applications that involve the collection of new data, it should alwa
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/scenarios-usage/frequency">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/scenarios-usage/frequency">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>frequency</key>
 		<path>all/data-usage/scenarios-usage/frequency</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/usage_frequency"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/scenarios-usage"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/scenarios-usage"/>
 		<is_collection>False</is_collection>
 		<order>3</order>
 		<help lang="en"/>
@@ -1485,13 +1485,13 @@ For project applications that involve the collection of new data, it should alwa
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/scenarios-usage/infrastructure">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/scenarios-usage/infrastructure">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>infrastructure</key>
 		<path>all/data-usage/scenarios-usage/infrastructure</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/usage_infrastructure"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/scenarios-usage"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/scenarios-usage"/>
 		<is_collection>False</is_collection>
 		<order>4</order>
 		<help lang="en"/>
@@ -1509,17 +1509,17 @@ For project applications that involve the collection of new data, it should alwa
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/infrastructure_resources"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/infrastructure_resources"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/scenarios-usage/support">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/scenarios-usage/support">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>support</key>
 		<path>all/data-usage/scenarios-usage/support</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/usage_support"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/scenarios-usage"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/scenarios-usage"/>
 		<is_collection>False</is_collection>
 		<order>5</order>
 		<help lang="en"/>
@@ -1537,17 +1537,17 @@ For project applications that involve the collection of new data, it should alwa
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/yes_with_text_no"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/yes_with_text_no"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/data-storage-and-security-storage">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/data-storage-and-security-storage">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-storage-and-security-storage</key>
 		<path>all/data-usage/data-storage-and-security-storage</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage"/>
 		<is_collection>True</is_collection>
 		<order>11</order>
 		<title lang="en">Data organisation</title>
@@ -1560,13 +1560,13 @@ For project applications that involve the collection of new data, it should alwa
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/data-storage-and-security-storage/type">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/data-storage-and-security-storage/type">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>type</key>
 		<path>all/data-usage/data-storage-and-security-storage/type</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/storage/type"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/data-storage-and-security-storage"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/data-storage-and-security-storage"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">If parts of the documentation or related software (custom development) are not stored with the data, also indicate where they are stored. This applies to the documentation of the software too.</help>
@@ -1586,13 +1586,13 @@ For project applications that involve the collection of new data, it should alwa
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/data-storage-and-security-storage/uri">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/data-storage-and-security-storage/uri">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>uri</key>
 		<path>all/data-usage/data-storage-and-security-storage/uri</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/storage/uri"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/data-storage-and-security-storage"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/data-storage-and-security-storage"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -1612,13 +1612,13 @@ For project applications that involve the collection of new data, it should alwa
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/data-storage-and-security-storage/organisation_policy">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/data-storage-and-security-storage/organisation_policy">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>organisation_policy</key>
 		<path>all/data-usage/data-storage-and-security-storage/organisation_policy</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/storage/organisation_policy"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/data-storage-and-security-storage"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/data-storage-and-security-storage"/>
 		<is_collection>False</is_collection>
 		<order>3</order>
 		<help lang="en"/>
@@ -1636,17 +1636,17 @@ For project applications that involve the collection of new data, it should alwa
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/yes_no_not_yet"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/yes_no_not_yet"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/data-storage-and-security-storage/naming_policy">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/data-storage-and-security-storage/naming_policy">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>naming_policy</key>
 		<path>all/data-usage/data-storage-and-security-storage/naming_policy</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/storage/naming_policy"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/data-storage-and-security-storage"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/data-storage-and-security-storage"/>
 		<is_collection>False</is_collection>
 		<order>4</order>
 		<help lang="en"/>
@@ -1664,17 +1664,17 @@ For project applications that involve the collection of new data, it should alwa
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/yes_no_not_yet"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/yes_no_not_yet"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/data-storage-and-security-data_security">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/data-storage-and-security-data_security">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-storage-and-security-data_security</key>
 		<path>all/data-usage/data-storage-and-security-data_security</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage"/>
 		<is_collection>True</is_collection>
 		<order>12</order>
 		<title lang="en">Data storage and security</title>
@@ -1687,13 +1687,13 @@ For project applications that involve the collection of new data, it should alwa
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/data-storage-and-security-data_security/access_permissions">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/data-storage-and-security-data_security/access_permissions">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>access_permissions</key>
 		<path>all/data-usage/data-storage-and-security-data_security/access_permissions</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/data_security/access_permissions"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/data-storage-and-security-data_security"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/data-storage-and-security-data_security"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en"/>
@@ -1713,13 +1713,13 @@ For project applications that involve the collection of new data, it should alwa
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/data-storage-and-security-data_security/backups">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/data-storage-and-security-data_security/backups">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>backups</key>
 		<path>all/data-usage/data-storage-and-security-data_security/backups</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/data_security/backups"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/data-storage-and-security-data_security"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/data-storage-and-security-data_security"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en">This question refers to backups while the data is being worked with. Questions of long-term preservation will be adressed in the respective section.</help>
@@ -1739,13 +1739,13 @@ For project applications that involve the collection of new data, it should alwa
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/data-storage-and-security-data_security/name">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/data-storage-and-security-data_security/name">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>name</key>
 		<path>all/data-usage/data-storage-and-security-data_security/name</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/data_security/backup_responsible/name"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/data-storage-and-security-data_security"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/data-storage-and-security-data_security"/>
 		<is_collection>True</is_collection>
 		<order>3</order>
 		<help lang="en">This question refers to backups while the data is being worked with. Questions of long-term preservation will be adressed in the respective section.</help>
@@ -1765,13 +1765,13 @@ For project applications that involve the collection of new data, it should alwa
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/data-storage-and-security-data_security/security_measures">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/data-storage-and-security-data_security/security_measures">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>security_measures</key>
 		<path>all/data-usage/data-storage-and-security-data_security/security_measures</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/data_security/security_measures"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/data-storage-and-security-data_security"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/data-storage-and-security-data_security"/>
 		<is_collection>False</is_collection>
 		<order>4</order>
 		<help lang="en"/>
@@ -1791,13 +1791,13 @@ For project applications that involve the collection of new data, it should alwa
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/data-sharing-and-re-use-interoperability">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/data-sharing-and-re-use-interoperability">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-sharing-and-re-use-interoperability</key>
 		<path>all/data-usage/data-sharing-and-re-use-interoperability</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage"/>
 		<is_collection>True</is_collection>
 		<order>51</order>
 		<title lang="en">Interoperability</title>
@@ -1810,13 +1810,13 @@ For project applications that involve the collection of new data, it should alwa
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/data-sharing-and-re-use-interoperability/interoperability">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/data-sharing-and-re-use-interoperability/interoperability">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>interoperability</key>
 		<path>all/data-usage/data-sharing-and-re-use-interoperability/interoperability</path>
 		<dc:comment>wortlaut noch relativ nah an Original-H2020-Frage</dc:comment>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/interoperability"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/data-sharing-and-re-use-interoperability"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/data-sharing-and-re-use-interoperability"/>
 		<is_collection>True</is_collection>
 		<order>1</order>
 		<help lang="en"/>
@@ -1834,17 +1834,17 @@ For project applications that involve the collection of new data, it should alwa
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_interoperability_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_interoperability_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/data-sharing-and-re-use-publication">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/data-sharing-and-re-use-publication">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-sharing-and-re-use-publication</key>
 		<path>all/data-usage/data-sharing-and-re-use-publication</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage"/>
 		<is_collection>True</is_collection>
 		<order>52</order>
 		<title lang="en">Data sharing and re-use</title>
@@ -1857,13 +1857,13 @@ For project applications that involve the collection of new data, it should alwa
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/data-sharing-and-re-use-publication/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/data-sharing-and-re-use-publication/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>all/data-usage/data-sharing-and-re-use-publication/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sharing/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/data-sharing-and-re-use-publication"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/data-sharing-and-re-use-publication"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en"/>
@@ -1881,17 +1881,17 @@ For project applications that involve the collection of new data, it should alwa
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_sharing_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_sharing_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/data-sharing-and-re-use-publication/explanation">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/data-sharing-and-re-use-publication/explanation">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>explanation</key>
 		<path>all/data-usage/data-sharing-and-re-use-publication/explanation</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sharing/explanation"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/data-sharing-and-re-use-publication"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/data-sharing-and-re-use-publication"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -1911,13 +1911,13 @@ For project applications that involve the collection of new data, it should alwa
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/data-sharing-and-re-use-publication/conditions">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/data-sharing-and-re-use-publication/conditions">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>conditions</key>
 		<path>all/data-usage/data-sharing-and-re-use-publication/conditions</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sharing/conditions"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/data-sharing-and-re-use-publication"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/data-sharing-and-re-use-publication"/>
 		<is_collection>True</is_collection>
 		<order>3</order>
 		<help lang="en">The options refer to the licenses of the &lt;a href=&quot;https://creativecommons.org/share-your-work/licensing-types-examples/&quot; target=_blank&quot;&gt;Creative Commons family&lt;/a&gt;.</help>
@@ -1935,17 +1935,17 @@ For project applications that involve the collection of new data, it should alwa
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_license_types"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_license_types"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/data-sharing-and-re-use-publication/restrictions_explanation">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/data-sharing-and-re-use-publication/restrictions_explanation">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>restrictions_explanation</key>
 		<path>all/data-usage/data-sharing-and-re-use-publication/restrictions_explanation</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sharing/restrictions_explanation"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/data-sharing-and-re-use-publication"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/data-sharing-and-re-use-publication"/>
 		<is_collection>False</is_collection>
 		<order>4</order>
 		<help lang="en"/>
@@ -1965,13 +1965,13 @@ For project applications that involve the collection of new data, it should alwa
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/data-sharing-and-re-use-publication/data_publication_date">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/data-sharing-and-re-use-publication/data_publication_date">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data_publication_date</key>
 		<path>all/data-usage/data-sharing-and-re-use-publication/data_publication_date</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/data_publication_date"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/data-sharing-and-re-use-publication"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/data-sharing-and-re-use-publication"/>
 		<is_collection>False</is_collection>
 		<order>6</order>
 		<help lang="en"/>
@@ -1990,16 +1990,16 @@ For project applications that involve the collection of new data, it should alwa
 		<unit/>
 		<optionsets/>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/data_sharing"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/data_sharing"/>
 		</conditions>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/collaborative-work-collaboration">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/collaborative-work-collaboration">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>collaborative-work-collaboration</key>
 		<path>all/data-usage/collaborative-work-collaboration</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage"/>
 		<is_collection>True</is_collection>
 		<order>53</order>
 		<title lang="en">Collaborative work</title>
@@ -2012,13 +2012,13 @@ For project applications that involve the collection of new data, it should alwa
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/collaborative-work-collaboration/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/collaborative-work-collaboration/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>all/data-usage/collaborative-work-collaboration/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/collaboration_yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/collaborative-work-collaboration"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/collaborative-work-collaboration"/>
 		<is_collection>False</is_collection>
 		<order>6</order>
 		<help lang="en"/>
@@ -2036,17 +2036,17 @@ For project applications that involve the collection of new data, it should alwa
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_collaboration_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_collaboration_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/collaborative-work-collaboration/tools">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/collaborative-work-collaboration/tools">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>tools</key>
 		<path>all/data-usage/collaborative-work-collaboration/tools</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/collaboration_tools"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/collaborative-work-collaboration"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/collaborative-work-collaboration"/>
 		<is_collection>False</is_collection>
 		<order>7</order>
 		<help lang="en"/>
@@ -2066,13 +2066,13 @@ For project applications that involve the collection of new data, it should alwa
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/collaborative-work-collaboration/organisation">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/collaborative-work-collaboration/organisation">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>organisation</key>
 		<path>all/data-usage/collaborative-work-collaboration/organisation</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/collaboration_organisation"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/collaborative-work-collaboration"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/collaborative-work-collaboration"/>
 		<is_collection>False</is_collection>
 		<order>8</order>
 		<help lang="en"/>
@@ -2092,13 +2092,13 @@ For project applications that involve the collection of new data, it should alwa
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/quality-assurance-dataset">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/quality-assurance-dataset">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>quality-assurance-dataset</key>
 		<path>all/data-usage/quality-assurance-dataset</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage"/>
 		<is_collection>True</is_collection>
 		<order>61</order>
 		<title lang="en">Quality assurance</title>
@@ -2111,13 +2111,13 @@ For project applications that involve the collection of new data, it should alwa
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/quality-assurance-dataset/measures">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/quality-assurance-dataset/measures">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>measures</key>
 		<path>all/data-usage/quality-assurance-dataset/measures</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/quality_assurance"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/quality-assurance-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/quality-assurance-dataset"/>
 		<is_collection>False</is_collection>
 		<order>7</order>
 		<help lang="en"/>
@@ -2137,14 +2137,14 @@ For project applications that involve the collection of new data, it should alwa
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/quality-assurance-integration">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/quality-assurance-integration">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>quality-assurance-integration</key>
 		<path>all/data-usage/quality-assurance-integration</path>
 		<dc:comment>the stipulation that re-used and created data are of the same type (= and thus capable to be integrated) is problematic, since this implies properties of the data that are not a given. May be this shoud be reformulated to : Is the
                                 connection between re-used and created data ensures (which goes into the provenance realm)</dc:comment>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage"/>
 		<is_collection>False</is_collection>
 		<order>63</order>
 		<title lang="en">Data integration</title>
@@ -2157,14 +2157,14 @@ For project applications that involve the collection of new data, it should alwa
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/quality-assurance-integration/integration">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/quality-assurance-integration/integration">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>integration</key>
 		<path>all/data-usage/quality-assurance-integration/integration</path>
 		<dc:comment>the stipulation that re-used and created data are of the same type (= and thus capable to be integrated) is problematic, since this implies properties of the data that are not a given. May be this shoud be reformulated to : Is the
                                 connection between re-used and created data ensures (which goes into the provenance realm)</dc:comment>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/integration"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/quality-assurance-integration"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/quality-assurance-integration"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<help lang="en"/>
@@ -2184,13 +2184,13 @@ For project applications that involve the collection of new data, it should alwa
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/costs-dataset">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/costs-dataset">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>costs-dataset</key>
 		<path>all/data-usage/costs-dataset</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage"/>
 		<is_collection>False</is_collection>
 		<order>70</order>
 		<title lang="en">Costs</title>
@@ -2203,13 +2203,13 @@ For project applications that involve the collection of new data, it should alwa
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/costs-dataset/creation_personnel">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/costs-dataset/creation_personnel">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>creation_personnel</key>
 		<path>all/data-usage/costs-dataset/creation_personnel</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/costs/creation/personnel"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/costs-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/costs-dataset"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">Please estimate the effort in person months.</help>
@@ -2229,13 +2229,13 @@ For project applications that involve the collection of new data, it should alwa
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/costs-dataset/creation_non_personnel">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/costs-dataset/creation_non_personnel">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>creation_non_personnel</key>
 		<path>all/data-usage/costs-dataset/creation_non_personnel</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/costs/creation/non_personnel"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/costs-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/costs-dataset"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en">Please estimate the effort in **Euro**.</help>
@@ -2254,16 +2254,16 @@ For project applications that involve the collection of new data, it should alwa
 		<unit>Euro</unit>
 		<optionsets/>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/additional_rdm_policy"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/additional_rdm_policy"/>
 		</conditions>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/costs-dataset/usage_personnel">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/costs-dataset/usage_personnel">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>usage_personnel</key>
 		<path>all/data-usage/costs-dataset/usage_personnel</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/costs/usage/personnel"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/costs-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/costs-dataset"/>
 		<is_collection>False</is_collection>
 		<order>3</order>
 		<help lang="en">Please estimate the effort in person months.</help>
@@ -2283,13 +2283,13 @@ For project applications that involve the collection of new data, it should alwa
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/costs-dataset/usage_non_personnel">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/costs-dataset/usage_non_personnel">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>usage_non_personnel</key>
 		<path>all/data-usage/costs-dataset/usage_non_personnel</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/costs/usage/non_personnel"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/costs-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/costs-dataset"/>
 		<is_collection>False</is_collection>
 		<order>4</order>
 		<help lang="en">Please estimate the costs in **Euro**.</help>
@@ -2309,13 +2309,13 @@ For project applications that involve the collection of new data, it should alwa
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/costs-dataset/storage_personnel">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/costs-dataset/storage_personnel">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>storage_personnel</key>
 		<path>all/data-usage/costs-dataset/storage_personnel</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/costs/storage/personnel"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/costs-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/costs-dataset"/>
 		<is_collection>False</is_collection>
 		<order>5</order>
 		<help lang="en">Please estimate the effort in person months.</help>
@@ -2335,13 +2335,13 @@ For project applications that involve the collection of new data, it should alwa
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/costs-dataset/storage_non_personnel">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/costs-dataset/storage_non_personnel">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>storage_non_personnel</key>
 		<path>all/data-usage/costs-dataset/storage_non_personnel</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/costs/storage/non_personnel"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/data-usage/costs-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/data-usage/costs-dataset"/>
 		<is_collection>False</is_collection>
 		<order>6</order>
 		<help lang="en">Please estimate the costs in **Euro**.</help>
@@ -2361,23 +2361,23 @@ For project applications that involve the collection of new data, it should alwa
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/doc">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/all/doc">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>doc</key>
 		<path>all/doc</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/all"/>
 		<order>4</order>
 		<title lang="en">Documentation</title>
 		<title lang="de">Dokumentation</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/doc/metadata-dataset">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/doc/metadata-dataset">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>metadata-dataset</key>
 		<path>all/doc/metadata-dataset</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/doc"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/all/doc"/>
 		<is_collection>True</is_collection>
 		<order>10</order>
 		<title lang="en">Metadata and data documentation</title>
@@ -2390,13 +2390,13 @@ For project applications that involve the collection of new data, it should alwa
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/doc/metadata-dataset/scope">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/doc/metadata-dataset/scope">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>scope</key>
 		<path>all/doc/metadata-dataset/scope</path>
 		<dc:comment>probably we should introduce a separate question for being findable and re-used</dc:comment>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/metadata/scope"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/doc/metadata-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/doc/metadata-dataset"/>
 		<is_collection>True</is_collection>
 		<order>0</order>
 		<help lang="en"/>
@@ -2414,17 +2414,17 @@ For project applications that involve the collection of new data, it should alwa
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/mandatory_metadata_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/mandatory_metadata_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/doc/metadata-dataset/standards">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/doc/metadata-dataset/standards">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>standards</key>
 		<path>all/doc/metadata-dataset/standards</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/metadata/standards"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/doc/metadata-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/doc/metadata-dataset"/>
 		<is_collection>True</is_collection>
 		<order>1</order>
 		<help lang="en">Also specify the metadata standard if it is already clear which one to use, e.g. because the repository specifies one.</help>
@@ -2442,17 +2442,17 @@ For project applications that involve the collection of new data, it should alwa
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/metadata_standards"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/metadata_standards"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/doc/metadata-dataset/mappings">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/doc/metadata-dataset/mappings">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>mappings</key>
 		<path>all/doc/metadata-dataset/mappings</path>
 		<dc:comment>original H2020 question</dc:comment>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/metadata/mappings"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/doc/metadata-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/doc/metadata-dataset"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en">This information is needed for a Horizon 2020 data management plan.</help>
@@ -2472,13 +2472,13 @@ For project applications that involve the collection of new data, it should alwa
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/doc/metadata-dataset/documentation">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/doc/metadata-dataset/documentation">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>documentation</key>
 		<path>all/doc/metadata-dataset/documentation</path>
 		<dc:comment>Eine Dokumentation wird vom Fachkollegium „Erziehungswissenschaft“ der DFG für solche Forschungsdaten gefordert, die bereitgestellt werden sollen, 'Bereitstellung und Nutzung quantitativer Forschungsdaten in der Bildungsforschung: Memorandum des Fachkollegiums „Erziehungswissenschaft“ der DFG', https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/richtlinien_forschungsdaten_bildungsforschung.pdf. Das Fachkollegium „Wirtschaftswissenschaften“ fordert sogar „die Bereitstellung der verwendeten Programme und eine aussagekräftige Beschreibung“ aller Forschungsdaten, die Grundlage einer Publikation sind, siehe 'Management von Forschungsdaten: Was erwartet das Fachkollegium 112 „Wirtschaftswissenschaften“ von Antragstellenden? (Stand November 2018)', https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/fachkollegium112_forschungsdatenmanagement_1811.pdf. Frage und Attribut wurden deshalb aufgenommen.</dc:comment>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/documentation"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/doc/metadata-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/doc/metadata-dataset"/>
 		<is_collection>False</is_collection>
 		<order>4</order>
 		<help lang="en">Examples:
@@ -2514,13 +2514,13 @@ Tragen Sie in dieses Feld die Bestandteile der Datendokumentation ein, die mit d
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/doc/metadata-dataset/documentation_where">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/doc/metadata-dataset/documentation_where">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>documentation_where</key>
 		<path>all/doc/metadata-dataset/documentation_where</path>
 		<dc:comment>Das DFG-Fachkollegium „Wirtschaftswissenschaften“ fordert die Dokumentation betreffend, „deren Ablage entweder bei den Zeitschriften selbst oder in Repositorien (an Universitäten, Forschungsinstituten oder an zentralen fachspezifischen Informationszentren)“, siehe 'Management von Forschungsdaten: Was erwartet das Fachkollegium 112 „Wirtschaftswissenschaften“ von Antragstellenden? (Stand November 2018)', https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/fachkollegium112_forschungsdatenmanagement_1811.pdf. Frage und Attribut wurden aufgenommen.</dc:comment>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/documentation/where"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/doc/metadata-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/doc/metadata-dataset"/>
 		<is_collection>False</is_collection>
 		<order>4</order>
 		<help lang="en"/>
@@ -2540,13 +2540,13 @@ Tragen Sie in dieses Feld die Bestandteile der Datendokumentation ein, die mit d
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/doc/metadata-dataset/documentation_on_request">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/doc/metadata-dataset/documentation_on_request">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>documentation_on_request</key>
 		<path>all/doc/metadata-dataset/documentation_on_request</path>
 		<dc:comment>Das DFG-Fachkollegium „Erziehungswissenschaft“ fordert nicht, dass die Dokumentation schon vollständig vorliegt, wenn die Daten archiviert werden, sondern hält eine „auf Nachfrage nutzerfreundliche Bereitstellung direkt durch die Datenproduzenten“ für ausreichend, wenn die Forschungsdaten bei der Institution selbst archiviert werden, siehe 'Bereitstellung und Nutzung quantitativer Forschungsdaten in der Bildungsforschung: Memorandum des Fachkollegiums „Erziehungswissenschaft“ der DFG', https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/richtlinien_forschungsdaten_bildungsforschung.pdf, Seite 6. Es soll hier nicht diskutiert werden, wie brauchbar eine nachträgliche Dokumentation von Forschungsdaten sein wird, aber um diese Variante im Datenmanagementplan beschreiben zu können, wurde die obige Frage einschließlich Attribut aufgenommen.</dc:comment>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/documentation_on_request"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/doc/metadata-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/doc/metadata-dataset"/>
 		<is_collection>False</is_collection>
 		<order>5</order>
 		<help lang="en">According to &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/richtlinien_forschungsdaten_bildungsforschung.pdf&quot; target=_blank&quot;&gt;Memorandum des Fachkollegiums „Erziehungswissenschaft“ der DFG&lt;/a&gt;, the provision is expressly provided upon request in the case of the following &lt;i&gt;forms of deployment&lt;/ i&gt;:
@@ -2574,13 +2574,13 @@ b) &lt;i&gt;Archivierung, erweiterte Dokumentation (Codebuch) und auf Nachfrage 
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/doc/metadata-dataset/creation_automatic">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/doc/metadata-dataset/creation_automatic">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>creation_automatic</key>
 		<path>all/doc/metadata-dataset/creation_automatic</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/metadata/creation_automatic"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/doc/metadata-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/doc/metadata-dataset"/>
 		<is_collection>False</is_collection>
 		<order>6</order>
 		<help lang="en"/>
@@ -2600,13 +2600,13 @@ b) &lt;i&gt;Archivierung, erweiterte Dokumentation (Codebuch) und auf Nachfrage 
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/doc/metadata-dataset/creation_semi_automatic">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/doc/metadata-dataset/creation_semi_automatic">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>creation_semi_automatic</key>
 		<path>all/doc/metadata-dataset/creation_semi_automatic</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/metadata/creation_semi_automatic"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/doc/metadata-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/doc/metadata-dataset"/>
 		<is_collection>False</is_collection>
 		<order>7</order>
 		<help lang="en"/>
@@ -2626,13 +2626,13 @@ b) &lt;i&gt;Archivierung, erweiterte Dokumentation (Codebuch) und auf Nachfrage 
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/doc/metadata-dataset/creation_manual">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/doc/metadata-dataset/creation_manual">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>creation_manual</key>
 		<path>all/doc/metadata-dataset/creation_manual</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/metadata/creation_manual"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/doc/metadata-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/doc/metadata-dataset"/>
 		<is_collection>False</is_collection>
 		<order>8</order>
 		<help lang="en"/>
@@ -2652,13 +2652,13 @@ b) &lt;i&gt;Archivierung, erweiterte Dokumentation (Codebuch) und auf Nachfrage 
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/doc/metadata-dataset/quality_assurance">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/doc/metadata-dataset/quality_assurance">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>quality_assurance</key>
 		<path>all/doc/metadata-dataset/quality_assurance</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/metadata/quality_assurance"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/doc/metadata-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/doc/metadata-dataset"/>
 		<is_collection>True</is_collection>
 		<order>9</order>
 		<help lang="en"/>
@@ -2676,17 +2676,17 @@ b) &lt;i&gt;Archivierung, erweiterte Dokumentation (Codebuch) und auf Nachfrage 
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/metadata_check_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/metadata_check_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/doc/metadata-dataset/responsible_person">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/doc/metadata-dataset/responsible_person">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>responsible_person</key>
 		<path>all/doc/metadata-dataset/responsible_person</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/metadata/responsible_person/name"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/doc/metadata-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/doc/metadata-dataset"/>
 		<is_collection>True</is_collection>
 		<order>10</order>
 		<help lang="en"/>
@@ -2706,13 +2706,13 @@ b) &lt;i&gt;Archivierung, erweiterte Dokumentation (Codebuch) und auf Nachfrage 
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/doc/metadata-costs">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/doc/metadata-costs">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>metadata-costs</key>
 		<path>all/doc/metadata-costs</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/doc"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/all/doc"/>
 		<is_collection>False</is_collection>
 		<order>12</order>
 		<title lang="en">Documentation costs</title>
@@ -2725,13 +2725,13 @@ b) &lt;i&gt;Archivierung, erweiterte Dokumentation (Codebuch) und auf Nachfrage 
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/doc/metadata-costs/personnel">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/doc/metadata-costs/personnel">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>personnel</key>
 		<path>all/doc/metadata-costs/personnel</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/costs/metadata/personnel"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/doc/metadata-costs"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/doc/metadata-costs"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">Please estimate the effort in person months.</help>
@@ -2751,13 +2751,13 @@ b) &lt;i&gt;Archivierung, erweiterte Dokumentation (Codebuch) und auf Nachfrage 
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/doc/metadata-costs/non_personnel">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/doc/metadata-costs/non_personnel">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>non_personnel</key>
 		<path>all/doc/metadata-costs/non_personnel</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/costs/metadata/non_personnel"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/doc/metadata-costs"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/doc/metadata-costs"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en">Please estimate the costs in **Euro**.</help>
@@ -2777,23 +2777,23 @@ b) &lt;i&gt;Archivierung, erweiterte Dokumentation (Codebuch) und auf Nachfrage 
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/referencing">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/all/referencing">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>referencing</key>
 		<path>all/referencing</path>
 		<dc:comment>der Abschnitt &quot;Metadaten und Referenzierung&quot; des Katalogs &quot;RDMO&quot; wurde in die beiden Abschnitte &quot;Metadaten und Datendokumentation&quot; und &quot;Referenzierung&quot; aufgeteilt.</dc:comment>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/all"/>
 		<order>5</order>
 		<title lang="en">Referencing</title>
 		<title lang="de">Referenzierung</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/referencing/structure-granularity-and-referencing-structure">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/referencing/structure-granularity-and-referencing-structure">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>structure-granularity-and-referencing-structure</key>
 		<path>all/referencing/structure-granularity-and-referencing-structure</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/referencing"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/all/referencing"/>
 		<is_collection>True</is_collection>
 		<order>20</order>
 		<title lang="en">Structure, granularity, and referencing</title>
@@ -2806,13 +2806,13 @@ b) &lt;i&gt;Archivierung, erweiterte Dokumentation (Codebuch) und auf Nachfrage 
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/referencing/structure-granularity-and-referencing-structure/structure">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/referencing/structure-granularity-and-referencing-structure/structure">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>structure</key>
 		<path>all/referencing/structure-granularity-and-referencing-structure/structure</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/structure"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/referencing/structure-granularity-and-referencing-structure"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/referencing/structure-granularity-and-referencing-structure"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<help lang="en"/>
@@ -2832,13 +2832,13 @@ b) &lt;i&gt;Archivierung, erweiterte Dokumentation (Codebuch) und auf Nachfrage 
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/referencing/structure-granularity-and-referencing-pids">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/referencing/structure-granularity-and-referencing-pids">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>structure-granularity-and-referencing-pids</key>
 		<path>all/referencing/structure-granularity-and-referencing-pids</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/referencing"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/all/referencing"/>
 		<is_collection>True</is_collection>
 		<order>21</order>
 		<title lang="en">Persistent Identifiers (PIDs)</title>
@@ -2851,13 +2851,13 @@ b) &lt;i&gt;Archivierung, erweiterte Dokumentation (Codebuch) und auf Nachfrage 
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/referencing/structure-granularity-and-referencing-pids/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/referencing/structure-granularity-and-referencing-pids/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>all/referencing/structure-granularity-and-referencing-pids/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/pids/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/referencing/structure-granularity-and-referencing-pids"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/referencing/structure-granularity-and-referencing-pids"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<help lang="en"/>
@@ -2877,13 +2877,13 @@ b) &lt;i&gt;Archivierung, erweiterte Dokumentation (Codebuch) und auf Nachfrage 
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/referencing/structure-granularity-and-referencing-pids/system">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/referencing/structure-granularity-and-referencing-pids/system">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>system</key>
 		<path>all/referencing/structure-granularity-and-referencing-pids/system</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/pids/system"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/referencing/structure-granularity-and-referencing-pids"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/referencing/structure-granularity-and-referencing-pids"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -2901,17 +2901,17 @@ b) &lt;i&gt;Archivierung, erweiterte Dokumentation (Codebuch) und auf Nachfrage 
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/pid_types"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/pid_types"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/referencing/structure-granularity-and-referencing-pids/subentities">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/referencing/structure-granularity-and-referencing-pids/subentities">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>subentities</key>
 		<path>all/referencing/structure-granularity-and-referencing-pids/subentities</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/pids/subentities"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/referencing/structure-granularity-and-referencing-pids"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/referencing/structure-granularity-and-referencing-pids"/>
 		<is_collection>False</is_collection>
 		<order>3</order>
 		<help lang="en"/>
@@ -2931,13 +2931,13 @@ b) &lt;i&gt;Archivierung, erweiterte Dokumentation (Codebuch) und auf Nachfrage 
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/referencing/structure-granularity-and-referencing-pids/name">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/referencing/structure-granularity-and-referencing-pids/name">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>name</key>
 		<path>all/referencing/structure-granularity-and-referencing-pids/name</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/pids/responsible_person/name"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/referencing/structure-granularity-and-referencing-pids"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/referencing/structure-granularity-and-referencing-pids"/>
 		<is_collection>True</is_collection>
 		<order>4</order>
 		<help lang="en">A prerequisite for PIDs to work as promised is that they - as well as the objects they refer to - are maintained in a continuous and reliable way. This means, for example, that if the object location changes, this information is updated. When the data are stored in a data centre or repository, these tasks are usually taken care of by the data centre / repository. However, to be sure, the responsibilities should be checked beforehand.</help>
@@ -2959,13 +2959,13 @@ b) &lt;i&gt;Archivierung, erweiterte Dokumentation (Codebuch) und auf Nachfrage 
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/referencing/structure-granularity-and-referencing-costs">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/referencing/structure-granularity-and-referencing-costs">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>structure-granularity-and-referencing-costs</key>
 		<path>all/referencing/structure-granularity-and-referencing-costs</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/referencing"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/all/referencing"/>
 		<is_collection>False</is_collection>
 		<order>23</order>
 		<title lang="en">PIDs costs</title>
@@ -2978,13 +2978,13 @@ b) &lt;i&gt;Archivierung, erweiterte Dokumentation (Codebuch) und auf Nachfrage 
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/referencing/structure-granularity-and-referencing-costs/personnel">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/referencing/structure-granularity-and-referencing-costs/personnel">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>personnel</key>
 		<path>all/referencing/structure-granularity-and-referencing-costs/personnel</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/costs/pid/personnel"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/referencing/structure-granularity-and-referencing-costs"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/referencing/structure-granularity-and-referencing-costs"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">Please estimate the effort in person months.</help>
@@ -3004,13 +3004,13 @@ b) &lt;i&gt;Archivierung, erweiterte Dokumentation (Codebuch) und auf Nachfrage 
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/referencing/structure-granularity-and-referencing-costs/non_personnel">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/referencing/structure-granularity-and-referencing-costs/non_personnel">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>non_personnel</key>
 		<path>all/referencing/structure-granularity-and-referencing-costs/non_personnel</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/costs/pid/non_personnel"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/referencing/structure-granularity-and-referencing-costs"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/referencing/structure-granularity-and-referencing-costs"/>
 		<is_collection>False</is_collection>
 		<order>3</order>
 		<help lang="en">Please estimate the costs in Euro.</help>
@@ -3030,23 +3030,23 @@ b) &lt;i&gt;Archivierung, erweiterte Dokumentation (Codebuch) und auf Nachfrage 
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>legal-and-ethics</key>
 		<path>all/legal-and-ethics</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/all"/>
 		<order>6</order>
 		<title lang="en">Legal and ethics</title>
 		<title lang="de">Rechtliche und ethische Fragen</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/general-legal-issues-international_yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/general-legal-issues-international_yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>general-legal-issues-international_yesno</key>
 		<path>all/legal-and-ethics/general-legal-issues-international_yesno</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics"/>
 		<is_collection>False</is_collection>
 		<order>10</order>
 		<title lang="en">General legal issues</title>
@@ -3059,13 +3059,13 @@ b) &lt;i&gt;Archivierung, erweiterte Dokumentation (Codebuch) und auf Nachfrage 
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/general-legal-issues-international_yesno/international_yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/general-legal-issues-international_yesno/international_yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>international_yesno</key>
 		<path>all/legal-and-ethics/general-legal-issues-international_yesno/international_yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/legal_aspects/international_yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/general-legal-issues-international_yesno"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/general-legal-issues-international_yesno"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<help lang="en">If you answer this question with &quot;Yes&quot;, please get in touch with the legal department or a respective contact person at your institution to clarify if this has consequences for the project and its data management and if yes, what
@@ -3087,13 +3087,13 @@ b) &lt;i&gt;Archivierung, erweiterte Dokumentation (Codebuch) und auf Nachfrage 
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/sensitive-data-personal_data_yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/sensitive-data-personal_data_yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>sensitive-data-personal_data_yesno</key>
 		<path>all/legal-and-ethics/sensitive-data-personal_data_yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics"/>
 		<is_collection>True</is_collection>
 		<order>20</order>
 		<title lang="en">Personal data</title>
@@ -3106,13 +3106,13 @@ b) &lt;i&gt;Archivierung, erweiterte Dokumentation (Codebuch) und auf Nachfrage 
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/sensitive-data-personal_data_yesno/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/sensitive-data-personal_data_yesno/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>all/legal-and-ethics/sensitive-data-personal_data_yesno/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sensitive_data/personal_data_yesno/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/sensitive-data-personal_data_yesno"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/sensitive-data-personal_data_yesno"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">The EU General Data Protection Regulation (GDPR) defines in Art. 4 personal data as &quot;any information relating to an identified or identifiable natural person&quot;. An identifiable natural person is &quot;one who can be identified, directly or indirectly, in particular by reference to an identifier such as a name, an identification number, location data, an online identifier or to one or more factors specific to the physical, physiological, genetic, mental, economic, cultural or social identity of that natural person&quot;.</help>
@@ -3132,13 +3132,13 @@ b) &lt;i&gt;Archivierung, erweiterte Dokumentation (Codebuch) und auf Nachfrage 
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/sensitive-data-privacy_law">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/sensitive-data-privacy_law">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>sensitive-data-privacy_law</key>
 		<path>all/legal-and-ethics/sensitive-data-privacy_law</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics"/>
 		<is_collection>False</is_collection>
 		<order>21</order>
 		<title lang="en">Data protection</title>
@@ -3150,16 +3150,16 @@ b) &lt;i&gt;Archivierung, erweiterte Dokumentation (Codebuch) und auf Nachfrage 
 		<verbose_name lang="de"/>
 		<verbose_name_plural lang="de"/>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/personal_data"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/personal_data"/>
 		</conditions>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/sensitive-data-privacy_law/privacy_law">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/sensitive-data-privacy_law/privacy_law">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>privacy_law</key>
 		<path>all/legal-and-ethics/sensitive-data-privacy_law/privacy_law</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/legal_aspects/sensitive_data/privacy_law"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/sensitive-data-privacy_law"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/sensitive-data-privacy_law"/>
 		<is_collection>True</is_collection>
 		<order>0</order>
 		<help lang="en">Opening clauses in the General Data Protection Regulation are the basis for national data protection laws in the EU. It depends on the kind of institution which law applies. Federal public bodies and private institutions are subject to the Federal Data Protection Act (BDSG). To public bodies of the states (e.g. universities), the respective State Data Protection Acts apply (exact demarcation see § 1 BDSG). In some areas, field-specific laws apply. These override the Federal and State Data Protection Acts. For example, the Tenth Social Code (§ 75 SBG X) is applicable to social data; scientific research in schools can be regulated in the respective school law of the state (for example in § 120 Education Act NRW).</help>
@@ -3178,17 +3178,17 @@ Landesdatenschutzgesetz (genaue Abgrenzung siehe § 1 BDSG). In bestimmten Berei
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/data_protection_laws"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/data_protection_laws"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/sensitive-data-personal_data">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/sensitive-data-personal_data">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>sensitive-data-personal_data</key>
 		<path>all/legal-and-ethics/sensitive-data-personal_data</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics"/>
 		<is_collection>True</is_collection>
 		<order>23</order>
 		<title lang="en">Sensitive data</title>
@@ -3200,16 +3200,16 @@ Landesdatenschutzgesetz (genaue Abgrenzung siehe § 1 BDSG). In bestimmten Berei
 		<verbose_name lang="de">Datensatz</verbose_name>
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/personal_data"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/personal_data"/>
 		</conditions>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/sensitive-data-personal_data/dsgvo_9">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/sensitive-data-personal_data/dsgvo_9">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>dsgvo_9</key>
 		<path>all/legal-and-ethics/sensitive-data-personal_data/dsgvo_9</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sensitive_data/personal_data/bdsg_3_9"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/sensitive-data-personal_data"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/sensitive-data-personal_data"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">These kinds of data are considered particularly sensitive and require even more extensive safeguards. If you answer this question with &quot;Yes&quot;, please get in touch with the data protection officer of your institution to check which additional protection measures are necessary.</help>
@@ -3229,13 +3229,13 @@ Landesdatenschutzgesetz (genaue Abgrenzung siehe § 1 BDSG). In bestimmten Berei
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/sensitive-data-personal_data/anonymization">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/sensitive-data-personal_data/anonymization">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>anonymization</key>
 		<path>all/legal-and-ethics/sensitive-data-personal_data/anonymization</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sensitive_data/personal_data/anonymization"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/sensitive-data-personal_data"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/sensitive-data-personal_data"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -3253,17 +3253,17 @@ Landesdatenschutzgesetz (genaue Abgrenzung siehe § 1 BDSG). In bestimmten Berei
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_anonymisation"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_anonymisation"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/sensitive-data-personal_data/extent">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/sensitive-data-personal_data/extent">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>extent</key>
 		<path>all/legal-and-ethics/sensitive-data-personal_data/extent</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sensitive_data/personal_data/consent/extent"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/sensitive-data-personal_data"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/sensitive-data-personal_data"/>
 		<is_collection>False</is_collection>
 		<order>3</order>
 		<help lang="en">Basically, the collection, processing, archiving and publication of personal data is only admissible, when the “informed consent” of the person in question has been obtained. However, there are a number of exceptions, some of which are described in Art. 6 of the General Data Protection Regulation or which have been made possible by law. For example, § 17 Datenschutzgesetz Nordrhein-Westfalen (DSG-NRW, 17 Mai 2018) allows the processing of personal data for scientific or historical research purposes or for statistical purposes even without consent if processing for these purposes is necessary and protected interests of the person concerned do not prevail.</help>
@@ -3281,17 +3281,17 @@ Landesdatenschutzgesetz (genaue Abgrenzung siehe § 1 BDSG). In bestimmten Berei
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/informed_consent_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/informed_consent_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/sensitive-data-personal_data/statement">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/sensitive-data-personal_data/statement">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>statement</key>
 		<path>all/legal-and-ethics/sensitive-data-personal_data/statement</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sensitive_data/personal_data/consent/statement"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/sensitive-data-personal_data"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/sensitive-data-personal_data"/>
 		<is_collection>False</is_collection>
 		<order>4</order>
 		<help lang="en"/>
@@ -3311,13 +3311,13 @@ Landesdatenschutzgesetz (genaue Abgrenzung siehe § 1 BDSG). In bestimmten Berei
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/sensitive-data-personal_data/record">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/sensitive-data-personal_data/record">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>record</key>
 		<path>all/legal-and-ethics/sensitive-data-personal_data/record</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sensitive_data/personal_data/consent/record"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/sensitive-data-personal_data"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/sensitive-data-personal_data"/>
 		<is_collection>False</is_collection>
 		<order>5</order>
 		<help lang="en"/>
@@ -3337,13 +3337,13 @@ Landesdatenschutzgesetz (genaue Abgrenzung siehe § 1 BDSG). In bestimmten Berei
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/sensitive-data-personal_data/deletion">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/sensitive-data-personal_data/deletion">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>deletion</key>
 		<path>all/legal-and-ethics/sensitive-data-personal_data/deletion</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sensitive_data/personal_data/deletion"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/sensitive-data-personal_data"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/sensitive-data-personal_data"/>
 		<is_collection>False</is_collection>
 		<order>6</order>
 		<help lang="en"/>
@@ -3363,13 +3363,13 @@ Landesdatenschutzgesetz (genaue Abgrenzung siehe § 1 BDSG). In bestimmten Berei
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/sensitive-data-other">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/sensitive-data-other">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>sensitive-data-other</key>
 		<path>all/legal-and-ethics/sensitive-data-other</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics"/>
 		<is_collection>True</is_collection>
 		<order>24</order>
 		<title lang="en">Other sensitive data</title>
@@ -3382,13 +3382,13 @@ Landesdatenschutzgesetz (genaue Abgrenzung siehe § 1 BDSG). In bestimmten Berei
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/sensitive-data-other/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/sensitive-data-other/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>all/legal-and-ethics/sensitive-data-other/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sensitive_data/other/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/sensitive-data-other"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/sensitive-data-other"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">Examples are data that contain trade or business secrets or geoinformation on endangered species.</help>
@@ -3408,13 +3408,13 @@ Landesdatenschutzgesetz (genaue Abgrenzung siehe § 1 BDSG). In bestimmten Berei
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/sensitive-data-other/description">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/sensitive-data-other/description">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>description</key>
 		<path>all/legal-and-ethics/sensitive-data-other/description</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sensitive_data/other/description"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/sensitive-data-other"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/sensitive-data-other"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -3433,16 +3433,16 @@ Landesdatenschutzgesetz (genaue Abgrenzung siehe § 1 BDSG). In bestimmten Berei
 		<unit/>
 		<optionsets/>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/other_sensitive_data"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/other_sensitive_data"/>
 		</conditions>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/sensitive-data-costs">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/sensitive-data-costs">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>sensitive-data-costs</key>
 		<path>all/legal-and-ethics/sensitive-data-costs</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics"/>
 		<is_collection>False</is_collection>
 		<order>26</order>
 		<title lang="en">Sensitive data costs</title>
@@ -3454,17 +3454,17 @@ Landesdatenschutzgesetz (genaue Abgrenzung siehe § 1 BDSG). In bestimmten Berei
 		<verbose_name lang="de"/>
 		<verbose_name_plural lang="de"/>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/other_sensitive_data"/>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/personal_data"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/other_sensitive_data"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/personal_data"/>
 		</conditions>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/sensitive-data-costs/anonymization_personnel">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/sensitive-data-costs/anonymization_personnel">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>anonymization_personnel</key>
 		<path>all/legal-and-ethics/sensitive-data-costs/anonymization_personnel</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/costs/sensitive_data/anonymization/personnel"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/sensitive-data-costs"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/sensitive-data-costs"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">Please estimate the effort in person months.</help>
@@ -3484,13 +3484,13 @@ Landesdatenschutzgesetz (genaue Abgrenzung siehe § 1 BDSG). In bestimmten Berei
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/sensitive-data-costs/anonymization_non_personnel">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/sensitive-data-costs/anonymization_non_personnel">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>anonymization_non_personnel</key>
 		<path>all/legal-and-ethics/sensitive-data-costs/anonymization_non_personnel</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/costs/sensitive_data/anonymization/non_personnel"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/sensitive-data-costs"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/sensitive-data-costs"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en">Please estimate the costs in **Euro**.</help>
@@ -3510,13 +3510,13 @@ Landesdatenschutzgesetz (genaue Abgrenzung siehe § 1 BDSG). In bestimmten Berei
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/sensitive-data-costs/security_personnel">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/sensitive-data-costs/security_personnel">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>security_personnel</key>
 		<path>all/legal-and-ethics/sensitive-data-costs/security_personnel</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/costs/sensitive_data/security/personnel"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/sensitive-data-costs"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/sensitive-data-costs"/>
 		<is_collection>False</is_collection>
 		<order>3</order>
 		<help lang="en">Please estimate the effort in person months.</help>
@@ -3536,13 +3536,13 @@ Landesdatenschutzgesetz (genaue Abgrenzung siehe § 1 BDSG). In bestimmten Berei
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/sensitive-data-costs/security_non_personnel">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/sensitive-data-costs/security_non_personnel">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>security_non_personnel</key>
 		<path>all/legal-and-ethics/sensitive-data-costs/security_non_personnel</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/costs/sensitive_data/security/non_personnel"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/sensitive-data-costs"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/sensitive-data-costs"/>
 		<is_collection>False</is_collection>
 		<order>4</order>
 		<help lang="en">Please estimate the costs in **Euro**.</help>
@@ -3562,13 +3562,13 @@ Landesdatenschutzgesetz (genaue Abgrenzung siehe § 1 BDSG). In bestimmten Berei
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/ethics">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/ethics">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>ethics</key>
 		<path>all/legal-and-ethics/ethics</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics"/>
 		<is_collection>False</is_collection>
 		<order>40</order>
 		<title lang="en">Ethics</title>
@@ -3581,13 +3581,13 @@ Landesdatenschutzgesetz (genaue Abgrenzung siehe § 1 BDSG). In bestimmten Berei
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/ethics/ethics_committee">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/ethics/ethics_committee">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>ethics_committee</key>
 		<path>all/legal-and-ethics/ethics/ethics_committee</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/legal_aspects/official_approval/ethics_committee"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/ethics"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/ethics"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en"/>
@@ -3605,17 +3605,17 @@ Landesdatenschutzgesetz (genaue Abgrenzung siehe § 1 BDSG). In bestimmten Berei
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/ethics_committee_approval_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/ethics_committee_approval_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/sensitive-data-official_approval">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/sensitive-data-official_approval">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>sensitive-data-official_approval</key>
 		<path>all/legal-and-ethics/sensitive-data-official_approval</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics"/>
 		<is_collection>False</is_collection>
 		<order>51</order>
 		<title lang="en">Official approval</title>
@@ -3628,13 +3628,13 @@ Landesdatenschutzgesetz (genaue Abgrenzung siehe § 1 BDSG). In bestimmten Berei
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/sensitive-data-official_approval/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/sensitive-data-official_approval/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>all/legal-and-ethics/sensitive-data-official_approval/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/legal_aspects/official_approval/statutatory_approval/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/sensitive-data-official_approval"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/sensitive-data-official_approval"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -3652,17 +3652,17 @@ Landesdatenschutzgesetz (genaue Abgrenzung siehe § 1 BDSG). In bestimmten Berei
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/ethics_permit_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/ethics_permit_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/sensitive-data-official_approval/title">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/sensitive-data-official_approval/title">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>title</key>
 		<path>all/legal-and-ethics/sensitive-data-official_approval/title</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/legal_aspects/official_approval/statutatory_approval/title"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/sensitive-data-official_approval"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/sensitive-data-official_approval"/>
 		<is_collection>False</is_collection>
 		<order>3</order>
 		<help lang="en"/>
@@ -3682,13 +3682,13 @@ Landesdatenschutzgesetz (genaue Abgrenzung siehe § 1 BDSG). In bestimmten Berei
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/sensitive-data-official_approval/agency">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/sensitive-data-official_approval/agency">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>agency</key>
 		<path>all/legal-and-ethics/sensitive-data-official_approval/agency</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/legal_aspects/official_approval/statutatory_approval/agency"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/sensitive-data-official_approval"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/sensitive-data-official_approval"/>
 		<is_collection>False</is_collection>
 		<order>4</order>
 		<help lang="en"/>
@@ -3708,15 +3708,15 @@ Landesdatenschutzgesetz (genaue Abgrenzung siehe § 1 BDSG). In bestimmten Berei
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/sensitive-data-official_approval/status">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/sensitive-data-official_approval/status">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>status</key>
 		<path>all/legal-and-ethics/sensitive-data-official_approval/status</path>
 		<dc:comment>Aus der &quot;Handreichung zum Umgang mit Forschungsdaten&quot; des DFG-Fachkollegiums &quot;Alte Kulturen&quot;:
 
 Offene Fragen oder besondere Herausforderungen müssen ausdrücklich erläutert werden (z.B. welche Genehmigung steht noch aus? Gibt es ggf. Fristen oder weitere Bedingungen für die Erlaubniserteilung?).</dc:comment>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/legal_aspects/official_approval/statutatory_approval/status"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/sensitive-data-official_approval"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/sensitive-data-official_approval"/>
 		<is_collection>False</is_collection>
 		<order>5</order>
 		<help lang="en"/>
@@ -3736,13 +3736,13 @@ Offene Fragen oder besondere Herausforderungen müssen ausdrücklich erläutert 
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/data-access-committee">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/data-access-committee">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-access-committee</key>
 		<path>all/legal-and-ethics/data-access-committee</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics"/>
 		<is_collection>False</is_collection>
 		<order>55</order>
 		<title lang="en">Data access committee</title>
@@ -3755,13 +3755,13 @@ Offene Fragen oder besondere Herausforderungen müssen ausdrücklich erläutert 
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/data-access-committee/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/data-access-committee/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>all/legal-and-ethics/data-access-committee/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/legal_aspects/official_approval/data_access_committee"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/data-access-committee"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/data-access-committee"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<help lang="en"/>
@@ -3781,13 +3781,13 @@ Offene Fragen oder besondere Herausforderungen müssen ausdrücklich erläutert 
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/intellectual-property-rights-yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/intellectual-property-rights-yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>intellectual-property-rights-yesno</key>
 		<path>all/legal-and-ethics/intellectual-property-rights-yesno</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics"/>
 		<is_collection>False</is_collection>
 		<order>61</order>
 		<title lang="en">Intellectual property rights I</title>
@@ -3800,13 +3800,13 @@ Offene Fragen oder besondere Herausforderungen müssen ausdrücklich erläutert 
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/intellectual-property-rights-yesno/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/intellectual-property-rights-yesno/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>all/legal-and-ethics/intellectual-property-rights-yesno/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/legal_aspects/ipr/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/intellectual-property-rights-yesno"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/intellectual-property-rights-yesno"/>
 		<is_collection>False</is_collection>
 		<order>6</order>
 		<help lang="en">Data or software can be subject to intellectual or industrial property rights. Applicable laws differ broadly even within EU. According to the German copyright law (UrhG) works of literature, scholarship and the arts that can be regarded as a “personal intellectual creation” are protected by copyright. Copyright protection expires 70 years after the death of the copyright holder. Mere data, e.g. measured data or survey data, and metadata (except in some cases descriptive metadata) are not protected by copyright. § 2 of the UrhG lists the following kinds of protected works (list is not concluded): 
@@ -3854,13 +3854,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/intellectual-property-rights-dataset">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/intellectual-property-rights-dataset">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>intellectual-property-rights-dataset</key>
 		<path>all/legal-and-ethics/intellectual-property-rights-dataset</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics"/>
 		<is_collection>True</is_collection>
 		<order>62</order>
 		<title lang="en">Intellectual property rights II</title>
@@ -3872,16 +3872,16 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<verbose_name lang="de">Datensatz</verbose_name>
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/intellectual_property_rights"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/intellectual_property_rights"/>
 		</conditions>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/intellectual-property-rights-dataset/copyrights">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/intellectual-property-rights-dataset/copyrights">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>copyrights</key>
 		<path>all/legal-and-ethics/intellectual-property-rights-dataset/copyrights</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/ipr/copyrights"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/intellectual-property-rights-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/intellectual-property-rights-dataset"/>
 		<is_collection>True</is_collection>
 		<order>0</order>
 		<help lang="en"/>
@@ -3899,17 +3899,17 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_copyright_laws"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_copyright_laws"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/intellectual-property-rights-dataset/other_rights">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/intellectual-property-rights-dataset/other_rights">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>other_rights</key>
 		<path>all/legal-and-ethics/intellectual-property-rights-dataset/other_rights</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/ipr/other_rights"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/intellectual-property-rights-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/intellectual-property-rights-dataset"/>
 		<is_collection>True</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -3927,17 +3927,17 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_other_rights"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_other_rights"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/intellectual-property-rights-dataset/owner">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/intellectual-property-rights-dataset/owner">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>owner</key>
 		<path>all/legal-and-ethics/intellectual-property-rights-dataset/owner</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/ipr/owner/name"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/intellectual-property-rights-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/intellectual-property-rights-dataset"/>
 		<is_collection>False</is_collection>
 		<order>3</order>
 		<help lang="en"/>
@@ -3955,17 +3955,17 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/yes_with_text_no"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/yes_with_text_no"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/intellectual-property-rights-dataset/status">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/intellectual-property-rights-dataset/status">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>status</key>
 		<path>all/legal-and-ethics/intellectual-property-rights-dataset/status</path>
 		<dc:comment>In der Handreichung zum Umgang mit Forschungsdaten des DFG-Fachkollegiums 104, &quot;Informationen zu rechtlichen Aspekten bei der Handhabung von Sprachkorpora&quot;, https://www.dfg.de/download/pdf/foerderung/grundlagen_dfg_foerderung/informationen_fachwissenschaften/geisteswissenschaften/standards_recht.pdf, wird ausdrücklich auf einzelne Rechte des Urhebers und die Notwendigkeit diese Rechte einzuholen hingewiesen. Frage und Attribut wurden aufgenommen.</dc:comment>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/ipr/status"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/intellectual-property-rights-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/intellectual-property-rights-dataset"/>
 		<is_collection>False</is_collection>
 		<order>4</order>
 		<help lang="en"/>
@@ -3985,13 +3985,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/intellectual-property-rights-costs">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/intellectual-property-rights-costs">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>intellectual-property-rights-costs</key>
 		<path>all/legal-and-ethics/intellectual-property-rights-costs</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics"/>
 		<is_collection>False</is_collection>
 		<order>65</order>
 		<title lang="en">Intellectual property rights costs</title>
@@ -4003,16 +4003,16 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<verbose_name lang="de"/>
 		<verbose_name_plural lang="de"/>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/intellectual_property_rights"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/intellectual_property_rights"/>
 		</conditions>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/intellectual-property-rights-costs/personnel">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/intellectual-property-rights-costs/personnel">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>personnel</key>
 		<path>all/legal-and-ethics/intellectual-property-rights-costs/personnel</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/costs/ipr/personnel"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/intellectual-property-rights-costs"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/intellectual-property-rights-costs"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">Please estimate the effort in person months.</help>
@@ -4032,13 +4032,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/intellectual-property-rights-costs/non_personnel">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/intellectual-property-rights-costs/non_personnel">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>non_personnel</key>
 		<path>all/legal-and-ethics/intellectual-property-rights-costs/non_personnel</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/costs/ipr/non_personnel"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/legal-and-ethics/intellectual-property-rights-costs"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/legal-and-ethics/intellectual-property-rights-costs"/>
 		<is_collection>False</is_collection>
 		<order>3</order>
 		<help lang="en">Please estimate the costs in **Euro**.</help>
@@ -4058,23 +4058,23 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/storage-and-long-term-preservation">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/all/storage-and-long-term-preservation">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>storage-and-long-term-preservation</key>
 		<path>all/storage-and-long-term-preservation</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/all"/>
 		<order>10</order>
 		<title lang="en">Storage and long-term preservation</title>
 		<title lang="de">Speicherung und Langzeitarchivierung</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/storage-and-long-term-preservation/selection-criteria">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/storage-and-long-term-preservation/selection-criteria">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>selection-criteria</key>
 		<path>all/storage-and-long-term-preservation/selection-criteria</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/storage-and-long-term-preservation"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/all/storage-and-long-term-preservation"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<title lang="en">Selection</title>
@@ -4087,13 +4087,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/storage-and-long-term-preservation/selection-criteria/selection_criteria">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/storage-and-long-term-preservation/selection-criteria/selection_criteria">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>selection_criteria</key>
 		<path>all/storage-and-long-term-preservation/selection-criteria/selection_criteria</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/preservation/selection_criteria"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/storage-and-long-term-preservation/selection-criteria"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/storage-and-long-term-preservation/selection-criteria"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<help lang="en"/>
@@ -4113,13 +4113,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/storage-and-long-term-preservation/selection-criteria/responsible_person">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/storage-and-long-term-preservation/selection-criteria/responsible_person">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>responsible_person</key>
 		<path>all/storage-and-long-term-preservation/selection-criteria/responsible_person</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/preservation/responsible_person/name"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/storage-and-long-term-preservation/selection-criteria"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/storage-and-long-term-preservation/selection-criteria"/>
 		<is_collection>True</is_collection>
 		<order>1</order>
 		<help lang="en"/>
@@ -4139,13 +4139,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/storage-and-long-term-preservation/long-term-preservation-datasets">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/storage-and-long-term-preservation/long-term-preservation-datasets">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>long-term-preservation-datasets</key>
 		<path>all/storage-and-long-term-preservation/long-term-preservation-datasets</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/storage-and-long-term-preservation"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/all/storage-and-long-term-preservation"/>
 		<is_collection>True</is_collection>
 		<order>11</order>
 		<title lang="en">Long-term preservation</title>
@@ -4158,13 +4158,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/storage-and-long-term-preservation/long-term-preservation-datasets/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/storage-and-long-term-preservation/long-term-preservation-datasets/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>all/storage-and-long-term-preservation/long-term-preservation-datasets/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en"/>
@@ -4184,13 +4184,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/storage-and-long-term-preservation/long-term-preservation-datasets/purpose">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/storage-and-long-term-preservation/long-term-preservation-datasets/purpose">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>purpose</key>
 		<path>all/storage-and-long-term-preservation/long-term-preservation-datasets/purpose</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/purpose"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>True</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -4208,17 +4208,17 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/preservation_motivation_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/preservation_motivation_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/storage-and-long-term-preservation/long-term-preservation-datasets/duration">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/storage-and-long-term-preservation/long-term-preservation-datasets/duration">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>duration</key>
 		<path>all/storage-and-long-term-preservation/long-term-preservation-datasets/duration</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/duration"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>False</is_collection>
 		<order>3</order>
 		<help lang="en"/>
@@ -4238,13 +4238,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/storage-and-long-term-preservation/long-term-preservation-datasets/reuse_duration">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/storage-and-long-term-preservation/long-term-preservation-datasets/reuse_duration">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>reuse_duration</key>
 		<path>all/storage-and-long-term-preservation/long-term-preservation-datasets/reuse_duration</path>
 		<dc:comment>Original H2020 question</dc:comment>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/reuse_duration"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>False</is_collection>
 		<order>4</order>
 		<help lang="en"/>
@@ -4264,13 +4264,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/storage-and-long-term-preservation/long-term-preservation-datasets/repository">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/storage-and-long-term-preservation/long-term-preservation-datasets/repository">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>repository</key>
 		<path>all/storage-and-long-term-preservation/long-term-preservation-datasets/repository</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/repository"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>True</is_collection>
 		<order>5</order>
 		<help lang="en"/>
@@ -4288,17 +4288,17 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/preservation_repository_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/preservation_repository_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/storage-and-long-term-preservation/long-term-preservation-datasets/certification">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/storage-and-long-term-preservation/long-term-preservation-datasets/certification">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>certification</key>
 		<path>all/storage-and-long-term-preservation/long-term-preservation-datasets/certification</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/certification"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>False</is_collection>
 		<order>6</order>
 		<help lang="en"/>
@@ -4318,13 +4318,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/storage-and-long-term-preservation/long-term-preservation-datasets/repository_arrangements">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/storage-and-long-term-preservation/long-term-preservation-datasets/repository_arrangements">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>repository_arrangements</key>
 		<path>all/storage-and-long-term-preservation/long-term-preservation-datasets/repository_arrangements</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/repository_arrangements"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>False</is_collection>
 		<order>7</order>
 		<help lang="en">(original question from Horizon 2020 FAIR Data Management Plan)</help>
@@ -4344,13 +4344,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/storage-and-long-term-preservation/long-term-preservation-datasets/responsible">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/storage-and-long-term-preservation/long-term-preservation-datasets/responsible">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>responsible</key>
 		<path>all/storage-and-long-term-preservation/long-term-preservation-datasets/responsible</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/pids/responsible_person/name"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>False</is_collection>
 		<order>8</order>
 		<help lang="en"/>
@@ -4370,13 +4370,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/storage-and-long-term-preservation/long-term-preservation-datasets/embargo_period">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/storage-and-long-term-preservation/long-term-preservation-datasets/embargo_period">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>embargo_period</key>
 		<path>all/storage-and-long-term-preservation/long-term-preservation-datasets/embargo_period</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/embargo_period"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>False</is_collection>
 		<order>9</order>
 		<help lang="en"/>
@@ -4396,13 +4396,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/storage-and-long-term-preservation/long-term-preservation-datasets/access_authentication">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/storage-and-long-term-preservation/long-term-preservation-datasets/access_authentication">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>access_authentication</key>
 		<path>all/storage-and-long-term-preservation/long-term-preservation-datasets/access_authentication</path>
 		<dc:comment>Original from H2020 FAIR Data Management Plan</dc:comment>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/access_authentication"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>False</is_collection>
 		<order>10</order>
 		<help lang="en"/>
@@ -4422,13 +4422,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/storage-and-long-term-preservation/long-term-preservation-datasets/data_archiving_date">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/storage-and-long-term-preservation/long-term-preservation-datasets/data_archiving_date">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data_archiving_date</key>
 		<path>all/storage-and-long-term-preservation/long-term-preservation-datasets/data_archiving_date</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/data_archiving_date"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>False</is_collection>
 		<order>11</order>
 		<help lang="en"/>
@@ -4448,13 +4448,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/storage-and-long-term-preservation/long-term-preservation-costs">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/storage-and-long-term-preservation/long-term-preservation-costs">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>long-term-preservation-costs</key>
 		<path>all/storage-and-long-term-preservation/long-term-preservation-costs</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/storage-and-long-term-preservation"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/all/storage-and-long-term-preservation"/>
 		<is_collection>False</is_collection>
 		<order>13</order>
 		<title lang="en">Long-term preservation costs</title>
@@ -4467,13 +4467,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/storage-and-long-term-preservation/long-term-preservation-costs/personnel">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/storage-and-long-term-preservation/long-term-preservation-costs/personnel">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>personnel</key>
 		<path>all/storage-and-long-term-preservation/long-term-preservation-costs/personnel</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/costs/preservation/personnel"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/storage-and-long-term-preservation/long-term-preservation-costs"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/storage-and-long-term-preservation/long-term-preservation-costs"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">Please estimate the effort in person months.</help>
@@ -4493,13 +4493,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/storage-and-long-term-preservation/long-term-preservation-costs/non_personnel">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/storage-and-long-term-preservation/long-term-preservation-costs/non_personnel">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>non_personnel</key>
 		<path>all/storage-and-long-term-preservation/long-term-preservation-costs/non_personnel</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/costs/preservation/non_personnel"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/storage-and-long-term-preservation/long-term-preservation-costs"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/storage-and-long-term-preservation/long-term-preservation-costs"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en">Please estimate the costs in **Euro**.</help>
@@ -4519,13 +4519,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/storage-and-long-term-preservation/long-term-preservation-costs/cover_how">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/all/storage-and-long-term-preservation/long-term-preservation-costs/cover_how">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>cover_how</key>
 		<path>all/storage-and-long-term-preservation/long-term-preservation-costs/cover_how</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/costs/preservation/cover_how"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/all/storage-and-long-term-preservation/long-term-preservation-costs"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/all/storage-and-long-term-preservation/long-term-preservation-costs"/>
 		<is_collection>False</is_collection>
 		<order>10</order>
 		<help lang="en"/>

--- a/shared/fodako/biodiversity_dfg.xml
+++ b/shared/fodako/biodiversity_dfg.xml
@@ -1,30 +1,30 @@
 <?xml version="1.0" ?>
 <rdmo xmlns:dc="http://purl.org/dc/elements/1.1/">
-	<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<catalog dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>biodiversity_dfg</key>
 		<dc:comment/>
 		<order>290</order>
 		<title lang="en">DFG Biodiversity research</title>
 		<title lang="de">DFG Biodiversitätsforschung</title>
 	</catalog>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/general">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/general">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>general</key>
 		<path>biodiversity_dfg/general</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg"/>
 		<order>0</order>
 		<title lang="en">General</title>
 		<title lang="de">Allgemein</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/general/other-requirements-yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/general/other-requirements-yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>other-requirements-yesno</key>
 		<path>biodiversity_dfg/general/other-requirements-yesno</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/general"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/general"/>
 		<is_collection>False</is_collection>
 		<order>50</order>
 		<title lang="en">Requirements I</title>
@@ -37,13 +37,13 @@
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/general/other-requirements-yesno/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/general/other-requirements-yesno/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>biodiversity_dfg/general/other-requirements-yesno/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/additional_rdm_policy/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/general/other-requirements-yesno"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/general/other-requirements-yesno"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<help lang="en"/>
@@ -61,17 +61,17 @@
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/other_requirements_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/other_requirements_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/general/other-requirements-requirements">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/general/other-requirements-requirements">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>other-requirements-requirements</key>
 		<path>biodiversity_dfg/general/other-requirements-requirements</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/general"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/general"/>
 		<is_collection>False</is_collection>
 		<order>51</order>
 		<title lang="en">Requirements II</title>
@@ -83,16 +83,16 @@
 		<verbose_name lang="de"/>
 		<verbose_name_plural lang="de"/>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/additional_rdm_policy"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/additional_rdm_policy"/>
 		</conditions>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/general/other-requirements-requirements/requirements">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/general/other-requirements-requirements/requirements">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>requirements</key>
 		<path>biodiversity_dfg/general/other-requirements-requirements/requirements</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/additional_rdm_policy/requirements"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/general/other-requirements-requirements"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/general/other-requirements-requirements"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<help lang="en">Please briefly outline them and refer to more detailed sources of information if necessary. Please also indicate, if the rules / guidelines are mandatory or optional.</help>
@@ -112,13 +112,13 @@
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/general/support">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/general/support">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>support</key>
 		<path>biodiversity_dfg/general/support</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/general"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/general"/>
 		<is_collection>False</is_collection>
 		<order>61</order>
 		<title lang="en">Support</title>
@@ -131,13 +131,13 @@
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/general/support/datamanagement">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/general/support/datamanagement">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>datamanagement</key>
 		<path>biodiversity_dfg/general/support/datamanagement</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/support"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/general/support"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/general/support"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en"/>
@@ -157,23 +157,23 @@
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/content-classification">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/content-classification">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>content-classification</key>
 		<path>biodiversity_dfg/content-classification</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg"/>
 		<order>1</order>
 		<title lang="en">Content classification</title>
 		<title lang="de">Inhaltliche Einordnung</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/content-classification/data-dataset">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/content-classification/data-dataset">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-dataset</key>
 		<path>biodiversity_dfg/content-classification/data-dataset</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/content-classification"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/content-classification"/>
 		<is_collection>True</is_collection>
 		<order>1</order>
 		<title lang="en">Datasets</title>
@@ -186,13 +186,13 @@
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/content-classification/data-dataset/description">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/content-classification/data-dataset/description">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>description</key>
 		<path>biodiversity_dfg/content-classification/data-dataset/description</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/description"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/content-classification/data-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/content-classification/data-dataset"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">In the &lt;a href=&quot;http://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/guidelines_biodiversity_research.pdf&quot; target=_blank&gt;Guidelines on the Handling of Research Data in Biodiversity Research&lt;/a&gt;, &quot;kind (individual, tissue, etc.) and type of data (picture, audio, text, source code, numbers)&quot; are recommended.</help>
@@ -212,13 +212,13 @@
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/content-classification/data-reuse">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/content-classification/data-reuse">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-reuse</key>
 		<path>biodiversity_dfg/content-classification/data-reuse</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/content-classification"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/content-classification"/>
 		<is_collection>True</is_collection>
 		<order>3</order>
 		<title lang="en">Reuse</title>
@@ -231,13 +231,13 @@
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/content-classification/data-reuse/scenario">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/content-classification/data-reuse/scenario">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>scenario</key>
 		<path>biodiversity_dfg/content-classification/data-reuse/scenario</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/reuse_scenario"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/content-classification/data-reuse"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/content-classification/data-reuse"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">It is important to set the fundamental course as to whether or not the data will be permitted for reuse. Of course, the potential for subsequent use can not be the sole decision criterion, but legal impediments, such as privacy, copyright and business secrets must be taken into account. Otherwise, consider the re-use potential against the disadvantages, e.g. a decrease in the readiness to participate and the expected extra effort of a data publication.</help>
@@ -257,13 +257,13 @@
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/content-classification/data-reproducibility">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/content-classification/data-reproducibility">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-reproducibility</key>
 		<path>biodiversity_dfg/content-classification/data-reproducibility</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/content-classification"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/content-classification"/>
 		<is_collection>True</is_collection>
 		<order>4</order>
 		<title lang="en">Reproducibility</title>
@@ -276,13 +276,13 @@
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/content-classification/data-reproducibility/reproducibility">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/content-classification/data-reproducibility/reproducibility">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>reproducibility</key>
 		<path>biodiversity_dfg/content-classification/data-reproducibility/reproducibility</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/reproducibility"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/content-classification/data-reproducibility"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/content-classification/data-reproducibility"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en">Some data can, technically, be created anew at any time, as is the case with scientific experiments or digitised versions of analog objects (as long as the originals are still there and in good shape). However, this can consume a
@@ -307,27 +307,27 @@
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_reproducible_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_reproducible_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/technical-classification">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/technical-classification">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>technical-classification</key>
 		<path>biodiversity_dfg/technical-classification</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg"/>
 		<order>2</order>
 		<title lang="en">Technical classification</title>
 		<title lang="de">Technische Einordnung</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/technical-classification/data-formats">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/technical-classification/data-formats">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-formats</key>
 		<path>biodiversity_dfg/technical-classification/data-formats</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/technical-classification"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/technical-classification"/>
 		<is_collection>True</is_collection>
 		<order>3</order>
 		<title lang="en">Formats</title>
@@ -340,13 +340,13 @@
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/technical-classification/data-formats/format">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/technical-classification/data-formats/format">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>format</key>
 		<path>biodiversity_dfg/technical-classification/data-formats/format</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/format"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/technical-classification/data-formats"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/technical-classification/data-formats"/>
 		<is_collection>False</is_collection>
 		<order>4</order>
 		<help lang="en">When choosing a data format, one should consider the consequences for collaborative use, long-term preservation as well as re-use. It is advisable to prefer formats that are standardised, open, non-proprietary and well-established in the respective scholarly community. A table with recommended file formats can be found in Kristin Briney, &lt;i&gt;Data Management for Researchers&lt;/i&gt;, Pelargic, 2015, pages 133-134.</help>
@@ -366,23 +366,23 @@
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-usage</key>
 		<path>biodiversity_dfg/data-usage</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg"/>
 		<order>3</order>
 		<title lang="en">Data usage</title>
 		<title lang="de">Datennutzung</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage/data-tools">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage/data-tools">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-tools</key>
 		<path>biodiversity_dfg/data-usage/data-tools</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage"/>
 		<is_collection>True</is_collection>
 		<order>4</order>
 		<title lang="en">Tools</title>
@@ -395,13 +395,13 @@
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage/data-tools/creation_methods">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage/data-tools/creation_methods">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>creation_methods</key>
 		<path>biodiversity_dfg/data-usage/data-tools/creation_methods</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/creation_methods"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage/data-tools"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage/data-tools"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">This information is necessary to be able to reconstruct the process by which the data was generated. It is also a prerequisite to judge the objectivity, reliability and validity of the dataset. For reproducible data, it is also
@@ -423,13 +423,13 @@
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage/data-tools/usage_technology">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage/data-tools/usage_technology">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>usage_technology</key>
 		<path>biodiversity_dfg/data-usage/data-tools/usage_technology</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/usage_technology"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage/data-tools"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage/data-tools"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en">To be able to re-use data (e.g. to replicate studies, for meta analysis or to solve new research questions), along with the data the software, equipment and knowledge about special methods to use the data are required. Just as with
@@ -451,13 +451,13 @@
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage/data-tools/documentation">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage/data-tools/documentation">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>documentation</key>
 		<path>biodiversity_dfg/data-usage/data-tools/documentation</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/software_documentation"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage/data-tools"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage/data-tools"/>
 		<is_collection>False</is_collection>
 		<order>3</order>
 		<help lang="en"/>
@@ -477,13 +477,13 @@
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage/data-storage-and-security-storage">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage/data-storage-and-security-storage">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-storage-and-security-storage</key>
 		<path>biodiversity_dfg/data-usage/data-storage-and-security-storage</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage"/>
 		<is_collection>True</is_collection>
 		<order>11</order>
 		<title lang="en">Data organisation</title>
@@ -496,13 +496,13 @@
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage/data-storage-and-security-storage/type">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage/data-storage-and-security-storage/type">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>type</key>
 		<path>biodiversity_dfg/data-usage/data-storage-and-security-storage/type</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/storage/type"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage/data-storage-and-security-storage"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage/data-storage-and-security-storage"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">If parts of the documentation or related software (custom development) are not stored with the data, also indicate where they are stored. This applies to the documentation of the software too.</help>
@@ -522,13 +522,13 @@
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage/data-storage-and-security-storage/organisation_policy">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage/data-storage-and-security-storage/organisation_policy">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>organisation_policy</key>
 		<path>biodiversity_dfg/data-usage/data-storage-and-security-storage/organisation_policy</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/storage/organisation_policy"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage/data-storage-and-security-storage"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage/data-storage-and-security-storage"/>
 		<is_collection>False</is_collection>
 		<order>3</order>
 		<help lang="en"/>
@@ -546,17 +546,17 @@
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/yes_no_not_yet"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/yes_no_not_yet"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage/data-storage-and-security-storage/naming_policy">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage/data-storage-and-security-storage/naming_policy">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>naming_policy</key>
 		<path>biodiversity_dfg/data-usage/data-storage-and-security-storage/naming_policy</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/storage/naming_policy"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage/data-storage-and-security-storage"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage/data-storage-and-security-storage"/>
 		<is_collection>False</is_collection>
 		<order>4</order>
 		<help lang="en"/>
@@ -574,17 +574,17 @@
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/yes_no_not_yet"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/yes_no_not_yet"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage/data-storage-and-security-data_security">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage/data-storage-and-security-data_security">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-storage-and-security-data_security</key>
 		<path>biodiversity_dfg/data-usage/data-storage-and-security-data_security</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage"/>
 		<is_collection>True</is_collection>
 		<order>12</order>
 		<title lang="en">Data storage and security</title>
@@ -597,13 +597,13 @@
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage/data-storage-and-security-data_security/access_permissions">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage/data-storage-and-security-data_security/access_permissions">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>access_permissions</key>
 		<path>biodiversity_dfg/data-usage/data-storage-and-security-data_security/access_permissions</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/data_security/access_permissions"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage/data-storage-and-security-data_security"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage/data-storage-and-security-data_security"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en"/>
@@ -623,13 +623,13 @@
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage/data-storage-and-security-data_security/backups">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage/data-storage-and-security-data_security/backups">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>backups</key>
 		<path>biodiversity_dfg/data-usage/data-storage-and-security-data_security/backups</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/data_security/backups"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage/data-storage-and-security-data_security"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage/data-storage-and-security-data_security"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en">This question refers to backups while the data is being worked with. Questions of long-term preservation will be adressed in the respective section.</help>
@@ -649,13 +649,13 @@
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage/data-storage-and-security-data_security/security_measures">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage/data-storage-and-security-data_security/security_measures">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>security_measures</key>
 		<path>biodiversity_dfg/data-usage/data-storage-and-security-data_security/security_measures</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/data_security/security_measures"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage/data-storage-and-security-data_security"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage/data-storage-and-security-data_security"/>
 		<is_collection>False</is_collection>
 		<order>4</order>
 		<help lang="en"/>
@@ -675,13 +675,13 @@
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage/data-sharing-and-re-use-publication">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage/data-sharing-and-re-use-publication">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-sharing-and-re-use-publication</key>
 		<path>biodiversity_dfg/data-usage/data-sharing-and-re-use-publication</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage"/>
 		<is_collection>True</is_collection>
 		<order>52</order>
 		<title lang="en">Data sharing and re-use</title>
@@ -694,13 +694,13 @@
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage/data-sharing-and-re-use-publication/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage/data-sharing-and-re-use-publication/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>biodiversity_dfg/data-usage/data-sharing-and-re-use-publication/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sharing/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage/data-sharing-and-re-use-publication"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage/data-sharing-and-re-use-publication"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">From the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/guidelines_biodiversity_research.pdf&quot; target=_blank&gt;Guidelines on the Handling of Research Data in Biodiversity Research&lt;/a&gt;:
@@ -722,17 +722,17 @@ Die Ermöglichung des öffentlichen, kostenlosen Zugangs zu Daten, die aus DFG f
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_sharing_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_sharing_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage/data-sharing-and-re-use-publication/explanation">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage/data-sharing-and-re-use-publication/explanation">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>explanation</key>
 		<path>biodiversity_dfg/data-usage/data-sharing-and-re-use-publication/explanation</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sharing/explanation"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage/data-sharing-and-re-use-publication"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage/data-sharing-and-re-use-publication"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -752,13 +752,13 @@ Die Ermöglichung des öffentlichen, kostenlosen Zugangs zu Daten, die aus DFG f
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage/data-sharing-and-re-use-publication/conditions">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage/data-sharing-and-re-use-publication/conditions">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>conditions</key>
 		<path>biodiversity_dfg/data-usage/data-sharing-and-re-use-publication/conditions</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sharing/conditions"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage/data-sharing-and-re-use-publication"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage/data-sharing-and-re-use-publication"/>
 		<is_collection>True</is_collection>
 		<order>3</order>
 		<help lang="en">The options refer to the licenses of the &lt;a href=&quot;https://creativecommons.org/share-your-work/licensing-types-examples/&quot; target=_blank&quot;&gt;Creative Commons family&lt;/a&gt;. From the &lt;a href=&quot;http://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/guidelines_biodiversity_research.pdf&quot; target=_blank&gt;Guidelines on the Handling of Research Data in Biodiversity Research&lt;/a&gt;: Expected is information &quot;on which conditions re-use will be rendered possible and, if applicable, who will decide this in the long term&quot;.</help>
@@ -776,17 +776,17 @@ Die Ermöglichung des öffentlichen, kostenlosen Zugangs zu Daten, die aus DFG f
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_license_types"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_license_types"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage/data-sharing-and-re-use-publication/restrictions_explanation">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage/data-sharing-and-re-use-publication/restrictions_explanation">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>restrictions_explanation</key>
 		<path>biodiversity_dfg/data-usage/data-sharing-and-re-use-publication/restrictions_explanation</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sharing/restrictions_explanation"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage/data-sharing-and-re-use-publication"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage/data-sharing-and-re-use-publication"/>
 		<is_collection>False</is_collection>
 		<order>4</order>
 		<help lang="en"/>
@@ -806,13 +806,13 @@ Die Ermöglichung des öffentlichen, kostenlosen Zugangs zu Daten, die aus DFG f
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage/data-sharing-and-re-use-publication/data_publication_date">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage/data-sharing-and-re-use-publication/data_publication_date">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data_publication_date</key>
 		<path>biodiversity_dfg/data-usage/data-sharing-and-re-use-publication/data_publication_date</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/data_publication_date"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage/data-sharing-and-re-use-publication"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage/data-sharing-and-re-use-publication"/>
 		<is_collection>False</is_collection>
 		<order>6</order>
 		<help lang="en"/>
@@ -831,16 +831,16 @@ Die Ermöglichung des öffentlichen, kostenlosen Zugangs zu Daten, die aus DFG f
 		<unit/>
 		<optionsets/>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/data_sharing"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/data_sharing"/>
 		</conditions>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage/quality-assurance-dataset">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage/quality-assurance-dataset">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>quality-assurance-dataset</key>
 		<path>biodiversity_dfg/data-usage/quality-assurance-dataset</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage"/>
 		<is_collection>True</is_collection>
 		<order>61</order>
 		<title lang="en">Quality assurance</title>
@@ -853,13 +853,13 @@ Die Ermöglichung des öffentlichen, kostenlosen Zugangs zu Daten, die aus DFG f
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage/quality-assurance-dataset/measures">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage/quality-assurance-dataset/measures">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>measures</key>
 		<path>biodiversity_dfg/data-usage/quality-assurance-dataset/measures</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/quality_assurance"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage/quality-assurance-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage/quality-assurance-dataset"/>
 		<is_collection>False</is_collection>
 		<order>7</order>
 		<help lang="en"/>
@@ -879,13 +879,13 @@ Die Ermöglichung des öffentlichen, kostenlosen Zugangs zu Daten, die aus DFG f
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage/costs-dataset">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage/costs-dataset">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>costs-dataset</key>
 		<path>biodiversity_dfg/data-usage/costs-dataset</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage"/>
 		<is_collection>False</is_collection>
 		<order>70</order>
 		<title lang="en">Costs</title>
@@ -898,13 +898,13 @@ Die Ermöglichung des öffentlichen, kostenlosen Zugangs zu Daten, die aus DFG f
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage/costs-dataset/creation_personnel">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage/costs-dataset/creation_personnel">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>creation_personnel</key>
 		<path>biodiversity_dfg/data-usage/costs-dataset/creation_personnel</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/costs/creation/personnel"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage/costs-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage/costs-dataset"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">Please estimate the effort in person months.</help>
@@ -924,13 +924,13 @@ Die Ermöglichung des öffentlichen, kostenlosen Zugangs zu Daten, die aus DFG f
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage/costs-dataset/creation_non_personnel">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage/costs-dataset/creation_non_personnel">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>creation_non_personnel</key>
 		<path>biodiversity_dfg/data-usage/costs-dataset/creation_non_personnel</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/costs/creation/non_personnel"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage/costs-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage/costs-dataset"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en">Please estimate the effort in **Euro**.</help>
@@ -949,16 +949,16 @@ Die Ermöglichung des öffentlichen, kostenlosen Zugangs zu Daten, die aus DFG f
 		<unit>Euro</unit>
 		<optionsets/>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/additional_rdm_policy"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/additional_rdm_policy"/>
 		</conditions>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage/costs-dataset/usage_personnel">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage/costs-dataset/usage_personnel">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>usage_personnel</key>
 		<path>biodiversity_dfg/data-usage/costs-dataset/usage_personnel</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/costs/usage/personnel"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage/costs-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage/costs-dataset"/>
 		<is_collection>False</is_collection>
 		<order>3</order>
 		<help lang="en">Please estimate the effort in person months.</help>
@@ -978,13 +978,13 @@ Die Ermöglichung des öffentlichen, kostenlosen Zugangs zu Daten, die aus DFG f
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage/costs-dataset/usage_non_personnel">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage/costs-dataset/usage_non_personnel">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>usage_non_personnel</key>
 		<path>biodiversity_dfg/data-usage/costs-dataset/usage_non_personnel</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/costs/usage/non_personnel"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage/costs-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage/costs-dataset"/>
 		<is_collection>False</is_collection>
 		<order>4</order>
 		<help lang="en">Please estimate the costs in **Euro**.</help>
@@ -1004,13 +1004,13 @@ Die Ermöglichung des öffentlichen, kostenlosen Zugangs zu Daten, die aus DFG f
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage/costs-dataset/storage_personnel">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage/costs-dataset/storage_personnel">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>storage_personnel</key>
 		<path>biodiversity_dfg/data-usage/costs-dataset/storage_personnel</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/costs/storage/personnel"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage/costs-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage/costs-dataset"/>
 		<is_collection>False</is_collection>
 		<order>5</order>
 		<help lang="en">Please estimate the effort in person months.</help>
@@ -1030,13 +1030,13 @@ Die Ermöglichung des öffentlichen, kostenlosen Zugangs zu Daten, die aus DFG f
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage/costs-dataset/storage_non_personnel">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage/costs-dataset/storage_non_personnel">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>storage_non_personnel</key>
 		<path>biodiversity_dfg/data-usage/costs-dataset/storage_non_personnel</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/costs/storage/non_personnel"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/data-usage/costs-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/data-usage/costs-dataset"/>
 		<is_collection>False</is_collection>
 		<order>6</order>
 		<help lang="en">Please estimate the costs in **Euro**.</help>
@@ -1056,23 +1056,23 @@ Die Ermöglichung des öffentlichen, kostenlosen Zugangs zu Daten, die aus DFG f
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/doc">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/doc">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>doc</key>
 		<path>biodiversity_dfg/doc</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg"/>
 		<order>4</order>
 		<title lang="en">Documentation</title>
 		<title lang="de">Dokumentation</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/doc/metadata-dataset">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/doc/metadata-dataset">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>metadata-dataset</key>
 		<path>biodiversity_dfg/doc/metadata-dataset</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/doc"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/doc"/>
 		<is_collection>True</is_collection>
 		<order>10</order>
 		<title lang="en">Metadata and data documentation</title>
@@ -1085,13 +1085,13 @@ Die Ermöglichung des öffentlichen, kostenlosen Zugangs zu Daten, die aus DFG f
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/doc/metadata-dataset/standards">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/doc/metadata-dataset/standards">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>standards</key>
 		<path>biodiversity_dfg/doc/metadata-dataset/standards</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/metadata/standards"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/doc/metadata-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/doc/metadata-dataset"/>
 		<is_collection>True</is_collection>
 		<order>1</order>
 		<help lang="en">Also specify the metadata standard if it is already clear which one to use, e.g. because the repository specifies one.</help>
@@ -1109,17 +1109,17 @@ Die Ermöglichung des öffentlichen, kostenlosen Zugangs zu Daten, die aus DFG f
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/metadata_standards"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/metadata_standards"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/doc/metadata-dataset/documentation">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/doc/metadata-dataset/documentation">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>documentation</key>
 		<path>biodiversity_dfg/doc/metadata-dataset/documentation</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/documentation"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/doc/metadata-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/doc/metadata-dataset"/>
 		<is_collection>False</is_collection>
 		<order>4</order>
 		<help lang="en">Context of the investigations, methods used, etc.</help>
@@ -1139,13 +1139,13 @@ Die Ermöglichung des öffentlichen, kostenlosen Zugangs zu Daten, die aus DFG f
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/doc/metadata-costs">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/doc/metadata-costs">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>metadata-costs</key>
 		<path>biodiversity_dfg/doc/metadata-costs</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/doc"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/doc"/>
 		<is_collection>False</is_collection>
 		<order>12</order>
 		<title lang="en">Documentation costs</title>
@@ -1158,13 +1158,13 @@ Die Ermöglichung des öffentlichen, kostenlosen Zugangs zu Daten, die aus DFG f
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/doc/metadata-costs/personnel">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/doc/metadata-costs/personnel">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>personnel</key>
 		<path>biodiversity_dfg/doc/metadata-costs/personnel</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/costs/metadata/personnel"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/doc/metadata-costs"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/doc/metadata-costs"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">Please estimate the effort in person months.</help>
@@ -1184,13 +1184,13 @@ Die Ermöglichung des öffentlichen, kostenlosen Zugangs zu Daten, die aus DFG f
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/doc/metadata-costs/non_personnel">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/doc/metadata-costs/non_personnel">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>non_personnel</key>
 		<path>biodiversity_dfg/doc/metadata-costs/non_personnel</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/costs/metadata/non_personnel"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/doc/metadata-costs"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/doc/metadata-costs"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en">Please estimate the costs in **Euro**.</help>
@@ -1210,23 +1210,23 @@ Die Ermöglichung des öffentlichen, kostenlosen Zugangs zu Daten, die aus DFG f
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/referencing">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/referencing">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>referencing</key>
 		<path>biodiversity_dfg/referencing</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg"/>
 		<order>5</order>
 		<title lang="en">Referencing</title>
 		<title lang="de">Referenzierung</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/referencing/structure-granularity-and-referencing-structure">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/referencing/structure-granularity-and-referencing-structure">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>structure-granularity-and-referencing-structure</key>
 		<path>biodiversity_dfg/referencing/structure-granularity-and-referencing-structure</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/referencing"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/referencing"/>
 		<is_collection>True</is_collection>
 		<order>20</order>
 		<title lang="en">Structure, granularity, and referencing</title>
@@ -1239,13 +1239,13 @@ Die Ermöglichung des öffentlichen, kostenlosen Zugangs zu Daten, die aus DFG f
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/referencing/structure-granularity-and-referencing-structure/structure">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/referencing/structure-granularity-and-referencing-structure/structure">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>structure</key>
 		<path>biodiversity_dfg/referencing/structure-granularity-and-referencing-structure/structure</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/structure"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/referencing/structure-granularity-and-referencing-structure"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/referencing/structure-granularity-and-referencing-structure"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<help lang="en">According to the &lt;a href=&quot;http://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/guidelines_biodiversity_research.pdf&quot; target=_blank&gt;Guidelines on the Handling of Research Data in Biodiversity Research&lt;/a&gt; information concerning &quot;the connection to research objects (e.g. voucher specimen or soil samples) and other referenced data&quot; is expected.</help>
@@ -1265,13 +1265,13 @@ Die Ermöglichung des öffentlichen, kostenlosen Zugangs zu Daten, die aus DFG f
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/referencing/structure-granularity-and-referencing-pids">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/referencing/structure-granularity-and-referencing-pids">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>structure-granularity-and-referencing-pids</key>
 		<path>biodiversity_dfg/referencing/structure-granularity-and-referencing-pids</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/referencing"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/referencing"/>
 		<is_collection>True</is_collection>
 		<order>21</order>
 		<title lang="en">Persistent Identifiers (PIDs)</title>
@@ -1284,13 +1284,13 @@ Die Ermöglichung des öffentlichen, kostenlosen Zugangs zu Daten, die aus DFG f
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/referencing/structure-granularity-and-referencing-pids/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/referencing/structure-granularity-and-referencing-pids/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>biodiversity_dfg/referencing/structure-granularity-and-referencing-pids/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/pids/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/referencing/structure-granularity-and-referencing-pids"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/referencing/structure-granularity-and-referencing-pids"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<help lang="en"/>
@@ -1310,13 +1310,13 @@ Die Ermöglichung des öffentlichen, kostenlosen Zugangs zu Daten, die aus DFG f
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/referencing/structure-granularity-and-referencing-costs">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/referencing/structure-granularity-and-referencing-costs">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>structure-granularity-and-referencing-costs</key>
 		<path>biodiversity_dfg/referencing/structure-granularity-and-referencing-costs</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/referencing"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/referencing"/>
 		<is_collection>False</is_collection>
 		<order>23</order>
 		<title lang="en">PIDs costs</title>
@@ -1329,13 +1329,13 @@ Die Ermöglichung des öffentlichen, kostenlosen Zugangs zu Daten, die aus DFG f
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/referencing/structure-granularity-and-referencing-costs/personnel">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/referencing/structure-granularity-and-referencing-costs/personnel">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>personnel</key>
 		<path>biodiversity_dfg/referencing/structure-granularity-and-referencing-costs/personnel</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/costs/pid/personnel"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/referencing/structure-granularity-and-referencing-costs"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/referencing/structure-granularity-and-referencing-costs"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">Please estimate the effort in person months.</help>
@@ -1355,13 +1355,13 @@ Die Ermöglichung des öffentlichen, kostenlosen Zugangs zu Daten, die aus DFG f
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/referencing/structure-granularity-and-referencing-costs/non_personnel">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/referencing/structure-granularity-and-referencing-costs/non_personnel">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>non_personnel</key>
 		<path>biodiversity_dfg/referencing/structure-granularity-and-referencing-costs/non_personnel</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/costs/pid/non_personnel"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/referencing/structure-granularity-and-referencing-costs"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/referencing/structure-granularity-and-referencing-costs"/>
 		<is_collection>False</is_collection>
 		<order>3</order>
 		<help lang="en">Please estimate the costs in Euro.</help>
@@ -1381,23 +1381,23 @@ Die Ermöglichung des öffentlichen, kostenlosen Zugangs zu Daten, die aus DFG f
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/legal-and-ethics">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/legal-and-ethics">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>legal-and-ethics</key>
 		<path>biodiversity_dfg/legal-and-ethics</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg"/>
 		<order>6</order>
 		<title lang="en">Legal and ethics</title>
 		<title lang="de">Rechtliche und ethische Fragen</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/legal-and-ethics/sensitive-data-personal_data_yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/legal-and-ethics/sensitive-data-personal_data_yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>sensitive-data-personal_data_yesno</key>
 		<path>biodiversity_dfg/legal-and-ethics/sensitive-data-personal_data_yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/legal-and-ethics"/>
 		<is_collection>True</is_collection>
 		<order>21</order>
 		<title lang="en">Personal data</title>
@@ -1410,13 +1410,13 @@ Die Ermöglichung des öffentlichen, kostenlosen Zugangs zu Daten, die aus DFG f
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/legal-and-ethics/sensitive-data-personal_data_yesno/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/legal-and-ethics/sensitive-data-personal_data_yesno/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>biodiversity_dfg/legal-and-ethics/sensitive-data-personal_data_yesno/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sensitive_data/personal_data_yesno/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/legal-and-ethics/sensitive-data-personal_data_yesno"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/legal-and-ethics/sensitive-data-personal_data_yesno"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">The EU General Data Protection Regulation (GDPR) defines in Art. 4 personal data as &quot;any information relating to an identified or identifiable natural person&quot;. An identifiable natural person is &quot;one who can be identified, directly or indirectly, in particular by reference to an identifier such as a name, an identification number, location data, an online identifier or to one or more factors specific to the physical, physiological, genetic, mental, economic, cultural or social identity of that natural person&quot;.</help>
@@ -1436,13 +1436,13 @@ Die Ermöglichung des öffentlichen, kostenlosen Zugangs zu Daten, die aus DFG f
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/legal-and-ethics/sensitive-data-personal_data">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/legal-and-ethics/sensitive-data-personal_data">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>sensitive-data-personal_data</key>
 		<path>biodiversity_dfg/legal-and-ethics/sensitive-data-personal_data</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/legal-and-ethics"/>
 		<is_collection>True</is_collection>
 		<order>24</order>
 		<title lang="en">Sensitive data</title>
@@ -1454,16 +1454,16 @@ Die Ermöglichung des öffentlichen, kostenlosen Zugangs zu Daten, die aus DFG f
 		<verbose_name lang="de">Datensatz</verbose_name>
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/personal_data"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/personal_data"/>
 		</conditions>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/legal-and-ethics/sensitive-data-personal_data/anonymization">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/legal-and-ethics/sensitive-data-personal_data/anonymization">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>anonymization</key>
 		<path>biodiversity_dfg/legal-and-ethics/sensitive-data-personal_data/anonymization</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sensitive_data/personal_data/anonymization"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/legal-and-ethics/sensitive-data-personal_data"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/legal-and-ethics/sensitive-data-personal_data"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -1481,17 +1481,17 @@ Die Ermöglichung des öffentlichen, kostenlosen Zugangs zu Daten, die aus DFG f
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_anonymisation"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_anonymisation"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/legal-and-ethics/intellectual-property-rights-yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/legal-and-ethics/intellectual-property-rights-yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>intellectual-property-rights-yesno</key>
 		<path>biodiversity_dfg/legal-and-ethics/intellectual-property-rights-yesno</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/legal-and-ethics"/>
 		<is_collection>False</is_collection>
 		<order>30</order>
 		<title lang="en">Intellectual property rights I</title>
@@ -1504,13 +1504,13 @@ Die Ermöglichung des öffentlichen, kostenlosen Zugangs zu Daten, die aus DFG f
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/legal-and-ethics/intellectual-property-rights-yesno/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/legal-and-ethics/intellectual-property-rights-yesno/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>biodiversity_dfg/legal-and-ethics/intellectual-property-rights-yesno/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/legal_aspects/ipr/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/legal-and-ethics/intellectual-property-rights-yesno"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/legal-and-ethics/intellectual-property-rights-yesno"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<help lang="en">Data or software can be subject to intellectual or industrial property rights. Applicable laws differ broadly even within EU. According to the German copyright law (UrhG) works of literature, scholarship and the arts that can be regarded as a “personal intellectual creation” are protected by copyright. Copyright protection expires 70 years after the death of the copyright holder. Mere data, e.g. measured data or survey data, and metadata (except in some cases descriptive metadata) are not protected by copyright. § 2 of the UrhG lists the following kinds of protected works (list is not concluded): 
@@ -1558,13 +1558,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/legal-and-ethics/intellectual-property-rights-dataset">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/legal-and-ethics/intellectual-property-rights-dataset">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>intellectual-property-rights-dataset</key>
 		<path>biodiversity_dfg/legal-and-ethics/intellectual-property-rights-dataset</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/legal-and-ethics"/>
 		<is_collection>True</is_collection>
 		<order>31</order>
 		<title lang="en">Intellectual property rights II</title>
@@ -1576,16 +1576,16 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<verbose_name lang="de">Datensatz</verbose_name>
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/intellectual_property_rights"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/intellectual_property_rights"/>
 		</conditions>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/legal-and-ethics/intellectual-property-rights-dataset/copyrights">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/legal-and-ethics/intellectual-property-rights-dataset/copyrights">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>copyrights</key>
 		<path>biodiversity_dfg/legal-and-ethics/intellectual-property-rights-dataset/copyrights</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/ipr/copyrights"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
 		<is_collection>True</is_collection>
 		<order>0</order>
 		<help lang="en"/>
@@ -1603,17 +1603,17 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_copyright_laws"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_copyright_laws"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/legal-and-ethics/intellectual-property-rights-dataset/other_rights">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/legal-and-ethics/intellectual-property-rights-dataset/other_rights">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>other_rights</key>
 		<path>biodiversity_dfg/legal-and-ethics/intellectual-property-rights-dataset/other_rights</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/ipr/other_rights"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
 		<is_collection>True</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -1631,17 +1631,17 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_other_rights"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_other_rights"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/legal-and-ethics/intellectual-property-rights-costs">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/legal-and-ethics/intellectual-property-rights-costs">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>intellectual-property-rights-costs</key>
 		<path>biodiversity_dfg/legal-and-ethics/intellectual-property-rights-costs</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/legal-and-ethics"/>
 		<is_collection>False</is_collection>
 		<order>65</order>
 		<title lang="en">Intellectual property rights costs</title>
@@ -1653,16 +1653,16 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<verbose_name lang="de"/>
 		<verbose_name_plural lang="de"/>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/intellectual_property_rights"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/intellectual_property_rights"/>
 		</conditions>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/legal-and-ethics/intellectual-property-rights-costs/personnel">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/legal-and-ethics/intellectual-property-rights-costs/personnel">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>personnel</key>
 		<path>biodiversity_dfg/legal-and-ethics/intellectual-property-rights-costs/personnel</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/costs/ipr/personnel"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/legal-and-ethics/intellectual-property-rights-costs"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/legal-and-ethics/intellectual-property-rights-costs"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">Please estimate the effort in person months.</help>
@@ -1682,13 +1682,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/legal-and-ethics/intellectual-property-rights-costs/non_personnel">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/legal-and-ethics/intellectual-property-rights-costs/non_personnel">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>non_personnel</key>
 		<path>biodiversity_dfg/legal-and-ethics/intellectual-property-rights-costs/non_personnel</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/costs/ipr/non_personnel"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/legal-and-ethics/intellectual-property-rights-costs"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/legal-and-ethics/intellectual-property-rights-costs"/>
 		<is_collection>False</is_collection>
 		<order>3</order>
 		<help lang="en">Please estimate the costs in **Euro**.</help>
@@ -1708,23 +1708,23 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/storage-and-long-term-preservation">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/storage-and-long-term-preservation">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>storage-and-long-term-preservation</key>
 		<path>biodiversity_dfg/storage-and-long-term-preservation</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg"/>
 		<order>10</order>
 		<title lang="en">Storage and long-term preservation</title>
 		<title lang="de">Speicherung und Langzeitarchivierung</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/storage-and-long-term-preservation/long-term-preservation-datasets">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/storage-and-long-term-preservation/long-term-preservation-datasets">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>long-term-preservation-datasets</key>
 		<path>biodiversity_dfg/storage-and-long-term-preservation/long-term-preservation-datasets</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/storage-and-long-term-preservation"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/storage-and-long-term-preservation"/>
 		<is_collection>True</is_collection>
 		<order>11</order>
 		<title lang="en">Long-term preservation</title>
@@ -1737,13 +1737,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>biodiversity_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en"/>
@@ -1763,13 +1763,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/purpose">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/purpose">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>purpose</key>
 		<path>biodiversity_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/purpose</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/purpose"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>True</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -1787,17 +1787,17 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/preservation_motivation_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/preservation_motivation_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/duration">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/duration">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>duration</key>
 		<path>biodiversity_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/duration</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/duration"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>False</is_collection>
 		<order>3</order>
 		<help lang="en"/>
@@ -1817,13 +1817,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/repository">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/repository">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>repository</key>
 		<path>biodiversity_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/repository</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/repository"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>True</is_collection>
 		<order>5</order>
 		<help lang="en"/>
@@ -1841,17 +1841,17 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/preservation_repository_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/preservation_repository_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/storage-and-long-term-preservation/long-term-preservation-costs">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/storage-and-long-term-preservation/long-term-preservation-costs">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>long-term-preservation-costs</key>
 		<path>biodiversity_dfg/storage-and-long-term-preservation/long-term-preservation-costs</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/storage-and-long-term-preservation"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/storage-and-long-term-preservation"/>
 		<is_collection>False</is_collection>
 		<order>13</order>
 		<title lang="en">Long-term preservation costs</title>
@@ -1864,13 +1864,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/storage-and-long-term-preservation/long-term-preservation-costs/personnel">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/storage-and-long-term-preservation/long-term-preservation-costs/personnel">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>personnel</key>
 		<path>biodiversity_dfg/storage-and-long-term-preservation/long-term-preservation-costs/personnel</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/costs/preservation/personnel"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/storage-and-long-term-preservation/long-term-preservation-costs"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/storage-and-long-term-preservation/long-term-preservation-costs"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">Please estimate the effort in person months.</help>
@@ -1890,13 +1890,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/storage-and-long-term-preservation/long-term-preservation-costs/non_personnel">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/storage-and-long-term-preservation/long-term-preservation-costs/non_personnel">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>non_personnel</key>
 		<path>biodiversity_dfg/storage-and-long-term-preservation/long-term-preservation-costs/non_personnel</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/costs/preservation/non_personnel"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/storage-and-long-term-preservation/long-term-preservation-costs"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/storage-and-long-term-preservation/long-term-preservation-costs"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en">Please estimate the costs in **Euro**.</help>
@@ -1916,13 +1916,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/storage-and-long-term-preservation/long-term-preservation-costs/cover_how">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/storage-and-long-term-preservation/long-term-preservation-costs/cover_how">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>cover_how</key>
 		<path>biodiversity_dfg/storage-and-long-term-preservation/long-term-preservation-costs/cover_how</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/costs/preservation/cover_how"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/biodiversity_dfg/storage-and-long-term-preservation/long-term-preservation-costs"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/biodiversity_dfg/storage-and-long-term-preservation/long-term-preservation-costs"/>
 		<is_collection>False</is_collection>
 		<order>10</order>
 		<help lang="en"/>

--- a/shared/fodako/dfg.xml
+++ b/shared/fodako/dfg.xml
@@ -1,30 +1,30 @@
 <?xml version="1.0" ?>
 <rdmo xmlns:dc="http://purl.org/dc/elements/1.1/">
-	<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<catalog dc:uri="https://rdmo.fodako.nrw/questions/dfg">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>dfg</key>
 		<dc:comment>Dieser Fragenkatalog ist eine Teilmenge des Katalogs &quot;RDMO&quot; und enthält nur die Fragen, die die Anforderungen in den &quot;Leitlinien zum Umgang mit Forschungsdaten&quot; der DFG, http://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten, abdecken. Die Fragen sind somit ausgesucht für Datenmanagementpläne, die Förderanträgen an die Deutsche Forschungsgemeinschaft (DFG) beigelegt werden sollen und keine fachspezifischen Zusatzanforderungen zu erfüllen haben.</dc:comment>
 		<order>500</order>
 		<title lang="en">DFG</title>
 		<title lang="de">DFG</title>
 	</catalog>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/general">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/dfg/general">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>general</key>
 		<path>dfg/general</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/dfg"/>
 		<order>0</order>
 		<title lang="en">General</title>
 		<title lang="de">Allgemein</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/general/other-requirements-yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/dfg/general/other-requirements-yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>other-requirements-yesno</key>
 		<path>dfg/general/other-requirements-yesno</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/general"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/dfg/general"/>
 		<is_collection>False</is_collection>
 		<order>50</order>
 		<title lang="en">Requirements I</title>
@@ -37,13 +37,13 @@
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/general/other-requirements-yesno/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/dfg/general/other-requirements-yesno/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>dfg/general/other-requirements-yesno/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/additional_rdm_policy/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/general/other-requirements-yesno"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/dfg/general/other-requirements-yesno"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<help lang="en">Examples of discipline-specific requirements are: 
@@ -78,17 +78,17 @@
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/other_requirements_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/other_requirements_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/general/other-requirements-requirements">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/dfg/general/other-requirements-requirements">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>other-requirements-requirements</key>
 		<path>dfg/general/other-requirements-requirements</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/general"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/dfg/general"/>
 		<is_collection>False</is_collection>
 		<order>51</order>
 		<title lang="en">Requirements II</title>
@@ -100,16 +100,16 @@
 		<verbose_name lang="de"/>
 		<verbose_name_plural lang="de"/>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/additional_rdm_policy"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/additional_rdm_policy"/>
 		</conditions>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/general/other-requirements-requirements/requirements">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/dfg/general/other-requirements-requirements/requirements">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>requirements</key>
 		<path>dfg/general/other-requirements-requirements/requirements</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/additional_rdm_policy/requirements"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/general/other-requirements-requirements"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/dfg/general/other-requirements-requirements"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<help lang="en">Please briefly outline them and refer to more detailed sources of information if necessary. Please also indicate, if the rules / guidelines are mandatory or optional.</help>
@@ -129,23 +129,23 @@
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/content-classification">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/dfg/content-classification">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>content-classification</key>
 		<path>dfg/content-classification</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/dfg"/>
 		<order>1</order>
 		<title lang="en">Content classification</title>
 		<title lang="de">Inhaltliche Einordnung</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/content-classification/data-dataset">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/dfg/content-classification/data-dataset">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-dataset</key>
 		<path>dfg/content-classification/data-dataset</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/content-classification"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/dfg/content-classification"/>
 		<is_collection>True</is_collection>
 		<order>1</order>
 		<title lang="en">Datasets</title>
@@ -158,13 +158,13 @@
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/content-classification/data-dataset/description">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/dfg/content-classification/data-dataset/description">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>description</key>
 		<path>dfg/content-classification/data-dataset/description</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/description"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/content-classification/data-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/dfg/content-classification/data-dataset"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">Please briefly describe the data type and / or the method used to create or collect the data, for example: 
@@ -196,13 +196,13 @@
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/content-classification/data-reuse">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/dfg/content-classification/data-reuse">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-reuse</key>
 		<path>dfg/content-classification/data-reuse</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/content-classification"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/dfg/content-classification"/>
 		<is_collection>True</is_collection>
 		<order>3</order>
 		<title lang="en">Reuse</title>
@@ -215,13 +215,13 @@
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/content-classification/data-reuse/scenario">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/dfg/content-classification/data-reuse/scenario">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>scenario</key>
 		<path>dfg/content-classification/data-reuse/scenario</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/reuse_scenario"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/content-classification/data-reuse"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/dfg/content-classification/data-reuse"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">It is important to set the fundamental course as to whether or not the data will be permitted for reuse. Of course, the potential for subsequent use can not be the sole decision criterion, but legal impediments, such as privacy, copyright and business secrets must be taken into account. Otherwise, consider the re-use potential against the disadvantages, e.g. a decrease in the readiness to participate and the expected extra effort of a data publication.</help>
@@ -241,23 +241,23 @@
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/technical-classification">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/dfg/technical-classification">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>technical-classification</key>
 		<path>dfg/technical-classification</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/dfg"/>
 		<order>2</order>
 		<title lang="en">Technical classification</title>
 		<title lang="de">Technische Einordnung</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/technical-classification/data-formats">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/dfg/technical-classification/data-formats">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-formats</key>
 		<path>dfg/technical-classification/data-formats</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/technical-classification"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/dfg/technical-classification"/>
 		<is_collection>True</is_collection>
 		<order>3</order>
 		<title lang="en">Formats</title>
@@ -270,13 +270,13 @@
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/technical-classification/data-formats/format">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/dfg/technical-classification/data-formats/format">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>format</key>
 		<path>dfg/technical-classification/data-formats/format</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/format"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/technical-classification/data-formats"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/dfg/technical-classification/data-formats"/>
 		<is_collection>False</is_collection>
 		<order>4</order>
 		<help lang="en">When choosing a data format, one should consider the consequences for collaborative use, long-term preservation as well as re-use. It is advisable to prefer formats that are standardised, open, non-proprietary and well-established in the respective scholarly community. A table with recommended file formats can be found in Kristin Briney, &lt;i&gt;Data Management for Researchers&lt;/i&gt;, Pelargic, 2015, pages 133-134.</help>
@@ -296,23 +296,23 @@
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/data-usage">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/dfg/data-usage">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-usage</key>
 		<path>dfg/data-usage</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/dfg"/>
 		<order>3</order>
 		<title lang="en">Data usage</title>
 		<title lang="de">Datennutzung</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/data-usage/data-storage-and-security-storage">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/dfg/data-usage/data-storage-and-security-storage">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-storage-and-security-storage</key>
 		<path>dfg/data-usage/data-storage-and-security-storage</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/data-usage"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/dfg/data-usage"/>
 		<is_collection>True</is_collection>
 		<order>11</order>
 		<title lang="en">Data organisation</title>
@@ -325,13 +325,13 @@
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/data-usage/data-storage-and-security-storage/type">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/dfg/data-usage/data-storage-and-security-storage/type">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>type</key>
 		<path>dfg/data-usage/data-storage-and-security-storage/type</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/storage/type"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/data-usage/data-storage-and-security-storage"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/dfg/data-usage/data-storage-and-security-storage"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">If parts of the documentation or related software (custom development) are not stored with the data, also indicate where they are stored. This applies to the documentation of the software too.</help>
@@ -351,13 +351,13 @@
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/data-usage/data-sharing-and-re-use-publication">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/dfg/data-usage/data-sharing-and-re-use-publication">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-sharing-and-re-use-publication</key>
 		<path>dfg/data-usage/data-sharing-and-re-use-publication</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/data-usage"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/dfg/data-usage"/>
 		<is_collection>True</is_collection>
 		<order>52</order>
 		<title lang="en">Data sharing and re-use</title>
@@ -370,13 +370,13 @@
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/data-usage/data-sharing-and-re-use-publication/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/dfg/data-usage/data-sharing-and-re-use-publication/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>dfg/data-usage/data-sharing-and-re-use-publication/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sharing/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/data-usage/data-sharing-and-re-use-publication"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/dfg/data-usage/data-sharing-and-re-use-publication"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en"/>
@@ -394,17 +394,17 @@
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_sharing_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_sharing_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/data-usage/data-sharing-and-re-use-publication/explanation">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/dfg/data-usage/data-sharing-and-re-use-publication/explanation">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>explanation</key>
 		<path>dfg/data-usage/data-sharing-and-re-use-publication/explanation</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sharing/explanation"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/data-usage/data-sharing-and-re-use-publication"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/dfg/data-usage/data-sharing-and-re-use-publication"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -424,13 +424,13 @@
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/data-usage/data-sharing-and-re-use-publication/conditions">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/dfg/data-usage/data-sharing-and-re-use-publication/conditions">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>conditions</key>
 		<path>dfg/data-usage/data-sharing-and-re-use-publication/conditions</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sharing/conditions"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/data-usage/data-sharing-and-re-use-publication"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/dfg/data-usage/data-sharing-and-re-use-publication"/>
 		<is_collection>True</is_collection>
 		<order>3</order>
 		<help lang="en">The options refer to the licenses of the &lt;a href=&quot;https://creativecommons.org/share-your-work/licensing-types-examples/&quot; target=_blank&quot;&gt;Creative Commons family&lt;/a&gt;.</help>
@@ -448,17 +448,17 @@
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_license_types"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_license_types"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/data-usage/data-sharing-and-re-use-publication/data_publication_date">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/dfg/data-usage/data-sharing-and-re-use-publication/data_publication_date">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data_publication_date</key>
 		<path>dfg/data-usage/data-sharing-and-re-use-publication/data_publication_date</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/data_publication_date"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/data-usage/data-sharing-and-re-use-publication"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/dfg/data-usage/data-sharing-and-re-use-publication"/>
 		<is_collection>False</is_collection>
 		<order>6</order>
 		<help lang="en"/>
@@ -477,16 +477,16 @@
 		<unit/>
 		<optionsets/>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/data_sharing"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/data_sharing"/>
 		</conditions>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/data-usage/quality-assurance-dataset">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/dfg/data-usage/quality-assurance-dataset">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>quality-assurance-dataset</key>
 		<path>dfg/data-usage/quality-assurance-dataset</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/data-usage"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/dfg/data-usage"/>
 		<is_collection>True</is_collection>
 		<order>61</order>
 		<title lang="en">Quality assurance</title>
@@ -499,13 +499,13 @@
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/data-usage/quality-assurance-dataset/measures">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/dfg/data-usage/quality-assurance-dataset/measures">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>measures</key>
 		<path>dfg/data-usage/quality-assurance-dataset/measures</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/quality_assurance"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/data-usage/quality-assurance-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/dfg/data-usage/quality-assurance-dataset"/>
 		<is_collection>False</is_collection>
 		<order>7</order>
 		<help lang="en"/>
@@ -525,23 +525,23 @@
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/legal-and-ethics">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/dfg/legal-and-ethics">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>legal-and-ethics</key>
 		<path>dfg/legal-and-ethics</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/dfg"/>
 		<order>5</order>
 		<title lang="en">Legal and ethics</title>
 		<title lang="de">Rechtliche und ethische Fragen</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/legal-and-ethics/sensitive-data-personal_data_yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/dfg/legal-and-ethics/sensitive-data-personal_data_yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>sensitive-data-personal_data_yesno</key>
 		<path>dfg/legal-and-ethics/sensitive-data-personal_data_yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/dfg/legal-and-ethics"/>
 		<is_collection>True</is_collection>
 		<order>21</order>
 		<title lang="en">Personal data</title>
@@ -554,13 +554,13 @@
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/legal-and-ethics/sensitive-data-personal_data_yesno/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/dfg/legal-and-ethics/sensitive-data-personal_data_yesno/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>dfg/legal-and-ethics/sensitive-data-personal_data_yesno/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sensitive_data/personal_data_yesno/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/legal-and-ethics/sensitive-data-personal_data_yesno"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/dfg/legal-and-ethics/sensitive-data-personal_data_yesno"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">The EU General Data Protection Regulation (GDPR) defines in Art. 4 personal data as &quot;any information relating to an identified or identifiable natural person&quot;. An identifiable natural person is &quot;one who can be identified, directly or indirectly, in particular by reference to an identifier such as a name, an identification number, location data, an online identifier or to one or more factors specific to the physical, physiological, genetic, mental, economic, cultural or social identity of that natural person&quot;.</help>
@@ -580,13 +580,13 @@
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/legal-and-ethics/sensitive-data-personal_data">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/dfg/legal-and-ethics/sensitive-data-personal_data">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>sensitive-data-personal_data</key>
 		<path>dfg/legal-and-ethics/sensitive-data-personal_data</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/dfg/legal-and-ethics"/>
 		<is_collection>True</is_collection>
 		<order>24</order>
 		<title lang="en">Sensitive data</title>
@@ -598,16 +598,16 @@
 		<verbose_name lang="de">Datensatz</verbose_name>
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/personal_data"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/personal_data"/>
 		</conditions>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/legal-and-ethics/sensitive-data-personal_data/anonymization">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/dfg/legal-and-ethics/sensitive-data-personal_data/anonymization">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>anonymization</key>
 		<path>dfg/legal-and-ethics/sensitive-data-personal_data/anonymization</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sensitive_data/personal_data/anonymization"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/legal-and-ethics/sensitive-data-personal_data"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/dfg/legal-and-ethics/sensitive-data-personal_data"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -625,17 +625,17 @@
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_anonymisation"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_anonymisation"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/legal-and-ethics/intellectual-property-rights-yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/dfg/legal-and-ethics/intellectual-property-rights-yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>intellectual-property-rights-yesno</key>
 		<path>dfg/legal-and-ethics/intellectual-property-rights-yesno</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/dfg/legal-and-ethics"/>
 		<is_collection>False</is_collection>
 		<order>30</order>
 		<title lang="en">Intellectual property rights I</title>
@@ -648,13 +648,13 @@
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/legal-and-ethics/intellectual-property-rights-yesno/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/dfg/legal-and-ethics/intellectual-property-rights-yesno/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>dfg/legal-and-ethics/intellectual-property-rights-yesno/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/legal_aspects/ipr/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/legal-and-ethics/intellectual-property-rights-yesno"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/dfg/legal-and-ethics/intellectual-property-rights-yesno"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<help lang="en">Data or software can be subject to intellectual or industrial property rights. Applicable laws differ broadly even within EU. According to the German copyright law (UrhG) works of literature, scholarship and the arts that can be regarded as a “personal intellectual creation” are protected by copyright. Copyright protection expires 70 years after the death of the copyright holder. Mere data, e.g. measured data or survey data, and metadata (except in some cases descriptive metadata) are not protected by copyright. § 2 of the UrhG lists the following kinds of protected works (list is not concluded): 
@@ -702,13 +702,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/legal-and-ethics/intellectual-property-rights-dataset">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/dfg/legal-and-ethics/intellectual-property-rights-dataset">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>intellectual-property-rights-dataset</key>
 		<path>dfg/legal-and-ethics/intellectual-property-rights-dataset</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/dfg/legal-and-ethics"/>
 		<is_collection>True</is_collection>
 		<order>31</order>
 		<title lang="en">Intellectual property rights II</title>
@@ -720,16 +720,16 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<verbose_name lang="de">Datensatz</verbose_name>
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/intellectual_property_rights"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/intellectual_property_rights"/>
 		</conditions>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/legal-and-ethics/intellectual-property-rights-dataset/copyrights">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/dfg/legal-and-ethics/intellectual-property-rights-dataset/copyrights">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>copyrights</key>
 		<path>dfg/legal-and-ethics/intellectual-property-rights-dataset/copyrights</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/ipr/copyrights"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
 		<is_collection>True</is_collection>
 		<order>0</order>
 		<help lang="en"/>
@@ -747,17 +747,17 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_copyright_laws"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_copyright_laws"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/legal-and-ethics/intellectual-property-rights-dataset/other_rights">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/dfg/legal-and-ethics/intellectual-property-rights-dataset/other_rights">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>other_rights</key>
 		<path>dfg/legal-and-ethics/intellectual-property-rights-dataset/other_rights</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/ipr/other_rights"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
 		<is_collection>True</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -775,27 +775,27 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_other_rights"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_other_rights"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/storage-and-long-term-preservation">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/dfg/storage-and-long-term-preservation">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>storage-and-long-term-preservation</key>
 		<path>dfg/storage-and-long-term-preservation</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/dfg"/>
 		<order>10</order>
 		<title lang="en">Storage and long-term preservation</title>
 		<title lang="de">Speicherung und Langzeitarchivierung</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/storage-and-long-term-preservation/long-term-preservation-datasets">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/dfg/storage-and-long-term-preservation/long-term-preservation-datasets">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>long-term-preservation-datasets</key>
 		<path>dfg/storage-and-long-term-preservation/long-term-preservation-datasets</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/storage-and-long-term-preservation"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/dfg/storage-and-long-term-preservation"/>
 		<is_collection>True</is_collection>
 		<order>11</order>
 		<title lang="en">Long-term preservation</title>
@@ -808,13 +808,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/storage-and-long-term-preservation/long-term-preservation-datasets/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/dfg/storage-and-long-term-preservation/long-term-preservation-datasets/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>dfg/storage-and-long-term-preservation/long-term-preservation-datasets/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en"/>
@@ -834,13 +834,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/storage-and-long-term-preservation/long-term-preservation-datasets/purpose">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/dfg/storage-and-long-term-preservation/long-term-preservation-datasets/purpose">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>purpose</key>
 		<path>dfg/storage-and-long-term-preservation/long-term-preservation-datasets/purpose</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/purpose"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>True</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -858,17 +858,17 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/preservation_motivation_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/preservation_motivation_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/storage-and-long-term-preservation/long-term-preservation-datasets/duration">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/dfg/storage-and-long-term-preservation/long-term-preservation-datasets/duration">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>duration</key>
 		<path>dfg/storage-and-long-term-preservation/long-term-preservation-datasets/duration</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/duration"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>False</is_collection>
 		<order>3</order>
 		<help lang="en"/>
@@ -888,13 +888,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/storage-and-long-term-preservation/long-term-preservation-datasets/repository">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/dfg/storage-and-long-term-preservation/long-term-preservation-datasets/repository">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>repository</key>
 		<path>dfg/storage-and-long-term-preservation/long-term-preservation-datasets/repository</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/repository"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>True</is_collection>
 		<order>5</order>
 		<help lang="en"/>
@@ -912,7 +912,7 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/preservation_repository_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/preservation_repository_options"/>
 		</optionsets>
 		<conditions/>
 	</question>

--- a/shared/fodako/economics_dfg.xml
+++ b/shared/fodako/economics_dfg.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <rdmo xmlns:dc="http://purl.org/dc/elements/1.1/">
-	<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<catalog dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>economics_dfg</key>
 		<dc:comment>Dieser Fragenkatalog ist eine Teilmenge des Katalogs &quot;RDMO&quot; und enthält nur die Fragen, die die Anforderungen
 
@@ -16,23 +16,23 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<title lang="en">DFG 112 Economics</title>
 		<title lang="de">DFG 112 Wirtschaftswiss.</title>
 	</catalog>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/general">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/general">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>general</key>
 		<path>economics_dfg/general</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg"/>
 		<order>0</order>
 		<title lang="en">General</title>
 		<title lang="de">Allgemein</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/general/other-requirements-yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/general/other-requirements-yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>other-requirements-yesno</key>
 		<path>economics_dfg/general/other-requirements-yesno</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/general"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/general"/>
 		<is_collection>False</is_collection>
 		<order>50</order>
 		<title lang="en">Requirements I</title>
@@ -45,13 +45,13 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/general/other-requirements-yesno/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/general/other-requirements-yesno/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>economics_dfg/general/other-requirements-yesno/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/additional_rdm_policy/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/general/other-requirements-yesno"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/general/other-requirements-yesno"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<help lang="en">This catalog contains only the questions that the requirements
@@ -89,17 +89,17 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/other_requirements_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/other_requirements_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/general/other-requirements-requirements">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/general/other-requirements-requirements">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>other-requirements-requirements</key>
 		<path>economics_dfg/general/other-requirements-requirements</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/general"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/general"/>
 		<is_collection>False</is_collection>
 		<order>51</order>
 		<title lang="en">Requirements II</title>
@@ -111,16 +111,16 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<verbose_name lang="de"/>
 		<verbose_name_plural lang="de"/>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/additional_rdm_policy"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/additional_rdm_policy"/>
 		</conditions>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/general/other-requirements-requirements/requirements">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/general/other-requirements-requirements/requirements">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>requirements</key>
 		<path>economics_dfg/general/other-requirements-requirements/requirements</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/additional_rdm_policy/requirements"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/general/other-requirements-requirements"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/general/other-requirements-requirements"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<help lang="en">Please briefly outline them and refer to more detailed sources of information if necessary.</help>
@@ -140,23 +140,23 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/content-classification">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/content-classification">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>content-classification</key>
 		<path>economics_dfg/content-classification</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg"/>
 		<order>1</order>
 		<title lang="en">Content classification</title>
 		<title lang="de">Inhaltliche Einordnung</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/content-classification/data-dataset">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/content-classification/data-dataset">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-dataset</key>
 		<path>economics_dfg/content-classification/data-dataset</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/content-classification"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/content-classification"/>
 		<is_collection>True</is_collection>
 		<order>1</order>
 		<title lang="en">Datasets</title>
@@ -169,13 +169,13 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/content-classification/data-dataset/description">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/content-classification/data-dataset/description">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>description</key>
 		<path>economics_dfg/content-classification/data-dataset/description</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/description"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/content-classification/data-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/content-classification/data-dataset"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">Please briefly describe the data type and / or the method used to create or collect the data, for example: 
@@ -207,13 +207,13 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/content-classification/data-existing_data">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/content-classification/data-existing_data">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-existing_data</key>
 		<path>economics_dfg/content-classification/data-existing_data</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/content-classification"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/content-classification"/>
 		<is_collection>True</is_collection>
 		<order>2</order>
 		<title lang="en">Data origin</title>
@@ -226,13 +226,13 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/content-classification/data-existing_data/origin">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/content-classification/data-existing_data/origin">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>origin</key>
 		<path>economics_dfg/content-classification/data-existing_data/origin</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/origin"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/content-classification/data-existing_data"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/content-classification/data-existing_data"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en"/>
@@ -250,17 +250,17 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_origin_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_origin_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/content-classification/data-existing_data/creator_name">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/content-classification/data-existing_data/creator_name">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>creator_name</key>
 		<path>economics_dfg/content-classification/data-existing_data/creator_name</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/creator/name"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/content-classification/data-existing_data"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/content-classification/data-existing_data"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -280,13 +280,13 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/content-classification/data-existing_data/uri">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/content-classification/data-existing_data/uri">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>uri</key>
 		<path>economics_dfg/content-classification/data-existing_data/uri</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/uri"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/content-classification/data-existing_data"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/content-classification/data-existing_data"/>
 		<is_collection>False</is_collection>
 		<order>3</order>
 		<help lang="en"/>
@@ -306,13 +306,13 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/content-classification/data-reuse">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/content-classification/data-reuse">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-reuse</key>
 		<path>economics_dfg/content-classification/data-reuse</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/content-classification"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/content-classification"/>
 		<is_collection>True</is_collection>
 		<order>3</order>
 		<title lang="en">Reuse</title>
@@ -325,13 +325,13 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/content-classification/data-reuse/scenario">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/content-classification/data-reuse/scenario">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>scenario</key>
 		<path>economics_dfg/content-classification/data-reuse/scenario</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/reuse_scenario"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/content-classification/data-reuse"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/content-classification/data-reuse"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">It is particularly important to set the fundamental course among which of the six variants in the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/basisinformationen_forschungsdatenmanagement.pdf&quot; target=_blank&gt;Basic Information on Research Data Management&lt;/a&gt; (in German) of the RatSWD, the dataset will fall. Therefore, at this point, it is best to indicate which variant you want to follow and justify this. Of course, the re-use potential can not be the sole decision criterion, but legal impediments, such as privacy, copyright and business secrets must be taken into account. Otherwise, weigh the re-use potential against the disadvantages, e.g. a decrease in the readiness to participate and the expected extra effort of a data publication.</help>
@@ -351,23 +351,23 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/technical-classification">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/technical-classification">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>technical-classification</key>
 		<path>economics_dfg/technical-classification</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg"/>
 		<order>2</order>
 		<title lang="en">Technical classification</title>
 		<title lang="de">Technische Einordnung</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/technical-classification/data-formats">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/technical-classification/data-formats">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-formats</key>
 		<path>economics_dfg/technical-classification/data-formats</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/technical-classification"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/technical-classification"/>
 		<is_collection>True</is_collection>
 		<order>3</order>
 		<title lang="en">Formats</title>
@@ -380,13 +380,13 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/technical-classification/data-formats/format">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/technical-classification/data-formats/format">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>format</key>
 		<path>economics_dfg/technical-classification/data-formats/format</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/format"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/technical-classification/data-formats"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/technical-classification/data-formats"/>
 		<is_collection>False</is_collection>
 		<order>4</order>
 		<help lang="en">When choosing a data format, one should consider the consequences for collaborative use, long-term preservation as well as re-use. It is advisable to prefer formats that are standardised, open, non-proprietary and well-established in the respective scholarly community. A table with recommended file formats can be found in Kristin Briney, &lt;i&gt;Data Management for Researchers&lt;/i&gt;, Pelargic, 2015, pages 133-134.</help>
@@ -406,13 +406,13 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/technical-classification/data-tools">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/technical-classification/data-tools">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-tools</key>
 		<path>economics_dfg/technical-classification/data-tools</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/technical-classification"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/technical-classification"/>
 		<is_collection>True</is_collection>
 		<order>4</order>
 		<title lang="en">Tools</title>
@@ -425,13 +425,13 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/technical-classification/data-tools/creation_methods">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/technical-classification/data-tools/creation_methods">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>creation_methods</key>
 		<path>economics_dfg/technical-classification/data-tools/creation_methods</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/creation_methods"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/technical-classification/data-tools"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/technical-classification/data-tools"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">This information is necessary to be able to reconstruct the process by which the data was generated. It is also a prerequisite to judge the objectivity, reliability and validity of the dataset. For reproducible data, it is also required to re-generate the data if need be.</help>
@@ -451,13 +451,13 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/technical-classification/data-tools/usage_technology">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/technical-classification/data-tools/usage_technology">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>usage_technology</key>
 		<path>economics_dfg/technical-classification/data-tools/usage_technology</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/usage_technology"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/technical-classification/data-tools"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/technical-classification/data-tools"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en">To be able to re-use data (e.g. to replicate studies, for meta analysis or to solve new research questions), along with the data the software, equipment and knowledge about special methods to use the data are required. Just as with
@@ -479,13 +479,13 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/technical-classification/data-tools/documentation">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/technical-classification/data-tools/documentation">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>documentation</key>
 		<path>economics_dfg/technical-classification/data-tools/documentation</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/software_documentation"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/technical-classification/data-tools"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/technical-classification/data-tools"/>
 		<is_collection>False</is_collection>
 		<order>3</order>
 		<help lang="en"/>
@@ -505,23 +505,23 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/data-usage">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/data-usage">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-usage</key>
 		<path>economics_dfg/data-usage</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg"/>
 		<order>3</order>
 		<title lang="en">Data usage</title>
 		<title lang="de">Datennutzung</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/data-usage/data-storage-and-security-storage">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/data-usage/data-storage-and-security-storage">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-storage-and-security-storage</key>
 		<path>economics_dfg/data-usage/data-storage-and-security-storage</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/data-usage"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/data-usage"/>
 		<is_collection>True</is_collection>
 		<order>11</order>
 		<title lang="en">Data organisation</title>
@@ -534,13 +534,13 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/data-usage/data-storage-and-security-storage/type">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/data-usage/data-storage-and-security-storage/type">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>type</key>
 		<path>economics_dfg/data-usage/data-storage-and-security-storage/type</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/storage/type"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/data-usage/data-storage-and-security-storage"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/data-usage/data-storage-and-security-storage"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">If parts of the documentation or related software (custom development) are not stored with the data, also indicate where they are stored. This applies to the documentation of the software too.</help>
@@ -560,13 +560,13 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/data-usage/data-storage-and-security-data_security">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/data-usage/data-storage-and-security-data_security">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-storage-and-security-data_security</key>
 		<path>economics_dfg/data-usage/data-storage-and-security-data_security</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/data-usage"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/data-usage"/>
 		<is_collection>True</is_collection>
 		<order>12</order>
 		<title lang="en">Data storage and security</title>
@@ -579,13 +579,13 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/data-usage/data-storage-and-security-data_security/access_permissions">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/data-usage/data-storage-and-security-data_security/access_permissions">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>access_permissions</key>
 		<path>economics_dfg/data-usage/data-storage-and-security-data_security/access_permissions</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/data_security/access_permissions"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/data-usage/data-storage-and-security-data_security"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/data-usage/data-storage-and-security-data_security"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en"/>
@@ -605,13 +605,13 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/data-usage/data-storage-and-security-data_security/backups">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/data-usage/data-storage-and-security-data_security/backups">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>backups</key>
 		<path>economics_dfg/data-usage/data-storage-and-security-data_security/backups</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/data_security/backups"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/data-usage/data-storage-and-security-data_security"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/data-usage/data-storage-and-security-data_security"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en">This question refers to backups while the data is being worked with. Questions of long-term preservation will be adressed in the respective section.</help>
@@ -631,13 +631,13 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/data-usage/data-storage-and-security-data_security/security_measures">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/data-usage/data-storage-and-security-data_security/security_measures">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>security_measures</key>
 		<path>economics_dfg/data-usage/data-storage-and-security-data_security/security_measures</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/data_security/security_measures"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/data-usage/data-storage-and-security-data_security"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/data-usage/data-storage-and-security-data_security"/>
 		<is_collection>False</is_collection>
 		<order>4</order>
 		<help lang="en"/>
@@ -657,13 +657,13 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/data-usage/data-sharing-and-re-use-publication">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/data-usage/data-sharing-and-re-use-publication">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-sharing-and-re-use-publication</key>
 		<path>economics_dfg/data-usage/data-sharing-and-re-use-publication</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/data-usage"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/data-usage"/>
 		<is_collection>True</is_collection>
 		<order>52</order>
 		<title lang="en">Data sharing and re-use</title>
@@ -676,13 +676,13 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/data-usage/data-sharing-and-re-use-publication/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/data-usage/data-sharing-and-re-use-publication/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>economics_dfg/data-usage/data-sharing-and-re-use-publication/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sharing/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/data-usage/data-sharing-and-re-use-publication"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/data-usage/data-sharing-and-re-use-publication"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en"/>
@@ -700,17 +700,17 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_sharing_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_sharing_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/data-usage/data-sharing-and-re-use-publication/explanation">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/data-usage/data-sharing-and-re-use-publication/explanation">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>explanation</key>
 		<path>economics_dfg/data-usage/data-sharing-and-re-use-publication/explanation</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sharing/explanation"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/data-usage/data-sharing-and-re-use-publication"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/data-usage/data-sharing-and-re-use-publication"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -730,13 +730,13 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/data-usage/data-sharing-and-re-use-publication/conditions">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/data-usage/data-sharing-and-re-use-publication/conditions">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>conditions</key>
 		<path>economics_dfg/data-usage/data-sharing-and-re-use-publication/conditions</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sharing/conditions"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/data-usage/data-sharing-and-re-use-publication"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/data-usage/data-sharing-and-re-use-publication"/>
 		<is_collection>True</is_collection>
 		<order>3</order>
 		<help lang="en">The options refer to the licenses of the &lt;a href=&quot;https://creativecommons.org/share-your-work/licensing-types-examples/&quot; target=_blank&quot;&gt;Creative Commons family&lt;/a&gt;.</help>
@@ -754,17 +754,17 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_license_types"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_license_types"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/data-usage/data-sharing-and-re-use-publication/data_publication_date">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/data-usage/data-sharing-and-re-use-publication/data_publication_date">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data_publication_date</key>
 		<path>economics_dfg/data-usage/data-sharing-and-re-use-publication/data_publication_date</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/data_publication_date"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/data-usage/data-sharing-and-re-use-publication"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/data-usage/data-sharing-and-re-use-publication"/>
 		<is_collection>False</is_collection>
 		<order>6</order>
 		<help lang="en"/>
@@ -783,16 +783,16 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<unit/>
 		<optionsets/>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/data_sharing"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/data_sharing"/>
 		</conditions>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/data-usage/quality-assurance-dataset">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/data-usage/quality-assurance-dataset">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>quality-assurance-dataset</key>
 		<path>economics_dfg/data-usage/quality-assurance-dataset</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/data-usage"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/data-usage"/>
 		<is_collection>True</is_collection>
 		<order>61</order>
 		<title lang="en">Quality assurance</title>
@@ -805,13 +805,13 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/data-usage/quality-assurance-dataset/measures">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/data-usage/quality-assurance-dataset/measures">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>measures</key>
 		<path>economics_dfg/data-usage/quality-assurance-dataset/measures</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/quality_assurance"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/data-usage/quality-assurance-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/data-usage/quality-assurance-dataset"/>
 		<is_collection>False</is_collection>
 		<order>7</order>
 		<help lang="en"/>
@@ -831,23 +831,23 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/doc">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/doc">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>doc</key>
 		<path>economics_dfg/doc</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg"/>
 		<order>4</order>
 		<title lang="en">Documentation</title>
 		<title lang="de">Dokumentation</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/doc/general">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/doc/general">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>general</key>
 		<path>economics_dfg/doc/general</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/doc"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/doc"/>
 		<is_collection>True</is_collection>
 		<order>10</order>
 		<title lang="en">Metadata and data documentation</title>
@@ -860,13 +860,13 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/doc/general/scope">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/doc/general/scope">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>scope</key>
 		<path>economics_dfg/doc/general/scope</path>
 		<dc:comment>probably we should introduce a separate question for being findable and re-used</dc:comment>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/metadata/scope"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/doc/general"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/doc/general"/>
 		<is_collection>True</is_collection>
 		<order>0</order>
 		<help lang="en"/>
@@ -884,17 +884,17 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/mandatory_metadata_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/mandatory_metadata_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/doc/general/standards">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/doc/general/standards">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>standards</key>
 		<path>economics_dfg/doc/general/standards</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/metadata/standards"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/doc/general"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/doc/general"/>
 		<is_collection>True</is_collection>
 		<order>1</order>
 		<help lang="en">Also specify the metadata standard if it is already clear which one to use, e.g. because the repository specifies one.</help>
@@ -912,17 +912,17 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/metadata_standards"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/metadata_standards"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/doc/general/documentation">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/doc/general/documentation">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>documentation</key>
 		<path>economics_dfg/doc/general/documentation</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/documentation"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/doc/general"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/doc/general"/>
 		<is_collection>False</is_collection>
 		<order>3</order>
 		<help lang="en">In this field, enter the components of the data documentation that are available with the data set and are not only supplied on request in the context of good scientific practice later.</help>
@@ -942,13 +942,13 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/doc/general/documentation_where">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/doc/general/documentation_where">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>documentation_where</key>
 		<path>economics_dfg/doc/general/documentation_where</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/documentation/where"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/doc/general"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/doc/general"/>
 		<is_collection>False</is_collection>
 		<order>4</order>
 		<help lang="en">The &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/fachkollegium112_forschungsdatenmanagement_1811.pdf&quot; target=_blank&gt;DFG Review Board 112&lt;/a&gt; expects a meaningful description of the data sets that should be stored either in the journals themselves or in repositories (at universities, research institutes or at central specialized information centers).</help>
@@ -968,13 +968,13 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/doc/general/quality_assurance">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/doc/general/quality_assurance">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>quality_assurance</key>
 		<path>economics_dfg/doc/general/quality_assurance</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/metadata/quality_assurance"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/doc/general"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/doc/general"/>
 		<is_collection>True</is_collection>
 		<order>6</order>
 		<help lang="en"/>
@@ -992,27 +992,27 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/metadata_check_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/metadata_check_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/legal-and-ethics">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/legal-and-ethics">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>legal-and-ethics</key>
 		<path>economics_dfg/legal-and-ethics</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg"/>
 		<order>5</order>
 		<title lang="en">Legal and ethics</title>
 		<title lang="de">Rechtliche und ethische Fragen</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/legal-and-ethics/sensitive-data-personal_data_yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/legal-and-ethics/sensitive-data-personal_data_yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>sensitive-data-personal_data_yesno</key>
 		<path>economics_dfg/legal-and-ethics/sensitive-data-personal_data_yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/legal-and-ethics"/>
 		<is_collection>True</is_collection>
 		<order>21</order>
 		<title lang="en">Personal data</title>
@@ -1025,13 +1025,13 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/legal-and-ethics/sensitive-data-personal_data_yesno/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/legal-and-ethics/sensitive-data-personal_data_yesno/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>economics_dfg/legal-and-ethics/sensitive-data-personal_data_yesno/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sensitive_data/personal_data_yesno/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/legal-and-ethics/sensitive-data-personal_data_yesno"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/legal-and-ethics/sensitive-data-personal_data_yesno"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">The EU General Data Protection Regulation (GDPR) defines in Art. 4 personal data as &quot;any information relating to an identified or identifiable natural person&quot;. An identifiable natural person is &quot;one who can be identified, directly or indirectly, in particular by reference to an identifier such as a name, an identification number, location data, an online identifier or to one or more factors specific to the physical, physiological, genetic, mental, economic, cultural or social identity of that natural person&quot;.</help>
@@ -1051,13 +1051,13 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/legal-and-ethics/sensitive-data-personal_data">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/legal-and-ethics/sensitive-data-personal_data">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>sensitive-data-personal_data</key>
 		<path>economics_dfg/legal-and-ethics/sensitive-data-personal_data</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/legal-and-ethics"/>
 		<is_collection>True</is_collection>
 		<order>24</order>
 		<title lang="en">Sensitive data</title>
@@ -1069,16 +1069,16 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<verbose_name lang="de">Datensatz</verbose_name>
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/personal_data"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/personal_data"/>
 		</conditions>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/legal-and-ethics/sensitive-data-personal_data/anonymization">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/legal-and-ethics/sensitive-data-personal_data/anonymization">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>anonymization</key>
 		<path>economics_dfg/legal-and-ethics/sensitive-data-personal_data/anonymization</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sensitive_data/personal_data/anonymization"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/legal-and-ethics/sensitive-data-personal_data"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/legal-and-ethics/sensitive-data-personal_data"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -1096,17 +1096,17 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_anonymisation"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_anonymisation"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/legal-and-ethics/sensitive-data-personal_data/extent">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/legal-and-ethics/sensitive-data-personal_data/extent">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>extent</key>
 		<path>economics_dfg/legal-and-ethics/sensitive-data-personal_data/extent</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sensitive_data/personal_data/consent/extent"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/legal-and-ethics/sensitive-data-personal_data"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/legal-and-ethics/sensitive-data-personal_data"/>
 		<is_collection>False</is_collection>
 		<order>3</order>
 		<help lang="en">Basically, the collection, processing, archiving and publication of personal data is only admissible, when the “informed consent” of the person in question has been obtained. However, there are a number of exceptions, some of which are described in Art. 6 of the General Data Protection Regulation or which have been made possible by law. For example, § 17 Datenschutzgesetz Nordrhein-Westfalen (DSG-NRW, 17 Mai 2018) allows the processing of personal data for scientific or historical research purposes or for statistical purposes even without consent if processing for these purposes is necessary and protected interests of the person concerned do not prevail.</help>
@@ -1124,17 +1124,17 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/informed_consent_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/informed_consent_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/legal-and-ethics/sensitive-data-personal_data/statement">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/legal-and-ethics/sensitive-data-personal_data/statement">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>statement</key>
 		<path>economics_dfg/legal-and-ethics/sensitive-data-personal_data/statement</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sensitive_data/personal_data/consent/statement"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/legal-and-ethics/sensitive-data-personal_data"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/legal-and-ethics/sensitive-data-personal_data"/>
 		<is_collection>False</is_collection>
 		<order>4</order>
 		<help lang="en"/>
@@ -1154,13 +1154,13 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/legal-and-ethics/sensitive-data-personal_data/record">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/legal-and-ethics/sensitive-data-personal_data/record">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>record</key>
 		<path>economics_dfg/legal-and-ethics/sensitive-data-personal_data/record</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sensitive_data/personal_data/consent/record"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/legal-and-ethics/sensitive-data-personal_data"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/legal-and-ethics/sensitive-data-personal_data"/>
 		<is_collection>False</is_collection>
 		<order>5</order>
 		<help lang="en"/>
@@ -1180,13 +1180,13 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/legal-and-ethics/sensitive-data-personal_data/deletion">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/legal-and-ethics/sensitive-data-personal_data/deletion">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>deletion</key>
 		<path>economics_dfg/legal-and-ethics/sensitive-data-personal_data/deletion</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sensitive_data/personal_data/deletion"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/legal-and-ethics/sensitive-data-personal_data"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/legal-and-ethics/sensitive-data-personal_data"/>
 		<is_collection>False</is_collection>
 		<order>6</order>
 		<help lang="en"/>
@@ -1206,13 +1206,13 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/legal-and-ethics/sensitive-data-other">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/legal-and-ethics/sensitive-data-other">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>sensitive-data-other</key>
 		<path>economics_dfg/legal-and-ethics/sensitive-data-other</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/legal-and-ethics"/>
 		<is_collection>True</is_collection>
 		<order>26</order>
 		<title lang="en">Other sensitive data</title>
@@ -1225,13 +1225,13 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/legal-and-ethics/sensitive-data-other/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/legal-and-ethics/sensitive-data-other/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>economics_dfg/legal-and-ethics/sensitive-data-other/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sensitive_data/other/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/legal-and-ethics/sensitive-data-other"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/legal-and-ethics/sensitive-data-other"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<help lang="en">Examples are data that contain trade or business secrets or geoinformation on endangered species.</help>
@@ -1251,13 +1251,13 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/legal-and-ethics/sensitive-data-other/description">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/legal-and-ethics/sensitive-data-other/description">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>description</key>
 		<path>economics_dfg/legal-and-ethics/sensitive-data-other/description</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sensitive_data/other/description"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/legal-and-ethics/sensitive-data-other"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/legal-and-ethics/sensitive-data-other"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -1276,16 +1276,16 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<unit/>
 		<optionsets/>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/other_sensitive_data"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/other_sensitive_data"/>
 		</conditions>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/legal-and-ethics/sensitive-data-official_approval">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/legal-and-ethics/sensitive-data-official_approval">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>sensitive-data-official_approval</key>
 		<path>economics_dfg/legal-and-ethics/sensitive-data-official_approval</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/legal-and-ethics"/>
 		<is_collection>False</is_collection>
 		<order>28</order>
 		<title lang="en">Official approval</title>
@@ -1298,13 +1298,13 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/legal-and-ethics/sensitive-data-official_approval/ethics_committee">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/legal-and-ethics/sensitive-data-official_approval/ethics_committee">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>ethics_committee</key>
 		<path>economics_dfg/legal-and-ethics/sensitive-data-official_approval/ethics_committee</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/legal_aspects/official_approval/ethics_committee"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/legal-and-ethics/sensitive-data-official_approval"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/legal-and-ethics/sensitive-data-official_approval"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en"/>
@@ -1322,17 +1322,17 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/ethics_committee_approval_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/ethics_committee_approval_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/legal-and-ethics/intellectual-property-rights-yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/legal-and-ethics/intellectual-property-rights-yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>intellectual-property-rights-yesno</key>
 		<path>economics_dfg/legal-and-ethics/intellectual-property-rights-yesno</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/legal-and-ethics"/>
 		<is_collection>False</is_collection>
 		<order>30</order>
 		<title lang="en">Intellectual property rights I</title>
@@ -1345,13 +1345,13 @@ abdecken. Die Fragen sind somit ausgesucht für wirtschaftswissenschaftliche Dat
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/legal-and-ethics/intellectual-property-rights-yesno/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/legal-and-ethics/intellectual-property-rights-yesno/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>economics_dfg/legal-and-ethics/intellectual-property-rights-yesno/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/legal_aspects/ipr/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/legal-and-ethics/intellectual-property-rights-yesno"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/legal-and-ethics/intellectual-property-rights-yesno"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<help lang="en">Data or software can be subject to intellectual or industrial property rights. Applicable laws differ broadly even within EU. According to the German copyright law (UrhG) works of literature, scholarship and the arts that can be regarded as a “personal intellectual creation” are protected by copyright. Copyright protection expires 70 years after the death of the copyright holder. Mere data, e.g. measured data or survey data, and metadata (except in some cases descriptive metadata) are not protected by copyright. § 2 of the UrhG lists the following kinds of protected works (list is not concluded): 
@@ -1399,13 +1399,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/legal-and-ethics/intellectual-property-rights-dataset">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/legal-and-ethics/intellectual-property-rights-dataset">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>intellectual-property-rights-dataset</key>
 		<path>economics_dfg/legal-and-ethics/intellectual-property-rights-dataset</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/legal-and-ethics"/>
 		<is_collection>True</is_collection>
 		<order>31</order>
 		<title lang="en">Intellectual property rights II</title>
@@ -1417,16 +1417,16 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<verbose_name lang="de">Datensatz</verbose_name>
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/intellectual_property_rights"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/intellectual_property_rights"/>
 		</conditions>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/legal-and-ethics/intellectual-property-rights-dataset/copyrights">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/legal-and-ethics/intellectual-property-rights-dataset/copyrights">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>copyrights</key>
 		<path>economics_dfg/legal-and-ethics/intellectual-property-rights-dataset/copyrights</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/ipr/copyrights"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
 		<is_collection>True</is_collection>
 		<order>0</order>
 		<help lang="en"/>
@@ -1444,17 +1444,17 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_copyright_laws"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_copyright_laws"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/legal-and-ethics/intellectual-property-rights-dataset/other_rights">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/legal-and-ethics/intellectual-property-rights-dataset/other_rights">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>other_rights</key>
 		<path>economics_dfg/legal-and-ethics/intellectual-property-rights-dataset/other_rights</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/ipr/other_rights"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
 		<is_collection>True</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -1472,27 +1472,27 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_other_rights"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_other_rights"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/storage-and-long-term-preservation">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/storage-and-long-term-preservation">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>storage-and-long-term-preservation</key>
 		<path>economics_dfg/storage-and-long-term-preservation</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg"/>
 		<order>10</order>
 		<title lang="en">Storage and long-term preservation</title>
 		<title lang="de">Speicherung und Langzeitarchivierung</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/storage-and-long-term-preservation/long-term-preservation-datasets">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/storage-and-long-term-preservation/long-term-preservation-datasets">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>long-term-preservation-datasets</key>
 		<path>economics_dfg/storage-and-long-term-preservation/long-term-preservation-datasets</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/storage-and-long-term-preservation"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/storage-and-long-term-preservation"/>
 		<is_collection>True</is_collection>
 		<order>11</order>
 		<title lang="en">Long-term preservation</title>
@@ -1505,13 +1505,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>economics_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en"/>
@@ -1531,13 +1531,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/purpose">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/purpose">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>purpose</key>
 		<path>economics_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/purpose</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/purpose"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>True</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -1555,17 +1555,17 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/preservation_motivation_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/preservation_motivation_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/duration">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/duration">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>duration</key>
 		<path>economics_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/duration</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/duration"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>False</is_collection>
 		<order>3</order>
 		<help lang="en"/>
@@ -1585,13 +1585,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/repository">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/repository">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>repository</key>
 		<path>economics_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/repository</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/repository"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>True</is_collection>
 		<order>5</order>
 		<help lang="en"/>
@@ -1609,17 +1609,17 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/preservation_repository_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/preservation_repository_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/embargo_period">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/embargo_period">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>embargo_period</key>
 		<path>economics_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/embargo_period</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/embargo_period"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>False</is_collection>
 		<order>8</order>
 		<help lang="en">An embargo period is an exclusion period for subsequent use by third parties.</help>
@@ -1639,13 +1639,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/access_authentication">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/access_authentication">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>access_authentication</key>
 		<path>economics_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/access_authentication</path>
 		<dc:comment>Original from H2020 FAIR Data Management Plan</dc:comment>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/access_authentication"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/economics_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/economics_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>False</is_collection>
 		<order>9</order>
 		<help lang="en"/>

--- a/shared/fodako/edition_dfg.xml
+++ b/shared/fodako/edition_dfg.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <rdmo xmlns:dc="http://purl.org/dc/elements/1.1/">
-	<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<catalog dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>edition_dfg</key>
 		<dc:comment>Dieser Fragenkatalog ist eine Teilmenge des Katalogs &quot;Alle Fragen&quot; (eine Überarbeitung des Katalogs &quot;RDMO&quot;) und enthält nur die Fragen, die die Anforderungen in den 
 
@@ -16,23 +16,23 @@ abdecken. Die Ausfüllhilfen geben Hinweise für Editionsprojekte.</dc:comment>
 		<title lang="en">DFG 105 Edition</title>
 		<title lang="de">DFG 105 Edition</title>
 	</catalog>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/general">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/general">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>general</key>
 		<path>edition_dfg/general</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg"/>
 		<order>0</order>
 		<title lang="en">General</title>
 		<title lang="de">Allgemein</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/general/other-requirements-yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/general/other-requirements-yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>other-requirements-yesno</key>
 		<path>edition_dfg/general/other-requirements-yesno</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/general"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/general"/>
 		<is_collection>False</is_collection>
 		<order>50</order>
 		<title lang="en">Requirements I</title>
@@ -45,13 +45,13 @@ abdecken. Die Ausfüllhilfen geben Hinweise für Editionsprojekte.</dc:comment>
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/general/other-requirements-yesno/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/general/other-requirements-yesno/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>edition_dfg/general/other-requirements-yesno/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/additional_rdm_policy/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/general/other-requirements-yesno"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/general/other-requirements-yesno"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<help lang="en">Edition projects in literature studies funded by the DFG should always observe the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/foerderkriterien_editionen_literaturwissenschaft.pdf&quot; target=_blank&gt; Funding criteria for scientific editions in literary studies &lt;/a&gt; (in German). Accordingly, this questionnaire takes into account the recommendations in this manual. This questionnaire takes into account these funding criteria and the interdisplinary &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/guidelines_research_data.pdf&quot; target=_blank&gt;DFG Guidelines on the Handling of Research Data&lt;/a&gt;.</help>
@@ -69,17 +69,17 @@ abdecken. Die Ausfüllhilfen geben Hinweise für Editionsprojekte.</dc:comment>
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/other_requirements_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/other_requirements_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/general/other-requirements-requirements">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/general/other-requirements-requirements">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>other-requirements-requirements</key>
 		<path>edition_dfg/general/other-requirements-requirements</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/general"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/general"/>
 		<is_collection>False</is_collection>
 		<order>51</order>
 		<title lang="en">Requirements II</title>
@@ -91,16 +91,16 @@ abdecken. Die Ausfüllhilfen geben Hinweise für Editionsprojekte.</dc:comment>
 		<verbose_name lang="de"/>
 		<verbose_name_plural lang="de"/>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/additional_rdm_policy"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/additional_rdm_policy"/>
 		</conditions>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/general/other-requirements-requirements/requirements">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/general/other-requirements-requirements/requirements">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>requirements</key>
 		<path>edition_dfg/general/other-requirements-requirements/requirements</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/additional_rdm_policy/requirements"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/general/other-requirements-requirements"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/general/other-requirements-requirements"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<help lang="en">At least, the following requirements and recommendations of the German Research Foundation must be observed:
@@ -128,13 +128,13 @@ abdecken. Die Ausfüllhilfen geben Hinweise für Editionsprojekte.</dc:comment>
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/general/support">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/general/support">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>support</key>
 		<path>edition_dfg/general/support</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/general"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/general"/>
 		<is_collection>False</is_collection>
 		<order>61</order>
 		<title lang="en">Support</title>
@@ -147,13 +147,13 @@ abdecken. Die Ausfüllhilfen geben Hinweise für Editionsprojekte.</dc:comment>
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/general/support/datamanagement">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/general/support/datamanagement">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>datamanagement</key>
 		<path>edition_dfg/general/support/datamanagement</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/support"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/general/support"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/general/support"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">From the&lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/foerderkriterien_editionen_literaturwissenschaft.pdf&quot; target=_blank&gt; Funding criteria for scientific editions in literary studies &lt;/a&gt; (in German):
@@ -177,23 +177,23 @@ Sofern im Projektteam keine ausreichende Expertise vorhanden ist, Texte im Basis
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/content-classification">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/content-classification">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>content-classification</key>
 		<path>edition_dfg/content-classification</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg"/>
 		<order>1</order>
 		<title lang="en">Content classification</title>
 		<title lang="de">Inhaltliche Einordnung</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/content-classification/data-dataset">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/content-classification/data-dataset">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-dataset</key>
 		<path>edition_dfg/content-classification/data-dataset</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/content-classification"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/content-classification"/>
 		<is_collection>True</is_collection>
 		<order>1</order>
 		<title lang="en">Datasets</title>
@@ -206,13 +206,13 @@ Sofern im Projektteam keine ausreichende Expertise vorhanden ist, Texte im Basis
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/content-classification/data-dataset/description">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/content-classification/data-dataset/description">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>description</key>
 		<path>edition_dfg/content-classification/data-dataset/description</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/description"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/content-classification/data-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/content-classification/data-dataset"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">From the&lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/foerderkriterien_editionen_literaturwissenschaft.pdf&quot; target=_blank&gt; Funding criteria for scientific editions in literary studies &lt;/a&gt; (in German):
@@ -240,13 +240,13 @@ Unabhängig von der spezifischen Form der Veröffentlichung der Edition sollten 
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/content-classification/data-reuse">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/content-classification/data-reuse">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-reuse</key>
 		<path>edition_dfg/content-classification/data-reuse</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/content-classification"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/content-classification"/>
 		<is_collection>True</is_collection>
 		<order>3</order>
 		<title lang="en">Reuse</title>
@@ -259,13 +259,13 @@ Unabhängig von der spezifischen Form der Veröffentlichung der Edition sollten 
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/content-classification/data-reuse/scenario">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/content-classification/data-reuse/scenario">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>scenario</key>
 		<path>edition_dfg/content-classification/data-reuse/scenario</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/reuse_scenario"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/content-classification/data-reuse"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/content-classification/data-reuse"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">It is important to set the fundamental course as to whether or not the data will be permitted for reuse. Of course, the potential for subsequent use can not be the sole decision criterion, but legal impediments, such as privacy, copyright and business secrets must be taken into account. Otherwise, consider the re-use potential against the disadvantages, e.g. a decrease in the readiness to participate and the expected extra effort of a data publication.</help>
@@ -285,23 +285,23 @@ Unabhängig von der spezifischen Form der Veröffentlichung der Edition sollten 
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/technical-classification">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/technical-classification">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>technical-classification</key>
 		<path>edition_dfg/technical-classification</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg"/>
 		<order>2</order>
 		<title lang="en">Technical classification</title>
 		<title lang="de">Technische Einordnung</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/technical-classification/data-formats">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/technical-classification/data-formats">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-formats</key>
 		<path>edition_dfg/technical-classification/data-formats</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/technical-classification"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/technical-classification"/>
 		<is_collection>True</is_collection>
 		<order>3</order>
 		<title lang="en">Formats</title>
@@ -314,13 +314,13 @@ Unabhängig von der spezifischen Form der Veröffentlichung der Edition sollten 
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/technical-classification/data-formats/format">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/technical-classification/data-formats/format">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>format</key>
 		<path>edition_dfg/technical-classification/data-formats/format</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/format"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/technical-classification/data-formats"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/technical-classification/data-formats"/>
 		<is_collection>False</is_collection>
 		<order>4</order>
 		<help lang="en">From the&lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/foerderkriterien_editionen_literaturwissenschaft.pdf&quot; target=_blank&gt; Funding criteria for scientific editions in literary studies &lt;/a&gt; (in German):
@@ -356,23 +356,23 @@ Weitere Anforderungen, z.B. zu Bildformaten, können in den &lt;a href=&quot;htt
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/data-usage">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/data-usage">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-usage</key>
 		<path>edition_dfg/data-usage</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg"/>
 		<order>3</order>
 		<title lang="en">Data usage</title>
 		<title lang="de">Datennutzung</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/data-usage/data-storage-and-security-storage">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/data-usage/data-storage-and-security-storage">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-storage-and-security-storage</key>
 		<path>edition_dfg/data-usage/data-storage-and-security-storage</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/data-usage"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/data-usage"/>
 		<is_collection>True</is_collection>
 		<order>11</order>
 		<title lang="en">Data organisation</title>
@@ -385,13 +385,13 @@ Weitere Anforderungen, z.B. zu Bildformaten, können in den &lt;a href=&quot;htt
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/data-usage/data-storage-and-security-storage/type">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/data-usage/data-storage-and-security-storage/type">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>type</key>
 		<path>edition_dfg/data-usage/data-storage-and-security-storage/type</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/storage/type"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/data-usage/data-storage-and-security-storage"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/data-usage/data-storage-and-security-storage"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">If parts of the documentation or related software (custom development) are not stored with the data, also indicate where they are stored. This applies to the documentation of the software too.</help>
@@ -411,13 +411,13 @@ Weitere Anforderungen, z.B. zu Bildformaten, können in den &lt;a href=&quot;htt
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/data-usage/data-sharing-and-re-use-publication">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/data-usage/data-sharing-and-re-use-publication">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-sharing-and-re-use-publication</key>
 		<path>edition_dfg/data-usage/data-sharing-and-re-use-publication</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/data-usage"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/data-usage"/>
 		<is_collection>True</is_collection>
 		<order>52</order>
 		<title lang="en">Data sharing and re-use</title>
@@ -430,13 +430,13 @@ Weitere Anforderungen, z.B. zu Bildformaten, können in den &lt;a href=&quot;htt
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/data-usage/data-sharing-and-re-use-publication/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/data-usage/data-sharing-and-re-use-publication/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>edition_dfg/data-usage/data-sharing-and-re-use-publication/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sharing/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/data-usage/data-sharing-and-re-use-publication"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/data-usage/data-sharing-and-re-use-publication"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en"/>
@@ -454,17 +454,17 @@ Weitere Anforderungen, z.B. zu Bildformaten, können in den &lt;a href=&quot;htt
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_sharing_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_sharing_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/data-usage/data-sharing-and-re-use-publication/explanation">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/data-usage/data-sharing-and-re-use-publication/explanation">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>explanation</key>
 		<path>edition_dfg/data-usage/data-sharing-and-re-use-publication/explanation</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sharing/explanation"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/data-usage/data-sharing-and-re-use-publication"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/data-usage/data-sharing-and-re-use-publication"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -484,13 +484,13 @@ Weitere Anforderungen, z.B. zu Bildformaten, können in den &lt;a href=&quot;htt
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/data-usage/data-sharing-and-re-use-publication/conditions">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/data-usage/data-sharing-and-re-use-publication/conditions">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>conditions</key>
 		<path>edition_dfg/data-usage/data-sharing-and-re-use-publication/conditions</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sharing/conditions"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/data-usage/data-sharing-and-re-use-publication"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/data-usage/data-sharing-and-re-use-publication"/>
 		<is_collection>True</is_collection>
 		<order>3</order>
 		<help lang="en">The options refer to the licenses of the &lt;a href=&quot;https://creativecommons.org/share-your-work/licensing-types-examples/&quot; target=_blank&quot;&gt;Creative Commons family&lt;/a&gt;. From the&lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/foerderkriterien_editionen_literaturwissenschaft.pdf&quot; target=_blank&gt; Funding criteria for scientific editions in literary studies &lt;/a&gt; (in German):
@@ -512,17 +512,17 @@ Die elektronische Ablage erfolgt ausdrücklich unter einer Lizenz, die eine frei
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_license_types"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_license_types"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/data-usage/data-sharing-and-re-use-publication/data_publication_date">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/data-usage/data-sharing-and-re-use-publication/data_publication_date">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data_publication_date</key>
 		<path>edition_dfg/data-usage/data-sharing-and-re-use-publication/data_publication_date</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/data_publication_date"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/data-usage/data-sharing-and-re-use-publication"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/data-usage/data-sharing-and-re-use-publication"/>
 		<is_collection>False</is_collection>
 		<order>6</order>
 		<help lang="en">From the&lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/foerderkriterien_editionen_literaturwissenschaft.pdf&quot; target=_blank&gt; Funding criteria for scientific editions in literary studies &lt;/a&gt; (in German):
@@ -549,16 +549,16 @@ Prioritär gefördert werden Projekte, deren im „Basisformat“ aufbereitete T
 		<unit/>
 		<optionsets/>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/data_sharing"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/data_sharing"/>
 		</conditions>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/data-usage/quality-assurance-dataset">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/data-usage/quality-assurance-dataset">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>quality-assurance-dataset</key>
 		<path>edition_dfg/data-usage/quality-assurance-dataset</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/data-usage"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/data-usage"/>
 		<is_collection>True</is_collection>
 		<order>61</order>
 		<title lang="en">Quality assurance</title>
@@ -571,13 +571,13 @@ Prioritär gefördert werden Projekte, deren im „Basisformat“ aufbereitete T
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/data-usage/quality-assurance-dataset/measures">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/data-usage/quality-assurance-dataset/measures">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>measures</key>
 		<path>edition_dfg/data-usage/quality-assurance-dataset/measures</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/quality_assurance"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/data-usage/quality-assurance-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/data-usage/quality-assurance-dataset"/>
 		<is_collection>False</is_collection>
 		<order>7</order>
 		<help lang="en"/>
@@ -597,23 +597,23 @@ Prioritär gefördert werden Projekte, deren im „Basisformat“ aufbereitete T
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/doc">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/doc">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>doc</key>
 		<path>edition_dfg/doc</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg"/>
 		<order>4</order>
 		<title lang="en">Documentation</title>
 		<title lang="de">Dokumentation</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/doc/metadata-dataset">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/doc/metadata-dataset">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>metadata-dataset</key>
 		<path>edition_dfg/doc/metadata-dataset</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/doc"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/doc"/>
 		<is_collection>True</is_collection>
 		<order>10</order>
 		<title lang="en">Data documentation</title>
@@ -626,13 +626,13 @@ Prioritär gefördert werden Projekte, deren im „Basisformat“ aufbereitete T
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/doc/metadata-dataset/documentation">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/doc/metadata-dataset/documentation">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>documentation</key>
 		<path>edition_dfg/doc/metadata-dataset/documentation</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/documentation"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/doc/metadata-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/doc/metadata-dataset"/>
 		<is_collection>False</is_collection>
 		<order>4</order>
 		<help lang="en">From the&lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/foerderkriterien_editionen_literaturwissenschaft.pdf&quot; target=_blank&gt; Funding criteria for scientific editions in literary studies &lt;/a&gt; (in German):
@@ -660,23 +660,23 @@ Die abgelegten Daten sollten im Idealfall der Version des Textes entsprechen, di
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/legal-and-ethics">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/legal-and-ethics">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>legal-and-ethics</key>
 		<path>edition_dfg/legal-and-ethics</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg"/>
 		<order>5</order>
 		<title lang="en">Legal and ethics</title>
 		<title lang="de">Rechtliche und ethische Fragen</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/legal-and-ethics/sensitive-data-personal_data_yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/legal-and-ethics/sensitive-data-personal_data_yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>sensitive-data-personal_data_yesno</key>
 		<path>edition_dfg/legal-and-ethics/sensitive-data-personal_data_yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/legal-and-ethics"/>
 		<is_collection>True</is_collection>
 		<order>21</order>
 		<title lang="en">Personal data</title>
@@ -689,13 +689,13 @@ Die abgelegten Daten sollten im Idealfall der Version des Textes entsprechen, di
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/legal-and-ethics/sensitive-data-personal_data_yesno/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/legal-and-ethics/sensitive-data-personal_data_yesno/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>edition_dfg/legal-and-ethics/sensitive-data-personal_data_yesno/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sensitive_data/personal_data_yesno/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/legal-and-ethics/sensitive-data-personal_data_yesno"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/legal-and-ethics/sensitive-data-personal_data_yesno"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">The EU General Data Protection Regulation (GDPR) defines in Art. 4 personal data as &quot;any information relating to an identified or identifiable natural person&quot;. An identifiable natural person is &quot;one who can be identified, directly or indirectly, in particular by reference to an identifier such as a name, an identification number, location data, an online identifier or to one or more factors specific to the physical, physiological, genetic, mental, economic, cultural or social identity of that natural person&quot;.</help>
@@ -715,13 +715,13 @@ Die abgelegten Daten sollten im Idealfall der Version des Textes entsprechen, di
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/legal-and-ethics/sensitive-data-personal_data">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/legal-and-ethics/sensitive-data-personal_data">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>sensitive-data-personal_data</key>
 		<path>edition_dfg/legal-and-ethics/sensitive-data-personal_data</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/legal-and-ethics"/>
 		<is_collection>True</is_collection>
 		<order>24</order>
 		<title lang="en">Sensitive data</title>
@@ -733,16 +733,16 @@ Die abgelegten Daten sollten im Idealfall der Version des Textes entsprechen, di
 		<verbose_name lang="de">Datensatz</verbose_name>
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/personal_data"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/personal_data"/>
 		</conditions>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/legal-and-ethics/sensitive-data-personal_data/anonymization">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/legal-and-ethics/sensitive-data-personal_data/anonymization">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>anonymization</key>
 		<path>edition_dfg/legal-and-ethics/sensitive-data-personal_data/anonymization</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sensitive_data/personal_data/anonymization"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/legal-and-ethics/sensitive-data-personal_data"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/legal-and-ethics/sensitive-data-personal_data"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -760,17 +760,17 @@ Die abgelegten Daten sollten im Idealfall der Version des Textes entsprechen, di
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_anonymisation"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_anonymisation"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/legal-and-ethics/intellectual-property-rights-yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/legal-and-ethics/intellectual-property-rights-yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>intellectual-property-rights-yesno</key>
 		<path>edition_dfg/legal-and-ethics/intellectual-property-rights-yesno</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/legal-and-ethics"/>
 		<is_collection>False</is_collection>
 		<order>30</order>
 		<title lang="en">Intellectual property rights I</title>
@@ -783,13 +783,13 @@ Die abgelegten Daten sollten im Idealfall der Version des Textes entsprechen, di
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/legal-and-ethics/intellectual-property-rights-yesno/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/legal-and-ethics/intellectual-property-rights-yesno/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>edition_dfg/legal-and-ethics/intellectual-property-rights-yesno/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/legal_aspects/ipr/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/legal-and-ethics/intellectual-property-rights-yesno"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/legal-and-ethics/intellectual-property-rights-yesno"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<help lang="en">Data or software can be subject to intellectual or industrial property rights. Applicable laws differ broadly even within EU. According to the German copyright law (UrhG) works of literature, scholarship and the arts that can be regarded as a “personal intellectual creation” are protected by copyright. Copyright protection expires 70 years after the death of the copyright holder. Mere data, e.g. measured data or survey data, and metadata (except in some cases descriptive metadata) are not protected by copyright. § 2 of the UrhG lists the following kinds of protected works (list is not concluded): 
@@ -837,13 +837,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/legal-and-ethics/intellectual-property-rights-dataset">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/legal-and-ethics/intellectual-property-rights-dataset">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>intellectual-property-rights-dataset</key>
 		<path>edition_dfg/legal-and-ethics/intellectual-property-rights-dataset</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/legal-and-ethics"/>
 		<is_collection>True</is_collection>
 		<order>31</order>
 		<title lang="en">Intellectual property rights II</title>
@@ -855,16 +855,16 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<verbose_name lang="de">Datensatz</verbose_name>
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/intellectual_property_rights"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/intellectual_property_rights"/>
 		</conditions>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/legal-and-ethics/intellectual-property-rights-dataset/copyrights">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/legal-and-ethics/intellectual-property-rights-dataset/copyrights">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>copyrights</key>
 		<path>edition_dfg/legal-and-ethics/intellectual-property-rights-dataset/copyrights</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/ipr/copyrights"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
 		<is_collection>True</is_collection>
 		<order>0</order>
 		<help lang="en"/>
@@ -882,17 +882,17 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_copyright_laws"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_copyright_laws"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/legal-and-ethics/intellectual-property-rights-dataset/other_rights">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/legal-and-ethics/intellectual-property-rights-dataset/other_rights">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>other_rights</key>
 		<path>edition_dfg/legal-and-ethics/intellectual-property-rights-dataset/other_rights</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/ipr/other_rights"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
 		<is_collection>True</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -910,27 +910,27 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_other_rights"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_other_rights"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/storage-and-long-term-preservation">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/storage-and-long-term-preservation">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>storage-and-long-term-preservation</key>
 		<path>edition_dfg/storage-and-long-term-preservation</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg"/>
 		<order>10</order>
 		<title lang="en">Storage and long-term preservation</title>
 		<title lang="de">Speicherung und Langzeitarchivierung</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/storage-and-long-term-preservation/long-term-preservation-datasets">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/storage-and-long-term-preservation/long-term-preservation-datasets">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>long-term-preservation-datasets</key>
 		<path>edition_dfg/storage-and-long-term-preservation/long-term-preservation-datasets</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/storage-and-long-term-preservation"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/storage-and-long-term-preservation"/>
 		<is_collection>True</is_collection>
 		<order>11</order>
 		<title lang="en">Long-term preservation</title>
@@ -943,13 +943,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>edition_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en"/>
@@ -969,13 +969,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/purpose">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/purpose">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>purpose</key>
 		<path>edition_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/purpose</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/purpose"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>True</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -993,17 +993,17 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/preservation_motivation_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/preservation_motivation_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/duration">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/duration">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>duration</key>
 		<path>edition_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/duration</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/duration"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>False</is_collection>
 		<order>3</order>
 		<help lang="en"/>
@@ -1023,13 +1023,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/repository">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/repository">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>repository</key>
 		<path>edition_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/repository</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/repository"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>True</is_collection>
 		<order>5</order>
 		<help lang="en">From the&lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/foerderkriterien_editionen_literaturwissenschaft.pdf&quot; target=_blank&gt; Funding criteria for scientific editions in literary studies &lt;/a&gt; (in German):
@@ -1051,17 +1051,17 @@ Die Texte werden zur Archivierung in einem institutionellen oder fachlichen Repo
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/preservation_repository_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/preservation_repository_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/certification">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/certification">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>certification</key>
 		<path>edition_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/certification</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/certification"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edition_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edition_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>False</is_collection>
 		<order>6</order>
 		<help lang="en">From the&lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/foerderkriterien_editionen_literaturwissenschaft.pdf&quot; target=_blank&gt; Funding criteria for scientific editions in literary studies &lt;/a&gt; (in German):

--- a/shared/fodako/edu_dfg.xml
+++ b/shared/fodako/edu_dfg.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <rdmo xmlns:dc="http://purl.org/dc/elements/1.1/">
-	<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<catalog dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>edu_dfg</key>
 		<dc:comment>Dieser Fragenkatalog ist eine Teilmenge des Katalogs &quot;RDMO&quot; und enthält nur die Fragen, die die Anforderungen
 
@@ -14,23 +14,23 @@ abdecken. Die Fragen sind somit ausgesucht für bildungswissenschaftliche Datenm
 		<title lang="en">DFG 109 Educational Research</title>
 		<title lang="de">DFG 109 Bildungswiss.</title>
 	</catalog>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/general">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/general">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>general</key>
 		<path>edu_dfg/general</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg"/>
 		<order>0</order>
 		<title lang="en">General</title>
 		<title lang="de">Allgemein</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/general/other-requirements-yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/general/other-requirements-yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>other-requirements-yesno</key>
 		<path>edu_dfg/general/other-requirements-yesno</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/general"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/general"/>
 		<is_collection>False</is_collection>
 		<order>50</order>
 		<title lang="en">Requirements I</title>
@@ -43,13 +43,13 @@ abdecken. Die Fragen sind somit ausgesucht für bildungswissenschaftliche Datenm
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/general/other-requirements-yesno/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/general/other-requirements-yesno/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>edu_dfg/general/other-requirements-yesno/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/additional_rdm_policy/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/general/other-requirements-yesno"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/general/other-requirements-yesno"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<help lang="en">This catalog contains only the questions that the requirements
@@ -88,17 +88,17 @@ abdecken. Die Fragen sind somit ausgesucht für bildungswissenschaftliche Datenm
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/other_requirements_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/other_requirements_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/general/other-requirements-requirements">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/general/other-requirements-requirements">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>other-requirements-requirements</key>
 		<path>edu_dfg/general/other-requirements-requirements</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/general"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/general"/>
 		<is_collection>False</is_collection>
 		<order>51</order>
 		<title lang="en">Requirements II</title>
@@ -110,16 +110,16 @@ abdecken. Die Fragen sind somit ausgesucht für bildungswissenschaftliche Datenm
 		<verbose_name lang="de"/>
 		<verbose_name_plural lang="de"/>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/additional_rdm_policy"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/additional_rdm_policy"/>
 		</conditions>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/general/other-requirements-requirements/requirements">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/general/other-requirements-requirements/requirements">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>requirements</key>
 		<path>edu_dfg/general/other-requirements-requirements/requirements</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/additional_rdm_policy/requirements"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/general/other-requirements-requirements"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/general/other-requirements-requirements"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<help lang="en">Please briefly outline them and refer to more detailed sources of information if necessary. At least the ones mentioned in the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/richtlinien_forschungsdaten_bildungsforschung.pdf&quot; target=_blank&gt;Memorandum des Fachkollegiums „Erziehungswissenschaft“ der DFG&lt;/a&gt; should be met.</help>
@@ -139,23 +139,23 @@ abdecken. Die Fragen sind somit ausgesucht für bildungswissenschaftliche Datenm
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/content-classification">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/content-classification">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>content-classification</key>
 		<path>edu_dfg/content-classification</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg"/>
 		<order>1</order>
 		<title lang="en">Content classification</title>
 		<title lang="de">Inhaltliche Einordnung</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/content-classification/data-dataset">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/content-classification/data-dataset">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-dataset</key>
 		<path>edu_dfg/content-classification/data-dataset</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/content-classification"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/content-classification"/>
 		<is_collection>True</is_collection>
 		<order>1</order>
 		<title lang="en">Datasets</title>
@@ -168,13 +168,13 @@ abdecken. Die Fragen sind somit ausgesucht für bildungswissenschaftliche Datenm
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/content-classification/data-dataset/description">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/content-classification/data-dataset/description">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>description</key>
 		<path>edu_dfg/content-classification/data-dataset/description</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/description"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/content-classification/data-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/content-classification/data-dataset"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">Please briefly describe the data type and / or the method used to create or collect the data, for example: 
@@ -206,13 +206,13 @@ abdecken. Die Fragen sind somit ausgesucht für bildungswissenschaftliche Datenm
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/content-classification/data-existing_data">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/content-classification/data-existing_data">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-existing_data</key>
 		<path>edu_dfg/content-classification/data-existing_data</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/content-classification"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/content-classification"/>
 		<is_collection>True</is_collection>
 		<order>2</order>
 		<title lang="en">Data origin</title>
@@ -225,13 +225,13 @@ abdecken. Die Fragen sind somit ausgesucht für bildungswissenschaftliche Datenm
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/content-classification/data-existing_data/origin">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/content-classification/data-existing_data/origin">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>origin</key>
 		<path>edu_dfg/content-classification/data-existing_data/origin</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/origin"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/content-classification/data-existing_data"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/content-classification/data-existing_data"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en"/>
@@ -249,17 +249,17 @@ abdecken. Die Fragen sind somit ausgesucht für bildungswissenschaftliche Datenm
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_origin_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_origin_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/content-classification/data-existing_data/creator_name">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/content-classification/data-existing_data/creator_name">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>creator_name</key>
 		<path>edu_dfg/content-classification/data-existing_data/creator_name</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/creator/name"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/content-classification/data-existing_data"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/content-classification/data-existing_data"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -279,13 +279,13 @@ abdecken. Die Fragen sind somit ausgesucht für bildungswissenschaftliche Datenm
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/content-classification/data-existing_data/uri">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/content-classification/data-existing_data/uri">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>uri</key>
 		<path>edu_dfg/content-classification/data-existing_data/uri</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/uri"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/content-classification/data-existing_data"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/content-classification/data-existing_data"/>
 		<is_collection>False</is_collection>
 		<order>3</order>
 		<help lang="en"/>
@@ -305,13 +305,13 @@ abdecken. Die Fragen sind somit ausgesucht für bildungswissenschaftliche Datenm
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/content-classification/data-reuse">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/content-classification/data-reuse">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-reuse</key>
 		<path>edu_dfg/content-classification/data-reuse</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/content-classification"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/content-classification"/>
 		<is_collection>True</is_collection>
 		<order>3</order>
 		<title lang="en">Reuse</title>
@@ -324,13 +324,13 @@ abdecken. Die Fragen sind somit ausgesucht für bildungswissenschaftliche Datenm
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/content-classification/data-reuse/scenario">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/content-classification/data-reuse/scenario">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>scenario</key>
 		<path>edu_dfg/content-classification/data-reuse/scenario</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/reuse_scenario"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/content-classification/data-reuse"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/content-classification/data-reuse"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">According to the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/richtlinien_forschungsdaten_bildungsforschung.pdf&quot; target=_blank&quot;&gt;Memorandum of the review board Educational Science of the DFG (in German)&lt;/a&gt; you should weigh up the re-use potential against the deployment effort, choose one of the following three possible consequences and justify your selection:
@@ -366,13 +366,13 @@ Selbstverständlich müssen rechtliche Hinderungsgründe (Datenschutz, Urheberre
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/content-classification/data-reuse/existing">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/content-classification/data-reuse/existing">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>existing</key>
 		<path>edu_dfg/content-classification/data-reuse/existing</path>
 		<dc:comment>Neue, noch nicht im Katalog RDMO enthaltene Frage, die aufgrund einer Anforderung in 'Bereitstellung und Nutzung quantitativer Forschungsdaten in der Bildungsforschung: Memorandum des Fachkollegiums „Erziehungswissenschaft“ der DFG' aufgenommen wurde</dc:comment>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/reuse_existing"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/content-classification/data-reuse"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/content-classification/data-reuse"/>
 		<is_collection>False</is_collection>
 		<order>3</order>
 		<help lang="en">From &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/richtlinien_forschungsdaten_bildungsforschung.pdf&quot;
@@ -398,23 +398,23 @@ For project applications that involve the collection of new data, it should alwa
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/technical-classification">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/technical-classification">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>technical-classification</key>
 		<path>edu_dfg/technical-classification</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg"/>
 		<order>2</order>
 		<title lang="en">Technical classification</title>
 		<title lang="de">Technische Einordnung</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/technical-classification/data-formats">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/technical-classification/data-formats">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-formats</key>
 		<path>edu_dfg/technical-classification/data-formats</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/technical-classification"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/technical-classification"/>
 		<is_collection>True</is_collection>
 		<order>3</order>
 		<title lang="en">Formats</title>
@@ -427,13 +427,13 @@ For project applications that involve the collection of new data, it should alwa
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/technical-classification/data-formats/format">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/technical-classification/data-formats/format">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>format</key>
 		<path>edu_dfg/technical-classification/data-formats/format</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/format"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/technical-classification/data-formats"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/technical-classification/data-formats"/>
 		<is_collection>False</is_collection>
 		<order>4</order>
 		<help lang="en">When choosing a data format, one should consider the consequences for collaborative use, long-term preservation as well as re-use. It is advisable to prefer formats that are standardised, open, non-proprietary and well-established in the respective scholarly community. A table with recommended file formats can be found in Kristin Briney, &lt;i&gt;Data Management for Researchers&lt;/i&gt;, Pelargic, 2015, pages 133-134.</help>
@@ -453,23 +453,23 @@ For project applications that involve the collection of new data, it should alwa
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/data-usage">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/data-usage">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-usage</key>
 		<path>edu_dfg/data-usage</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg"/>
 		<order>3</order>
 		<title lang="en">Data usage</title>
 		<title lang="de">Datennutzung</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/data-usage/data-storage-and-security-storage">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/data-usage/data-storage-and-security-storage">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-storage-and-security-storage</key>
 		<path>edu_dfg/data-usage/data-storage-and-security-storage</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/data-usage"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/data-usage"/>
 		<is_collection>True</is_collection>
 		<order>11</order>
 		<title lang="en">Data organisation</title>
@@ -482,13 +482,13 @@ For project applications that involve the collection of new data, it should alwa
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/data-usage/data-storage-and-security-storage/type">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/data-usage/data-storage-and-security-storage/type">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>type</key>
 		<path>edu_dfg/data-usage/data-storage-and-security-storage/type</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/storage/type"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/data-usage/data-storage-and-security-storage"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/data-usage/data-storage-and-security-storage"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">If parts of the documentation or related software (custom development) are not stored with the data, also indicate where they are stored. This applies to the documentation of the software too.</help>
@@ -508,13 +508,13 @@ For project applications that involve the collection of new data, it should alwa
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/data-usage/data-sharing-and-re-use-publication">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/data-usage/data-sharing-and-re-use-publication">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-sharing-and-re-use-publication</key>
 		<path>edu_dfg/data-usage/data-sharing-and-re-use-publication</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/data-usage"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/data-usage"/>
 		<is_collection>True</is_collection>
 		<order>52</order>
 		<title lang="en">Data sharing and re-use</title>
@@ -527,13 +527,13 @@ For project applications that involve the collection of new data, it should alwa
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/data-usage/data-sharing-and-re-use-publication/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/data-usage/data-sharing-and-re-use-publication/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>edu_dfg/data-usage/data-sharing-and-re-use-publication/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sharing/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/data-usage/data-sharing-and-re-use-publication"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/data-usage/data-sharing-and-re-use-publication"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en"/>
@@ -551,17 +551,17 @@ For project applications that involve the collection of new data, it should alwa
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_sharing_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_sharing_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/data-usage/data-sharing-and-re-use-publication/explanation">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/data-usage/data-sharing-and-re-use-publication/explanation">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>explanation</key>
 		<path>edu_dfg/data-usage/data-sharing-and-re-use-publication/explanation</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sharing/explanation"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/data-usage/data-sharing-and-re-use-publication"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/data-usage/data-sharing-and-re-use-publication"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -581,13 +581,13 @@ For project applications that involve the collection of new data, it should alwa
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/data-usage/data-sharing-and-re-use-publication/conditions">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/data-usage/data-sharing-and-re-use-publication/conditions">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>conditions</key>
 		<path>edu_dfg/data-usage/data-sharing-and-re-use-publication/conditions</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sharing/conditions"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/data-usage/data-sharing-and-re-use-publication"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/data-usage/data-sharing-and-re-use-publication"/>
 		<is_collection>True</is_collection>
 		<order>3</order>
 		<help lang="en">The options refer to the licenses of the &lt;a href=&quot;https://creativecommons.org/share-your-work/licensing-types-examples/&quot; target=_blank&quot;&gt;Creative Commons family&lt;/a&gt;.</help>
@@ -605,17 +605,17 @@ For project applications that involve the collection of new data, it should alwa
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_license_types"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_license_types"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/data-usage/data-sharing-and-re-use-publication/data_publication_date">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/data-usage/data-sharing-and-re-use-publication/data_publication_date">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data_publication_date</key>
 		<path>edu_dfg/data-usage/data-sharing-and-re-use-publication/data_publication_date</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/data_publication_date"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/data-usage/data-sharing-and-re-use-publication"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/data-usage/data-sharing-and-re-use-publication"/>
 		<is_collection>False</is_collection>
 		<order>6</order>
 		<help lang="en"/>
@@ -634,16 +634,16 @@ For project applications that involve the collection of new data, it should alwa
 		<unit/>
 		<optionsets/>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/data_sharing"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/data_sharing"/>
 		</conditions>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/data-usage/quality-assurance-dataset">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/data-usage/quality-assurance-dataset">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>quality-assurance-dataset</key>
 		<path>edu_dfg/data-usage/quality-assurance-dataset</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/data-usage"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/data-usage"/>
 		<is_collection>True</is_collection>
 		<order>61</order>
 		<title lang="en">Quality assurance</title>
@@ -656,13 +656,13 @@ For project applications that involve the collection of new data, it should alwa
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/data-usage/quality-assurance-dataset/measures">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/data-usage/quality-assurance-dataset/measures">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>measures</key>
 		<path>edu_dfg/data-usage/quality-assurance-dataset/measures</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/quality_assurance"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/data-usage/quality-assurance-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/data-usage/quality-assurance-dataset"/>
 		<is_collection>False</is_collection>
 		<order>7</order>
 		<help lang="en"/>
@@ -682,23 +682,23 @@ For project applications that involve the collection of new data, it should alwa
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/doc">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/doc">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>doc</key>
 		<path>edu_dfg/doc</path>
 		<dc:comment>hervorgegangen aus dem Abschnitt &quot;Metadaten und Referenzierung&quot; des Katalogs &quot;RDMO&quot;</dc:comment>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg"/>
 		<order>4</order>
 		<title lang="en">Documentation</title>
 		<title lang="de">Dokumentation</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/doc/general">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/doc/general">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>general</key>
 		<path>edu_dfg/doc/general</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/doc"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/doc"/>
 		<is_collection>True</is_collection>
 		<order>10</order>
 		<title lang="en">Necessity and availability</title>
@@ -711,13 +711,13 @@ For project applications that involve the collection of new data, it should alwa
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/doc/general/scope">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/doc/general/scope">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>scope</key>
 		<path>edu_dfg/doc/general/scope</path>
 		<dc:comment>probably we should introduce a separate question for being findable and re-used</dc:comment>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/metadata/scope"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/doc/general"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/doc/general"/>
 		<is_collection>True</is_collection>
 		<order>0</order>
 		<help lang="en"/>
@@ -735,17 +735,17 @@ For project applications that involve the collection of new data, it should alwa
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/mandatory_metadata_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/mandatory_metadata_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/doc/general/documentation">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/doc/general/documentation">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>documentation</key>
 		<path>edu_dfg/doc/general/documentation</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/documentation"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/doc/general"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/doc/general"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">According to &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/richtlinien_forschungsdaten_bildungsforschung.pdf&quot; target=_blank&quot;&gt;Memorandum des Fachkollegiums „Erziehungswissenschaft“ der DFG (in German)&lt;/a&gt;, the documentation of data records can be designed in different ways: It can range from raw data with traceable labels and a codebook to datasets that contain raw data as well as scales and metadata and that contain detailed technical reports and scale manuals (meta and paradata).
@@ -769,13 +769,13 @@ Tragen Sie in dieses Feld die Bestandteile der Datendokumentation ein, die mit d
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/doc/general/documentation_on_request">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/doc/general/documentation_on_request">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>documentation_on_request</key>
 		<path>edu_dfg/doc/general/documentation_on_request</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/documentation_on_request"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/doc/general"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/doc/general"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en">According to &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/richtlinien_forschungsdaten_bildungsforschung.pdf&quot; target=_blank&quot;&gt;Memorandum des Fachkollegiums „Erziehungswissenschaft“ der DFG&lt;/a&gt;, the provision is expressly provided upon request in the case of the following &lt;i&gt;forms of deployment&lt;/ i&gt;:
@@ -807,23 +807,23 @@ Scheuen Sie sich also nicht, hier die Teile der Datendokumentation zu nennen, di
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/legal-and-ethics">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/legal-and-ethics">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>legal-and-ethics</key>
 		<path>edu_dfg/legal-and-ethics</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg"/>
 		<order>5</order>
 		<title lang="en">Legal and ethics</title>
 		<title lang="de">Rechtliche und ethische Fragen</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/legal-and-ethics/sensitive-data-personal_data_yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/legal-and-ethics/sensitive-data-personal_data_yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>sensitive-data-personal_data_yesno</key>
 		<path>edu_dfg/legal-and-ethics/sensitive-data-personal_data_yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/legal-and-ethics"/>
 		<is_collection>True</is_collection>
 		<order>21</order>
 		<title lang="en">Personal data</title>
@@ -836,13 +836,13 @@ Scheuen Sie sich also nicht, hier die Teile der Datendokumentation zu nennen, di
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/legal-and-ethics/sensitive-data-personal_data_yesno/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/legal-and-ethics/sensitive-data-personal_data_yesno/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>edu_dfg/legal-and-ethics/sensitive-data-personal_data_yesno/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sensitive_data/personal_data_yesno/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/legal-and-ethics/sensitive-data-personal_data_yesno"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/legal-and-ethics/sensitive-data-personal_data_yesno"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">The EU General Data Protection Regulation (GDPR) defines in Art. 4 personal data as &quot;any information relating to an identified or identifiable natural person&quot;. An identifiable natural person is &quot;one who can be identified, directly or indirectly, in particular by reference to an identifier such as a name, an identification number, location data, an online identifier or to one or more factors specific to the physical, physiological, genetic, mental, economic, cultural or social identity of that natural person&quot;.</help>
@@ -862,13 +862,13 @@ Scheuen Sie sich also nicht, hier die Teile der Datendokumentation zu nennen, di
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/legal-and-ethics/sensitive-data-personal_data">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/legal-and-ethics/sensitive-data-personal_data">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>sensitive-data-personal_data</key>
 		<path>edu_dfg/legal-and-ethics/sensitive-data-personal_data</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/legal-and-ethics"/>
 		<is_collection>True</is_collection>
 		<order>24</order>
 		<title lang="en">Sensitive data</title>
@@ -880,16 +880,16 @@ Scheuen Sie sich also nicht, hier die Teile der Datendokumentation zu nennen, di
 		<verbose_name lang="de">Datensatz</verbose_name>
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/personal_data"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/personal_data"/>
 		</conditions>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/legal-and-ethics/sensitive-data-personal_data/anonymization">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/legal-and-ethics/sensitive-data-personal_data/anonymization">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>anonymization</key>
 		<path>edu_dfg/legal-and-ethics/sensitive-data-personal_data/anonymization</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sensitive_data/personal_data/anonymization"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/legal-and-ethics/sensitive-data-personal_data"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/legal-and-ethics/sensitive-data-personal_data"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -907,17 +907,17 @@ Scheuen Sie sich also nicht, hier die Teile der Datendokumentation zu nennen, di
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_anonymisation"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_anonymisation"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/legal-and-ethics/intellectual-property-rights-yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/legal-and-ethics/intellectual-property-rights-yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>intellectual-property-rights-yesno</key>
 		<path>edu_dfg/legal-and-ethics/intellectual-property-rights-yesno</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/legal-and-ethics"/>
 		<is_collection>False</is_collection>
 		<order>30</order>
 		<title lang="en">Intellectual property rights I</title>
@@ -930,13 +930,13 @@ Scheuen Sie sich also nicht, hier die Teile der Datendokumentation zu nennen, di
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/legal-and-ethics/intellectual-property-rights-yesno/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/legal-and-ethics/intellectual-property-rights-yesno/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>edu_dfg/legal-and-ethics/intellectual-property-rights-yesno/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/legal_aspects/ipr/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/legal-and-ethics/intellectual-property-rights-yesno"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/legal-and-ethics/intellectual-property-rights-yesno"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<help lang="en">Data or software can be subject to intellectual or industrial property rights. Applicable laws differ broadly even within EU. According to the German copyright law (UrhG) works of literature, scholarship and the arts that can be regarded as a “personal intellectual creation” are protected by copyright. Copyright protection expires 70 years after the death of the copyright holder. Mere data, e.g. measured data or survey data, and metadata (except in some cases descriptive metadata) are not protected by copyright. § 2 of the UrhG lists the following kinds of protected works (list is not concluded): 
@@ -984,13 +984,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/legal-and-ethics/intellectual-property-rights-dataset">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/legal-and-ethics/intellectual-property-rights-dataset">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>intellectual-property-rights-dataset</key>
 		<path>edu_dfg/legal-and-ethics/intellectual-property-rights-dataset</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/legal-and-ethics"/>
 		<is_collection>True</is_collection>
 		<order>31</order>
 		<title lang="en">Intellectual property rights II</title>
@@ -1002,16 +1002,16 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<verbose_name lang="de">Datensatz</verbose_name>
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/intellectual_property_rights"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/intellectual_property_rights"/>
 		</conditions>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/legal-and-ethics/intellectual-property-rights-dataset/copyrights">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/legal-and-ethics/intellectual-property-rights-dataset/copyrights">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>copyrights</key>
 		<path>edu_dfg/legal-and-ethics/intellectual-property-rights-dataset/copyrights</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/ipr/copyrights"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
 		<is_collection>True</is_collection>
 		<order>0</order>
 		<help lang="en"/>
@@ -1029,17 +1029,17 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_copyright_laws"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_copyright_laws"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/legal-and-ethics/intellectual-property-rights-dataset/other_rights">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/legal-and-ethics/intellectual-property-rights-dataset/other_rights">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>other_rights</key>
 		<path>edu_dfg/legal-and-ethics/intellectual-property-rights-dataset/other_rights</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/ipr/other_rights"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
 		<is_collection>True</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -1057,27 +1057,27 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_other_rights"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_other_rights"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/storage-and-long-term-preservation">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/storage-and-long-term-preservation">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>storage-and-long-term-preservation</key>
 		<path>edu_dfg/storage-and-long-term-preservation</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg"/>
 		<order>10</order>
 		<title lang="en">Storage and long-term preservation</title>
 		<title lang="de">Speicherung und Langzeitarchivierung</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/storage-and-long-term-preservation/long-term-preservation-datasets">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/storage-and-long-term-preservation/long-term-preservation-datasets">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>long-term-preservation-datasets</key>
 		<path>edu_dfg/storage-and-long-term-preservation/long-term-preservation-datasets</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/storage-and-long-term-preservation"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/storage-and-long-term-preservation"/>
 		<is_collection>True</is_collection>
 		<order>11</order>
 		<title lang="en">Long-term preservation</title>
@@ -1090,13 +1090,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>edu_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en"/>
@@ -1116,13 +1116,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/purpose">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/purpose">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>purpose</key>
 		<path>edu_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/purpose</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/purpose"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>True</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -1140,17 +1140,17 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/preservation_motivation_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/preservation_motivation_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/duration">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/duration">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>duration</key>
 		<path>edu_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/duration</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/duration"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>False</is_collection>
 		<order>3</order>
 		<help lang="en"/>
@@ -1170,13 +1170,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/repository">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/repository">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>repository</key>
 		<path>edu_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/repository</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/repository"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>True</is_collection>
 		<order>5</order>
 		<help lang="en"/>
@@ -1194,17 +1194,17 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/preservation_repository_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/preservation_repository_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/embargo_period">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/embargo_period">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>embargo_period</key>
 		<path>edu_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/embargo_period</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/embargo_period"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/edu_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/edu_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>False</is_collection>
 		<order>8</order>
 		<help lang="en">An embargo period is an exclusion period for subsequent use by third parties. The memorandum of the review board &quot;Educational Science&quot; of the DFG &lt;a href = &quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/richtlinien_forschungsdaten_bildungsforschung.pdf&quot; target = _ blank &quot;&gt;&quot;Bereitstellung und Nutzung quantitativer Forschungsdaten in der Bildungsforschung&quot; (in German)&lt;/a&gt; states the following: 

--- a/shared/fodako/ratswd_dfg.xml
+++ b/shared/fodako/ratswd_dfg.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <rdmo xmlns:dc="http://purl.org/dc/elements/1.1/">
-	<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<catalog dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>ratswd_dfg</key>
 		<dc:comment>Dieser Fragenkatalog ist eine Teilmenge des Katalogs &quot;RDMO&quot; und enthält nur die Fragen, die die Anforderungen
 
@@ -14,23 +14,23 @@ abdecken. Die Fragen sind somit ausgesucht für sozial- und wirtschaftswissensch
 		<title lang="en">DFG 111 Social Sciences</title>
 		<title lang="de">DFG 111 Sozialwiss.</title>
 	</catalog>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/general">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/general">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>general</key>
 		<path>ratswd_dfg/general</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg"/>
 		<order>0</order>
 		<title lang="en">General</title>
 		<title lang="de">Allgemein</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/general/other-requirements-yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/general/other-requirements-yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>other-requirements-yesno</key>
 		<path>ratswd_dfg/general/other-requirements-yesno</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/general"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/general"/>
 		<is_collection>False</is_collection>
 		<order>50</order>
 		<title lang="en">Requirements I</title>
@@ -43,13 +43,13 @@ abdecken. Die Fragen sind somit ausgesucht für sozial- und wirtschaftswissensch
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/general/other-requirements-yesno/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/general/other-requirements-yesno/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>ratswd_dfg/general/other-requirements-yesno/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/additional_rdm_policy/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/general/other-requirements-yesno"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/general/other-requirements-yesno"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<help lang="en">This catalog contains only the questions that the requirements
@@ -83,17 +83,17 @@ abdecken. Die Fragen sind außerdem konform mit den Empfehlungen in der DGS-Stel
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/other_requirements_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/other_requirements_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/general/other-requirements-requirements">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/general/other-requirements-requirements">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>other-requirements-requirements</key>
 		<path>ratswd_dfg/general/other-requirements-requirements</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/general"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/general"/>
 		<is_collection>False</is_collection>
 		<order>51</order>
 		<title lang="en">Requirements II</title>
@@ -105,16 +105,16 @@ abdecken. Die Fragen sind außerdem konform mit den Empfehlungen in der DGS-Stel
 		<verbose_name lang="de"/>
 		<verbose_name_plural lang="de"/>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/additional_rdm_policy"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/additional_rdm_policy"/>
 		</conditions>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/general/other-requirements-requirements/requirements">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/general/other-requirements-requirements/requirements">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>requirements</key>
 		<path>ratswd_dfg/general/other-requirements-requirements/requirements</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/additional_rdm_policy/requirements"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/general/other-requirements-requirements"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/general/other-requirements-requirements"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<help lang="en">Please briefly outline them and refer to more detailed sources of information if necessary. Please also indicate, if the rules / guidelines are mandatory or optional.</help>
@@ -134,23 +134,23 @@ abdecken. Die Fragen sind außerdem konform mit den Empfehlungen in der DGS-Stel
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/content-classification">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/content-classification">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>content-classification</key>
 		<path>ratswd_dfg/content-classification</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg"/>
 		<order>1</order>
 		<title lang="en">Content classification</title>
 		<title lang="de">Inhaltliche Einordnung</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/content-classification/data-dataset">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/content-classification/data-dataset">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-dataset</key>
 		<path>ratswd_dfg/content-classification/data-dataset</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/content-classification"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/content-classification"/>
 		<is_collection>True</is_collection>
 		<order>1</order>
 		<title lang="en">Datasets</title>
@@ -165,13 +165,13 @@ Die nächsten Fragen dienen zur Beschreibung der Datensätze, die im Projekt erz
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/content-classification/data-dataset/description">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/content-classification/data-dataset/description">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>description</key>
 		<path>ratswd_dfg/content-classification/data-dataset/description</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/description"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/content-classification/data-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/content-classification/data-dataset"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">Please briefly describe the data type and / or the method used to create or collect the data, for example: 
@@ -203,13 +203,13 @@ Die nächsten Fragen dienen zur Beschreibung der Datensätze, die im Projekt erz
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/content-classification/data-existing_data">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/content-classification/data-existing_data">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-existing_data</key>
 		<path>ratswd_dfg/content-classification/data-existing_data</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/content-classification"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/content-classification"/>
 		<is_collection>True</is_collection>
 		<order>2</order>
 		<title lang="en">Data origin</title>
@@ -222,13 +222,13 @@ Die nächsten Fragen dienen zur Beschreibung der Datensätze, die im Projekt erz
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/content-classification/data-existing_data/origin">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/content-classification/data-existing_data/origin">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>origin</key>
 		<path>ratswd_dfg/content-classification/data-existing_data/origin</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/origin"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/content-classification/data-existing_data"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/content-classification/data-existing_data"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en"/>
@@ -246,17 +246,17 @@ Die nächsten Fragen dienen zur Beschreibung der Datensätze, die im Projekt erz
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_origin_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_origin_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/content-classification/data-existing_data/creator_name">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/content-classification/data-existing_data/creator_name">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>creator_name</key>
 		<path>ratswd_dfg/content-classification/data-existing_data/creator_name</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/creator/name"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/content-classification/data-existing_data"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/content-classification/data-existing_data"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -276,13 +276,13 @@ Die nächsten Fragen dienen zur Beschreibung der Datensätze, die im Projekt erz
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/content-classification/data-existing_data/uri">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/content-classification/data-existing_data/uri">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>uri</key>
 		<path>ratswd_dfg/content-classification/data-existing_data/uri</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/uri"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/content-classification/data-existing_data"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/content-classification/data-existing_data"/>
 		<is_collection>False</is_collection>
 		<order>3</order>
 		<help lang="en"/>
@@ -302,13 +302,13 @@ Die nächsten Fragen dienen zur Beschreibung der Datensätze, die im Projekt erz
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/content-classification/data-reuse">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/content-classification/data-reuse">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-reuse</key>
 		<path>ratswd_dfg/content-classification/data-reuse</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/content-classification"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/content-classification"/>
 		<is_collection>True</is_collection>
 		<order>3</order>
 		<title lang="en">Reuse</title>
@@ -321,13 +321,13 @@ Die nächsten Fragen dienen zur Beschreibung der Datensätze, die im Projekt erz
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/content-classification/data-reuse/scenario">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/content-classification/data-reuse/scenario">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>scenario</key>
 		<path>ratswd_dfg/content-classification/data-reuse/scenario</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/reuse_scenario"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/content-classification/data-reuse"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/content-classification/data-reuse"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">Probably the most important consequence is the fundamental course setting under which of the six in the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/basisinformationen_forschungsdatenmanagement.pdf&quot; target=_blank&gt; Basic information about the research data management &lt;/a&gt; (German) of the RatSWD mentioned variants the dataset falls. At this point, therefore, indicate which variant you want to follow and justify your decision. Of course, the re-use potential can not be the sole criterion for decision-making, but legal impediments (such as data protection and copyright) and research ethical limits must be taken into account. Otherwise, consider the re-use potential against the disadvantages, e.g. a decrease in the readiness to participate and the expected extra effort of a data publication.</help>
@@ -347,23 +347,23 @@ Die nächsten Fragen dienen zur Beschreibung der Datensätze, die im Projekt erz
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/technical-classification">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/technical-classification">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>technical-classification</key>
 		<path>ratswd_dfg/technical-classification</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg"/>
 		<order>2</order>
 		<title lang="en">Technical classification</title>
 		<title lang="de">Technische Einordnung</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/technical-classification/data-formats">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/technical-classification/data-formats">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-formats</key>
 		<path>ratswd_dfg/technical-classification/data-formats</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/technical-classification"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/technical-classification"/>
 		<is_collection>True</is_collection>
 		<order>3</order>
 		<title lang="en">Formats</title>
@@ -376,13 +376,13 @@ Die nächsten Fragen dienen zur Beschreibung der Datensätze, die im Projekt erz
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/technical-classification/data-formats/format">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/technical-classification/data-formats/format">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>format</key>
 		<path>ratswd_dfg/technical-classification/data-formats/format</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/format"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/technical-classification/data-formats"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/technical-classification/data-formats"/>
 		<is_collection>False</is_collection>
 		<order>4</order>
 		<help lang="en">When choosing a data format, one should consider the consequences for collaborative use, long-term preservation as well as re-use. It is advisable to prefer formats that are standardised, open, non-proprietary and well-established in the respective scholarly community. A table with recommended file formats can be found in Kristin Briney, &lt;i&gt;Data Management for Researchers&lt;/i&gt;, Pelargic, 2015, pages 133-134.</help>
@@ -402,13 +402,13 @@ Die nächsten Fragen dienen zur Beschreibung der Datensätze, die im Projekt erz
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/technical-classification/data-tools">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/technical-classification/data-tools">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-tools</key>
 		<path>ratswd_dfg/technical-classification/data-tools</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/technical-classification"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/technical-classification"/>
 		<is_collection>True</is_collection>
 		<order>4</order>
 		<title lang="en">Tools</title>
@@ -421,13 +421,13 @@ Die nächsten Fragen dienen zur Beschreibung der Datensätze, die im Projekt erz
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/technical-classification/data-tools/creation_methods">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/technical-classification/data-tools/creation_methods">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>creation_methods</key>
 		<path>ratswd_dfg/technical-classification/data-tools/creation_methods</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/creation_methods"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/technical-classification/data-tools"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/technical-classification/data-tools"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">This information is necessary to be able to reconstruct the process by which the data was generated. It is also a prerequisite to judge the objectivity, reliability and validity of the dataset. For reproducible data, it is also required to re-generate the data if need be.</help>
@@ -447,13 +447,13 @@ Die nächsten Fragen dienen zur Beschreibung der Datensätze, die im Projekt erz
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/technical-classification/data-tools/usage_technology">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/technical-classification/data-tools/usage_technology">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>usage_technology</key>
 		<path>ratswd_dfg/technical-classification/data-tools/usage_technology</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/usage_technology"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/technical-classification/data-tools"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/technical-classification/data-tools"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en">To be able to re-use data (e.g. to replicate studies, for meta analysis or to solve new research questions), along with the data the software, equipment and knowledge about special methods to use the data are required . Just as with
@@ -475,13 +475,13 @@ Die nächsten Fragen dienen zur Beschreibung der Datensätze, die im Projekt erz
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/technical-classification/data-tools/documentation">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/technical-classification/data-tools/documentation">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>documentation</key>
 		<path>ratswd_dfg/technical-classification/data-tools/documentation</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/software_documentation"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/technical-classification/data-tools"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/technical-classification/data-tools"/>
 		<is_collection>False</is_collection>
 		<order>3</order>
 		<help lang="en"/>
@@ -501,23 +501,23 @@ Die nächsten Fragen dienen zur Beschreibung der Datensätze, die im Projekt erz
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/data-usage">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/data-usage">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-usage</key>
 		<path>ratswd_dfg/data-usage</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg"/>
 		<order>3</order>
 		<title lang="en">Data usage</title>
 		<title lang="de">Datennutzung</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/data-usage/data-storage-and-security-storage">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/data-usage/data-storage-and-security-storage">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-storage-and-security-storage</key>
 		<path>ratswd_dfg/data-usage/data-storage-and-security-storage</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/data-usage"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/data-usage"/>
 		<is_collection>True</is_collection>
 		<order>11</order>
 		<title lang="en">Data organisation</title>
@@ -530,13 +530,13 @@ Die nächsten Fragen dienen zur Beschreibung der Datensätze, die im Projekt erz
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/data-usage/data-storage-and-security-storage/type">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/data-usage/data-storage-and-security-storage/type">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>type</key>
 		<path>ratswd_dfg/data-usage/data-storage-and-security-storage/type</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/storage/type"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/data-usage/data-storage-and-security-storage"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/data-usage/data-storage-and-security-storage"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">If parts of the documentation or related software (custom development) are not stored with the data, also indicate where they are stored. This applies to the documentation of the software too.</help>
@@ -556,13 +556,13 @@ Die nächsten Fragen dienen zur Beschreibung der Datensätze, die im Projekt erz
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/data-usage/data-storage-and-security-data_security">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/data-usage/data-storage-and-security-data_security">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-storage-and-security-data_security</key>
 		<path>ratswd_dfg/data-usage/data-storage-and-security-data_security</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/data-usage"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/data-usage"/>
 		<is_collection>True</is_collection>
 		<order>12</order>
 		<title lang="en">Data storage and security</title>
@@ -575,13 +575,13 @@ Die nächsten Fragen dienen zur Beschreibung der Datensätze, die im Projekt erz
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/data-usage/data-storage-and-security-data_security/access_permissions">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/data-usage/data-storage-and-security-data_security/access_permissions">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>access_permissions</key>
 		<path>ratswd_dfg/data-usage/data-storage-and-security-data_security/access_permissions</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/data_security/access_permissions"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/data-usage/data-storage-and-security-data_security"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/data-usage/data-storage-and-security-data_security"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en"/>
@@ -601,13 +601,13 @@ Die nächsten Fragen dienen zur Beschreibung der Datensätze, die im Projekt erz
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/data-usage/data-storage-and-security-data_security/backups">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/data-usage/data-storage-and-security-data_security/backups">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>backups</key>
 		<path>ratswd_dfg/data-usage/data-storage-and-security-data_security/backups</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/data_security/backups"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/data-usage/data-storage-and-security-data_security"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/data-usage/data-storage-and-security-data_security"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en">This question refers to backups while the data is being worked with. Questions of long-term preservation will be adressed in the respective section.</help>
@@ -627,13 +627,13 @@ Die nächsten Fragen dienen zur Beschreibung der Datensätze, die im Projekt erz
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/data-usage/data-storage-and-security-data_security/security_measures">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/data-usage/data-storage-and-security-data_security/security_measures">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>security_measures</key>
 		<path>ratswd_dfg/data-usage/data-storage-and-security-data_security/security_measures</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/data_security/security_measures"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/data-usage/data-storage-and-security-data_security"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/data-usage/data-storage-and-security-data_security"/>
 		<is_collection>False</is_collection>
 		<order>4</order>
 		<help lang="en"/>
@@ -653,13 +653,13 @@ Die nächsten Fragen dienen zur Beschreibung der Datensätze, die im Projekt erz
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/data-usage/data-sharing-and-re-use-publication">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/data-usage/data-sharing-and-re-use-publication">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-sharing-and-re-use-publication</key>
 		<path>ratswd_dfg/data-usage/data-sharing-and-re-use-publication</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/data-usage"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/data-usage"/>
 		<is_collection>True</is_collection>
 		<order>52</order>
 		<title lang="en">Data sharing and re-use</title>
@@ -672,13 +672,13 @@ Die nächsten Fragen dienen zur Beschreibung der Datensätze, die im Projekt erz
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/data-usage/data-sharing-and-re-use-publication/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/data-usage/data-sharing-and-re-use-publication/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>ratswd_dfg/data-usage/data-sharing-and-re-use-publication/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sharing/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/data-usage/data-sharing-and-re-use-publication"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/data-usage/data-sharing-and-re-use-publication"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en"/>
@@ -696,17 +696,17 @@ Die nächsten Fragen dienen zur Beschreibung der Datensätze, die im Projekt erz
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_sharing_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_sharing_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/data-usage/data-sharing-and-re-use-publication/explanation">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/data-usage/data-sharing-and-re-use-publication/explanation">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>explanation</key>
 		<path>ratswd_dfg/data-usage/data-sharing-and-re-use-publication/explanation</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sharing/explanation"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/data-usage/data-sharing-and-re-use-publication"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/data-usage/data-sharing-and-re-use-publication"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -726,13 +726,13 @@ Die nächsten Fragen dienen zur Beschreibung der Datensätze, die im Projekt erz
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/data-usage/data-sharing-and-re-use-publication/conditions">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/data-usage/data-sharing-and-re-use-publication/conditions">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>conditions</key>
 		<path>ratswd_dfg/data-usage/data-sharing-and-re-use-publication/conditions</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sharing/conditions"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/data-usage/data-sharing-and-re-use-publication"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/data-usage/data-sharing-and-re-use-publication"/>
 		<is_collection>True</is_collection>
 		<order>3</order>
 		<help lang="en">The options refer to the licenses of the &lt;a href=&quot;https://creativecommons.org/share-your-work/licensing-types-examples/&quot; target=_blank&quot;&gt;Creative Commons family&lt;/a&gt;.</help>
@@ -750,17 +750,17 @@ Die nächsten Fragen dienen zur Beschreibung der Datensätze, die im Projekt erz
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_license_types"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_license_types"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/data-usage/data-sharing-and-re-use-publication/data_publication_date">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/data-usage/data-sharing-and-re-use-publication/data_publication_date">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data_publication_date</key>
 		<path>ratswd_dfg/data-usage/data-sharing-and-re-use-publication/data_publication_date</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/data_publication_date"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/data-usage/data-sharing-and-re-use-publication"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/data-usage/data-sharing-and-re-use-publication"/>
 		<is_collection>False</is_collection>
 		<order>6</order>
 		<help lang="en"/>
@@ -779,16 +779,16 @@ Die nächsten Fragen dienen zur Beschreibung der Datensätze, die im Projekt erz
 		<unit/>
 		<optionsets/>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/data_sharing"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/data_sharing"/>
 		</conditions>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/data-usage/quality-assurance-dataset">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/data-usage/quality-assurance-dataset">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>quality-assurance-dataset</key>
 		<path>ratswd_dfg/data-usage/quality-assurance-dataset</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/data-usage"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/data-usage"/>
 		<is_collection>True</is_collection>
 		<order>61</order>
 		<title lang="en">Quality assurance</title>
@@ -801,13 +801,13 @@ Die nächsten Fragen dienen zur Beschreibung der Datensätze, die im Projekt erz
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/data-usage/quality-assurance-dataset/measures">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/data-usage/quality-assurance-dataset/measures">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>measures</key>
 		<path>ratswd_dfg/data-usage/quality-assurance-dataset/measures</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/quality_assurance"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/data-usage/quality-assurance-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/data-usage/quality-assurance-dataset"/>
 		<is_collection>False</is_collection>
 		<order>7</order>
 		<help lang="en"/>
@@ -827,23 +827,23 @@ Die nächsten Fragen dienen zur Beschreibung der Datensätze, die im Projekt erz
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/doc">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/doc">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>doc</key>
 		<path>ratswd_dfg/doc</path>
 		<dc:comment>hervorgegangen aus dem Abschnitt &quot;Metadaten und Referenzierung&quot; des Katalogs &quot;RDMO&quot;</dc:comment>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg"/>
 		<order>4</order>
 		<title lang="en">Documentation</title>
 		<title lang="de">Dokumentation</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/doc/metadata-dataset">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/doc/metadata-dataset">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>metadata-dataset</key>
 		<path>ratswd_dfg/doc/metadata-dataset</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/doc"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/doc"/>
 		<is_collection>True</is_collection>
 		<order>10</order>
 		<title lang="en">Metadata and data documentation</title>
@@ -856,13 +856,13 @@ Die nächsten Fragen dienen zur Beschreibung der Datensätze, die im Projekt erz
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/doc/metadata-dataset/standards">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/doc/metadata-dataset/standards">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>standards</key>
 		<path>ratswd_dfg/doc/metadata-dataset/standards</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/metadata/standards"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/doc/metadata-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/doc/metadata-dataset"/>
 		<is_collection>True</is_collection>
 		<order>1</order>
 		<help lang="en">Also specify the metadata standard if it is already clear which one to use, e.g. because the repository specifies one.</help>
@@ -880,17 +880,17 @@ Die nächsten Fragen dienen zur Beschreibung der Datensätze, die im Projekt erz
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/metadata_standards"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/metadata_standards"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/doc/metadata-dataset/quality_assurance">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/doc/metadata-dataset/quality_assurance">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>quality_assurance</key>
 		<path>ratswd_dfg/doc/metadata-dataset/quality_assurance</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/metadata/quality_assurance"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/doc/metadata-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/doc/metadata-dataset"/>
 		<is_collection>True</is_collection>
 		<order>6</order>
 		<help lang="en"/>
@@ -908,27 +908,27 @@ Die nächsten Fragen dienen zur Beschreibung der Datensätze, die im Projekt erz
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/metadata_check_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/metadata_check_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/legal-and-ethics">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/legal-and-ethics">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>legal-and-ethics</key>
 		<path>ratswd_dfg/legal-and-ethics</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg"/>
 		<order>5</order>
 		<title lang="en">Legal and ethics</title>
 		<title lang="de">Rechtliche und ethische Fragen</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/legal-and-ethics/sensitive-data-personal_data_yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/legal-and-ethics/sensitive-data-personal_data_yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>sensitive-data-personal_data_yesno</key>
 		<path>ratswd_dfg/legal-and-ethics/sensitive-data-personal_data_yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/legal-and-ethics"/>
 		<is_collection>True</is_collection>
 		<order>21</order>
 		<title lang="en">Personal data</title>
@@ -941,13 +941,13 @@ Die nächsten Fragen dienen zur Beschreibung der Datensätze, die im Projekt erz
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/legal-and-ethics/sensitive-data-personal_data_yesno/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/legal-and-ethics/sensitive-data-personal_data_yesno/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>ratswd_dfg/legal-and-ethics/sensitive-data-personal_data_yesno/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sensitive_data/personal_data_yesno/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/legal-and-ethics/sensitive-data-personal_data_yesno"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/legal-and-ethics/sensitive-data-personal_data_yesno"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">The EU General Data Protection Regulation (GDPR) defines in Art. 4 personal data as &quot;any information relating to an identified or identifiable natural person&quot;. An identifiable natural person is &quot;one who can be identified, directly or indirectly, in particular by reference to an identifier such as a name, an identification number, location data, an online identifier or to one or more factors specific to the physical, physiological, genetic, mental, economic, cultural or social identity of that natural person&quot;.</help>
@@ -967,13 +967,13 @@ Die nächsten Fragen dienen zur Beschreibung der Datensätze, die im Projekt erz
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/legal-and-ethics/sensitive-data-personal_data">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/legal-and-ethics/sensitive-data-personal_data">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>sensitive-data-personal_data</key>
 		<path>ratswd_dfg/legal-and-ethics/sensitive-data-personal_data</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/legal-and-ethics"/>
 		<is_collection>True</is_collection>
 		<order>24</order>
 		<title lang="en">Sensitive data</title>
@@ -985,16 +985,16 @@ Die nächsten Fragen dienen zur Beschreibung der Datensätze, die im Projekt erz
 		<verbose_name lang="de">Datensatz</verbose_name>
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/personal_data"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/personal_data"/>
 		</conditions>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/legal-and-ethics/sensitive-data-personal_data/anonymization">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/legal-and-ethics/sensitive-data-personal_data/anonymization">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>anonymization</key>
 		<path>ratswd_dfg/legal-and-ethics/sensitive-data-personal_data/anonymization</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sensitive_data/personal_data/anonymization"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/legal-and-ethics/sensitive-data-personal_data"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/legal-and-ethics/sensitive-data-personal_data"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -1012,17 +1012,17 @@ Die nächsten Fragen dienen zur Beschreibung der Datensätze, die im Projekt erz
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_anonymisation"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_anonymisation"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/legal-and-ethics/sensitive-data-personal_data/extent">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/legal-and-ethics/sensitive-data-personal_data/extent">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>extent</key>
 		<path>ratswd_dfg/legal-and-ethics/sensitive-data-personal_data/extent</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sensitive_data/personal_data/consent/extent"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/legal-and-ethics/sensitive-data-personal_data"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/legal-and-ethics/sensitive-data-personal_data"/>
 		<is_collection>False</is_collection>
 		<order>3</order>
 		<help lang="en">Basically, the collection, processing, archiving and publication of personal data is only admissible, when the “informed consent” of the person in question has been obtained. However, there are a number of exceptions, some of which are described in Art. 6 of the General Data Protection Regulation or which have been made possible by law. For example, § 17 Datenschutzgesetz Nordrhein-Westfalen (DSG-NRW, 17 Mai 2018) allows the processing of personal data for scientific or historical research purposes or for statistical purposes even without consent if processing for these purposes is necessary and protected interests of the person concerned do not prevail.</help>
@@ -1040,17 +1040,17 @@ Die nächsten Fragen dienen zur Beschreibung der Datensätze, die im Projekt erz
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/informed_consent_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/informed_consent_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/legal-and-ethics/sensitive-data-personal_data/statement">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/legal-and-ethics/sensitive-data-personal_data/statement">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>statement</key>
 		<path>ratswd_dfg/legal-and-ethics/sensitive-data-personal_data/statement</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sensitive_data/personal_data/consent/statement"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/legal-and-ethics/sensitive-data-personal_data"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/legal-and-ethics/sensitive-data-personal_data"/>
 		<is_collection>False</is_collection>
 		<order>4</order>
 		<help lang="en"/>
@@ -1070,13 +1070,13 @@ Die nächsten Fragen dienen zur Beschreibung der Datensätze, die im Projekt erz
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/legal-and-ethics/sensitive-data-personal_data/record">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/legal-and-ethics/sensitive-data-personal_data/record">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>record</key>
 		<path>ratswd_dfg/legal-and-ethics/sensitive-data-personal_data/record</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sensitive_data/personal_data/consent/record"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/legal-and-ethics/sensitive-data-personal_data"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/legal-and-ethics/sensitive-data-personal_data"/>
 		<is_collection>False</is_collection>
 		<order>5</order>
 		<help lang="en"/>
@@ -1096,13 +1096,13 @@ Die nächsten Fragen dienen zur Beschreibung der Datensätze, die im Projekt erz
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/legal-and-ethics/sensitive-data-personal_data/deletion">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/legal-and-ethics/sensitive-data-personal_data/deletion">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>deletion</key>
 		<path>ratswd_dfg/legal-and-ethics/sensitive-data-personal_data/deletion</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sensitive_data/personal_data/deletion"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/legal-and-ethics/sensitive-data-personal_data"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/legal-and-ethics/sensitive-data-personal_data"/>
 		<is_collection>False</is_collection>
 		<order>6</order>
 		<help lang="en"/>
@@ -1122,13 +1122,13 @@ Die nächsten Fragen dienen zur Beschreibung der Datensätze, die im Projekt erz
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/legal-and-ethics/sensitive-data-official_approval">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/legal-and-ethics/sensitive-data-official_approval">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>sensitive-data-official_approval</key>
 		<path>ratswd_dfg/legal-and-ethics/sensitive-data-official_approval</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/legal-and-ethics"/>
 		<is_collection>False</is_collection>
 		<order>28</order>
 		<title lang="en">Official approval</title>
@@ -1141,13 +1141,13 @@ Die nächsten Fragen dienen zur Beschreibung der Datensätze, die im Projekt erz
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/legal-and-ethics/sensitive-data-official_approval/ethics_committee">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/legal-and-ethics/sensitive-data-official_approval/ethics_committee">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>ethics_committee</key>
 		<path>ratswd_dfg/legal-and-ethics/sensitive-data-official_approval/ethics_committee</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/legal_aspects/official_approval/ethics_committee"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/legal-and-ethics/sensitive-data-official_approval"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/legal-and-ethics/sensitive-data-official_approval"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en"/>
@@ -1165,17 +1165,17 @@ Die nächsten Fragen dienen zur Beschreibung der Datensätze, die im Projekt erz
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/ethics_committee_approval_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/ethics_committee_approval_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/legal-and-ethics/intellectual-property-rights-yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/legal-and-ethics/intellectual-property-rights-yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>intellectual-property-rights-yesno</key>
 		<path>ratswd_dfg/legal-and-ethics/intellectual-property-rights-yesno</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/legal-and-ethics"/>
 		<is_collection>False</is_collection>
 		<order>30</order>
 		<title lang="en">Intellectual property rights I</title>
@@ -1188,13 +1188,13 @@ Die nächsten Fragen dienen zur Beschreibung der Datensätze, die im Projekt erz
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/legal-and-ethics/intellectual-property-rights-yesno/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/legal-and-ethics/intellectual-property-rights-yesno/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>ratswd_dfg/legal-and-ethics/intellectual-property-rights-yesno/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/legal_aspects/ipr/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/legal-and-ethics/intellectual-property-rights-yesno"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/legal-and-ethics/intellectual-property-rights-yesno"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<help lang="en">Data or software can be subject to intellectual or industrial property rights. Applicable laws differ broadly even within EU. According to the German copyright law (UrhG) works of literature, scholarship and the arts that can be regarded as a “personal intellectual creation” are protected by copyright. Copyright protection expires 70 years after the death of the copyright holder. Mere data, e.g. measured data or survey data, and metadata (except in some cases descriptive metadata) are not protected by copyright. § 2 of the UrhG lists the following kinds of protected works (list is not concluded): 
@@ -1243,13 +1243,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/legal-and-ethics/intellectual-property-rights-dataset">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/legal-and-ethics/intellectual-property-rights-dataset">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>intellectual-property-rights-dataset</key>
 		<path>ratswd_dfg/legal-and-ethics/intellectual-property-rights-dataset</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/legal-and-ethics"/>
 		<is_collection>True</is_collection>
 		<order>31</order>
 		<title lang="en">Intellectual property rights II</title>
@@ -1261,16 +1261,16 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<verbose_name lang="de">Datensatz</verbose_name>
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/intellectual_property_rights"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/intellectual_property_rights"/>
 		</conditions>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/legal-and-ethics/intellectual-property-rights-dataset/copyrights">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/legal-and-ethics/intellectual-property-rights-dataset/copyrights">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>copyrights</key>
 		<path>ratswd_dfg/legal-and-ethics/intellectual-property-rights-dataset/copyrights</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/ipr/copyrights"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
 		<is_collection>True</is_collection>
 		<order>0</order>
 		<help lang="en"/>
@@ -1288,17 +1288,17 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_copyright_laws"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_copyright_laws"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/legal-and-ethics/intellectual-property-rights-dataset/other_rights">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/legal-and-ethics/intellectual-property-rights-dataset/other_rights">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>other_rights</key>
 		<path>ratswd_dfg/legal-and-ethics/intellectual-property-rights-dataset/other_rights</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/ipr/other_rights"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
 		<is_collection>True</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -1316,27 +1316,27 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_other_rights"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_other_rights"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/storage-and-long-term-preservation">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/storage-and-long-term-preservation">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>storage-and-long-term-preservation</key>
 		<path>ratswd_dfg/storage-and-long-term-preservation</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg"/>
 		<order>10</order>
 		<title lang="en">Storage and long-term preservation</title>
 		<title lang="de">Speicherung und Langzeitarchivierung</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/storage-and-long-term-preservation/long-term-preservation-datasets">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/storage-and-long-term-preservation/long-term-preservation-datasets">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>long-term-preservation-datasets</key>
 		<path>ratswd_dfg/storage-and-long-term-preservation/long-term-preservation-datasets</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/storage-and-long-term-preservation"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/storage-and-long-term-preservation"/>
 		<is_collection>True</is_collection>
 		<order>11</order>
 		<title lang="en">Long-term preservation</title>
@@ -1349,13 +1349,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>ratswd_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en"/>
@@ -1375,13 +1375,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/purpose">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/purpose">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>purpose</key>
 		<path>ratswd_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/purpose</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/purpose"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>True</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -1399,17 +1399,17 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/preservation_motivation_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/preservation_motivation_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/duration">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/duration">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>duration</key>
 		<path>ratswd_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/duration</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/duration"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>False</is_collection>
 		<order>3</order>
 		<help lang="en"/>
@@ -1429,13 +1429,13 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/repository">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/repository">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>repository</key>
 		<path>ratswd_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/repository</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/repository"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>True</is_collection>
 		<order>5</order>
 		<help lang="en"/>
@@ -1453,17 +1453,17 @@ Nach § 3 sind auch „Übersetzungen und andere Bearbeitungen“ von Werken ges
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/preservation_repository_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/preservation_repository_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/access_authentication">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/access_authentication">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>access_authentication</key>
 		<path>ratswd_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/access_authentication</path>
 		<dc:comment>Original from H2020 FAIR Data Management Plan</dc:comment>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/access_authentication"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/ratswd_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/ratswd_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>False</is_collection>
 		<order>9</order>
 		<help lang="en"/>

--- a/shared/fodako/spokencorpus_dfg.xml
+++ b/shared/fodako/spokencorpus_dfg.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <rdmo xmlns:dc="http://purl.org/dc/elements/1.1/">
-	<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<catalog dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>spokencorpus_dfg</key>
 		<dc:comment>Dieser Fragenkatalog ist eine Teilmenge des Katalogs &quot;Alle Fragen&quot; (eine Überarbeitung des Katalogs &quot;RDMO&quot;) und enthält nur die Fragen, die die Anforderungen in den 
 
@@ -18,23 +18,23 @@ abdecken. Die Ausfüllhilfen geben Hinweise für Sprachkorpus-Projekte.</dc:comm
 		<title lang="en">DFG 104 Spoken corpus</title>
 		<title lang="de">DFG 104 Mündlicher Korpus</title>
 	</catalog>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/general">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/general">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>general</key>
 		<path>spokencorpus_dfg/general</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg"/>
 		<order>0</order>
 		<title lang="en">General</title>
 		<title lang="de">Allgemein</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/general/other-requirements-yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/general/other-requirements-yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>other-requirements-yesno</key>
 		<path>spokencorpus_dfg/general/other-requirements-yesno</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/general"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/general"/>
 		<is_collection>False</is_collection>
 		<order>50</order>
 		<title lang="en">Requirements I</title>
@@ -47,13 +47,13 @@ abdecken. Die Ausfüllhilfen geben Hinweise für Sprachkorpus-Projekte.</dc:comm
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/general/other-requirements-yesno/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/general/other-requirements-yesno/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>spokencorpus_dfg/general/other-requirements-yesno/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/additional_rdm_policy/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/general/other-requirements-yesno"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/general/other-requirements-yesno"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<help lang="en">For example, the DFG Review Board on Linguistics has published the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/grundlagen_dfg_foerderung/informationen_fachwissenschaften/geisteswissenschaften/standards_sprachkorpora.pdf&quot; target=_blank&quot;&gt; Recommendations on data technology standards and tools for the collection of spoken corpora &lt;/a&gt; (in German). This questionnaire takes into account these recommendations, the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/guidelines_review_board_linguistics_corpora.pdf&quot; target=_blank&gt;Information for Building Language Corpora Under German Law&lt;/a&gt; and the interdisplinary &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/guidelines_research_data.pdf&quot; target=_blank&gt;DFG Guidelines on the Handling of Research Data&lt;/a&gt;.</help>
@@ -71,17 +71,17 @@ abdecken. Die Ausfüllhilfen geben Hinweise für Sprachkorpus-Projekte.</dc:comm
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/other_requirements_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/other_requirements_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/general/other-requirements-requirements">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/general/other-requirements-requirements">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>other-requirements-requirements</key>
 		<path>spokencorpus_dfg/general/other-requirements-requirements</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/general"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/general"/>
 		<is_collection>False</is_collection>
 		<order>51</order>
 		<title lang="en">Requirements II</title>
@@ -93,16 +93,16 @@ abdecken. Die Ausfüllhilfen geben Hinweise für Sprachkorpus-Projekte.</dc:comm
 		<verbose_name lang="de"/>
 		<verbose_name_plural lang="de"/>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/additional_rdm_policy"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/additional_rdm_policy"/>
 		</conditions>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/general/other-requirements-requirements/requirements">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/general/other-requirements-requirements/requirements">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>requirements</key>
 		<path>spokencorpus_dfg/general/other-requirements-requirements/requirements</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/additional_rdm_policy/requirements"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/general/other-requirements-requirements"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/general/other-requirements-requirements"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<help lang="en">The German Research Foundation has published the following requirements and recommendations:
@@ -134,23 +134,23 @@ Darüber hinaus wurde 2016 der Standard &quot;ISO 24624:2016: Language resource 
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/content-classification">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/content-classification">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>content-classification</key>
 		<path>spokencorpus_dfg/content-classification</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg"/>
 		<order>1</order>
 		<title lang="en">Content classification</title>
 		<title lang="de">Inhaltliche Einordnung</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/content-classification/data-dataset">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/content-classification/data-dataset">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-dataset</key>
 		<path>spokencorpus_dfg/content-classification/data-dataset</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/content-classification"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/content-classification"/>
 		<is_collection>True</is_collection>
 		<order>1</order>
 		<title lang="en">Datasets</title>
@@ -163,13 +163,13 @@ Darüber hinaus wurde 2016 der Standard &quot;ISO 24624:2016: Language resource 
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/content-classification/data-dataset/description">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/content-classification/data-dataset/description">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>description</key>
 		<path>spokencorpus_dfg/content-classification/data-dataset/description</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/description"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/content-classification/data-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/content-classification/data-dataset"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">Please describe the type of data involved and the method used to collect or create the data. From the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/grundlagen_dfg_foerderung/informationen_fachwissenschaften/geisteswissenschaften/standards_sprachkorpora.pdf&quot; target=_blank&quot;&gt; Recommendations on data technology standards and tools for the collection of corpora&lt;/a&gt;, Part 1:
@@ -201,13 +201,13 @@ Für bestimmte kommunikative Ereignisse ist es sinnvoll und empfehlenswert, für
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/content-classification/data-reuse">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/content-classification/data-reuse">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-reuse</key>
 		<path>spokencorpus_dfg/content-classification/data-reuse</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/content-classification"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/content-classification"/>
 		<is_collection>True</is_collection>
 		<order>3</order>
 		<title lang="en">Reuse</title>
@@ -220,13 +220,13 @@ Für bestimmte kommunikative Ereignisse ist es sinnvoll und empfehlenswert, für
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/content-classification/data-reuse/scenario">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/content-classification/data-reuse/scenario">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>scenario</key>
 		<path>spokencorpus_dfg/content-classification/data-reuse/scenario</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/reuse_scenario"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/content-classification/data-reuse"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/content-classification/data-reuse"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">It is important to set the fundamental course as to whether or not the data will be permitted for reuse. Of course, the potential for subsequent use can not be the sole decision criterion, but legal impediments, such as privacy, copyright and contracts with project partners must be taken into account. Otherwise, consider the re-use potential against the disadvantages, e.g. a decrease in the readiness to participate.
@@ -254,23 +254,23 @@ Sinn der Empfehlungen zur Standardisierung bei der Erstellung von Primärdaten (
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/technical-classification">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/technical-classification">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>technical-classification</key>
 		<path>spokencorpus_dfg/technical-classification</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg"/>
 		<order>2</order>
 		<title lang="en">Technical classification</title>
 		<title lang="de">Technische Einordnung</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/technical-classification/data-formats">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/technical-classification/data-formats">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-formats</key>
 		<path>spokencorpus_dfg/technical-classification/data-formats</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/technical-classification"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/technical-classification"/>
 		<is_collection>True</is_collection>
 		<order>3</order>
 		<title lang="en">Formats</title>
@@ -283,13 +283,13 @@ Sinn der Empfehlungen zur Standardisierung bei der Erstellung von Primärdaten (
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/technical-classification/data-formats/format">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/technical-classification/data-formats/format">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>format</key>
 		<path>spokencorpus_dfg/technical-classification/data-formats/format</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/format"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/technical-classification/data-formats"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/technical-classification/data-formats"/>
 		<is_collection>False</is_collection>
 		<order>4</order>
 		<help lang="en">From the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/grundlagen_dfg_foerderung/informationen_fachwissenschaften/geisteswissenschaften/standards_sprachkorpora.pdf&quot; target=_blank&quot;&gt; Recommendations on data technology standards and tools for the collection of corpora &lt;/a&gt; (in German), Part 1, spoken corpora:
@@ -349,13 +349,13 @@ Für die Transkription und weitere Annotation mündlicher Daten ist in den letzt
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/technical-classification/data-tools">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/technical-classification/data-tools">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-tools</key>
 		<path>spokencorpus_dfg/technical-classification/data-tools</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/technical-classification"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/technical-classification"/>
 		<is_collection>False</is_collection>
 		<order>4</order>
 		<title lang="en">Tools</title>
@@ -368,13 +368,13 @@ Für die Transkription und weitere Annotation mündlicher Daten ist in den letzt
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/technical-classification/data-tools/creation_methods">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/technical-classification/data-tools/creation_methods">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>creation_methods</key>
 		<path>spokencorpus_dfg/technical-classification/data-tools/creation_methods</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/creation_methods"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/technical-classification/data-tools"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/technical-classification/data-tools"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">&lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/grundlagen_dfg_foerderung/informationen_fachwissenschaften/geisteswissenschaften/standards_sprachkorpora.pdf&quot; target=_blank&gt; Recommendations on data technology standards and tools for the collection of corpora &lt;/a&gt; (in German) concerning transcription and further annotation:
@@ -432,23 +432,23 @@ Die Auswahl eines Transkriptionssystems und erst recht die Entscheidung, welche 
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/data-usage">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/data-usage">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-usage</key>
 		<path>spokencorpus_dfg/data-usage</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg"/>
 		<order>3</order>
 		<title lang="en">Data usage</title>
 		<title lang="de">Datennutzung</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/data-usage/data-storage-and-security-storage">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/data-usage/data-storage-and-security-storage">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-storage-and-security-storage</key>
 		<path>spokencorpus_dfg/data-usage/data-storage-and-security-storage</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/data-usage"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/data-usage"/>
 		<is_collection>True</is_collection>
 		<order>11</order>
 		<title lang="en">Data organisation</title>
@@ -461,13 +461,13 @@ Die Auswahl eines Transkriptionssystems und erst recht die Entscheidung, welche 
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/data-usage/data-storage-and-security-storage/type">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/data-usage/data-storage-and-security-storage/type">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>type</key>
 		<path>spokencorpus_dfg/data-usage/data-storage-and-security-storage/type</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/storage/type"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/data-usage/data-storage-and-security-storage"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/data-usage/data-storage-and-security-storage"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">If parts of the documentation or related software (custom development) are not stored with the data, also indicate where they are stored. This applies to the documentation of the software too.</help>
@@ -487,13 +487,13 @@ Die Auswahl eines Transkriptionssystems und erst recht die Entscheidung, welche 
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/data-usage/data-storage-and-security-data_security">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/data-usage/data-storage-and-security-data_security">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-storage-and-security-data_security</key>
 		<path>spokencorpus_dfg/data-usage/data-storage-and-security-data_security</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/data-usage"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/data-usage"/>
 		<is_collection>True</is_collection>
 		<order>12</order>
 		<title lang="en">Data storage and security</title>
@@ -506,13 +506,13 @@ Die Auswahl eines Transkriptionssystems und erst recht die Entscheidung, welche 
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/data-usage/data-storage-and-security-data_security/backups">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/data-usage/data-storage-and-security-data_security/backups">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>backups</key>
 		<path>spokencorpus_dfg/data-usage/data-storage-and-security-data_security/backups</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/data_security/backups"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/data-usage/data-storage-and-security-data_security"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/data-usage/data-storage-and-security-data_security"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en">This question refers to backups while the data is being worked with. Questions of long-term preservation will be adressed in the respective section.
@@ -540,13 +540,13 @@ Aufnahmen sollten möglichst unmittelbar nach der Erhebung vom Aufnahmegerät au
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/data-usage/data-sharing-and-re-use-publication">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/data-usage/data-sharing-and-re-use-publication">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-sharing-and-re-use-publication</key>
 		<path>spokencorpus_dfg/data-usage/data-sharing-and-re-use-publication</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/data-usage"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/data-usage"/>
 		<is_collection>True</is_collection>
 		<order>52</order>
 		<title lang="en">Data sharing and re-use</title>
@@ -559,13 +559,13 @@ Aufnahmen sollten möglichst unmittelbar nach der Erhebung vom Aufnahmegerät au
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/data-usage/data-sharing-and-re-use-publication/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/data-usage/data-sharing-and-re-use-publication/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>spokencorpus_dfg/data-usage/data-sharing-and-re-use-publication/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sharing/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/data-usage/data-sharing-and-re-use-publication"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/data-usage/data-sharing-and-re-use-publication"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en"/>
@@ -583,17 +583,17 @@ Aufnahmen sollten möglichst unmittelbar nach der Erhebung vom Aufnahmegerät au
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_sharing_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_sharing_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/data-usage/data-sharing-and-re-use-publication/explanation">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/data-usage/data-sharing-and-re-use-publication/explanation">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>explanation</key>
 		<path>spokencorpus_dfg/data-usage/data-sharing-and-re-use-publication/explanation</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sharing/explanation"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/data-usage/data-sharing-and-re-use-publication"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/data-usage/data-sharing-and-re-use-publication"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -613,13 +613,13 @@ Aufnahmen sollten möglichst unmittelbar nach der Erhebung vom Aufnahmegerät au
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/data-usage/data-sharing-and-re-use-publication/conditions">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/data-usage/data-sharing-and-re-use-publication/conditions">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>conditions</key>
 		<path>spokencorpus_dfg/data-usage/data-sharing-and-re-use-publication/conditions</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sharing/conditions"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/data-usage/data-sharing-and-re-use-publication"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/data-usage/data-sharing-and-re-use-publication"/>
 		<is_collection>True</is_collection>
 		<order>3</order>
 		<help lang="en">The options refer to the licenses of the &lt;a href=&quot;https://creativecommons.org/share-your-work/licensing-types-examples/&quot; target=_blank&quot;&gt;Creative Commons family&lt;/a&gt; here.</help>
@@ -637,17 +637,17 @@ Aufnahmen sollten möglichst unmittelbar nach der Erhebung vom Aufnahmegerät au
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_license_types"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_license_types"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/data-usage/data-sharing-and-re-use-publication/data_publication_date">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/data-usage/data-sharing-and-re-use-publication/data_publication_date">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data_publication_date</key>
 		<path>spokencorpus_dfg/data-usage/data-sharing-and-re-use-publication/data_publication_date</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/data_publication_date"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/data-usage/data-sharing-and-re-use-publication"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/data-usage/data-sharing-and-re-use-publication"/>
 		<is_collection>False</is_collection>
 		<order>6</order>
 		<help lang="en"/>
@@ -666,16 +666,16 @@ Aufnahmen sollten möglichst unmittelbar nach der Erhebung vom Aufnahmegerät au
 		<unit/>
 		<optionsets/>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/data_sharing"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/data_sharing"/>
 		</conditions>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/data-usage/quality-assurance-dataset">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/data-usage/quality-assurance-dataset">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>quality-assurance-dataset</key>
 		<path>spokencorpus_dfg/data-usage/quality-assurance-dataset</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/data-usage"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/data-usage"/>
 		<is_collection>True</is_collection>
 		<order>61</order>
 		<title lang="en">Quality assurance</title>
@@ -688,13 +688,13 @@ Aufnahmen sollten möglichst unmittelbar nach der Erhebung vom Aufnahmegerät au
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/data-usage/quality-assurance-dataset/measures">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/data-usage/quality-assurance-dataset/measures">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>measures</key>
 		<path>spokencorpus_dfg/data-usage/quality-assurance-dataset/measures</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/quality_assurance"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/data-usage/quality-assurance-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/data-usage/quality-assurance-dataset"/>
 		<is_collection>False</is_collection>
 		<order>7</order>
 		<help lang="en"/>
@@ -714,23 +714,23 @@ Aufnahmen sollten möglichst unmittelbar nach der Erhebung vom Aufnahmegerät au
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/doc">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/doc">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>doc</key>
 		<path>spokencorpus_dfg/doc</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg"/>
 		<order>4</order>
 		<title lang="en">Documentation</title>
 		<title lang="de">Dokumentation</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/doc/metadata-dataset">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/doc/metadata-dataset">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>metadata-dataset</key>
 		<path>spokencorpus_dfg/doc/metadata-dataset</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/doc"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/doc"/>
 		<is_collection>True</is_collection>
 		<order>10</order>
 		<title lang="en">Metadata and data documentation</title>
@@ -743,13 +743,13 @@ Aufnahmen sollten möglichst unmittelbar nach der Erhebung vom Aufnahmegerät au
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/doc/metadata-dataset/standards">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/doc/metadata-dataset/standards">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>standards</key>
 		<path>spokencorpus_dfg/doc/metadata-dataset/standards</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/metadata/standards"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/doc/metadata-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/doc/metadata-dataset"/>
 		<is_collection>True</is_collection>
 		<order>1</order>
 		<help lang="en">From the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/grundlagen_dfg_foerderung/informationen_fachwissenschaften/geisteswissenschaften/standards_sprachkorpora.pdf&quot; target=_blank&quot;&gt; Recommendations on data technology standards and tools for the collection of corpora &lt;/a&gt; (in German), Part 1, spoken corpora:
@@ -803,17 +803,17 @@ Konkrete Empfehlungen
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/metadata_standards"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/metadata_standards"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/doc/metadata-dataset/documentation">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/doc/metadata-dataset/documentation">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>documentation</key>
 		<path>spokencorpus_dfg/doc/metadata-dataset/documentation</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/documentation"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/doc/metadata-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/doc/metadata-dataset"/>
 		<is_collection>False</is_collection>
 		<order>4</order>
 		<help lang="en">From the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/grundlagen_dfg_foerderung/informationen_fachwissenschaften/geisteswissenschaften/standards_sprachkorpora.pdf&quot; target=_blank&quot;&gt; Recommendations on data technology standards and tools for the collection of writing corpora &lt;/a&gt; (in German), Part 1, Spoken Corpora:
@@ -841,23 +841,23 @@ Die Originalaufnahmen (Rohdaten) sollten zumindest für die Projektlaufzeit zu A
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/legal-and-ethics">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/legal-and-ethics">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>legal-and-ethics</key>
 		<path>spokencorpus_dfg/legal-and-ethics</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg"/>
 		<order>5</order>
 		<title lang="en">Legal and ethics</title>
 		<title lang="de">Rechtliche und ethische Fragen</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/legal-and-ethics/sensitive-data-personal_data_yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/legal-and-ethics/sensitive-data-personal_data_yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>sensitive-data-personal_data_yesno</key>
 		<path>spokencorpus_dfg/legal-and-ethics/sensitive-data-personal_data_yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/legal-and-ethics"/>
 		<is_collection>True</is_collection>
 		<order>21</order>
 		<title lang="en">Personal data</title>
@@ -870,13 +870,13 @@ Die Originalaufnahmen (Rohdaten) sollten zumindest für die Projektlaufzeit zu A
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/legal-and-ethics/sensitive-data-personal_data_yesno/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/legal-and-ethics/sensitive-data-personal_data_yesno/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>spokencorpus_dfg/legal-and-ethics/sensitive-data-personal_data_yesno/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sensitive_data/personal_data_yesno/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/legal-and-ethics/sensitive-data-personal_data_yesno"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/legal-and-ethics/sensitive-data-personal_data_yesno"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">The EU General Data Protection Regulation (GDPR) defines in Art. 4 personal data as &quot;any information relating to an identified or identifiable natural person&quot;. An identifiable natural person is &quot;one who can be identified, directly or indirectly, in particular by reference to an identifier such as a name, an identification number, location data, an online identifier or to one or more factors specific to the physical, physiological, genetic, mental, economic, cultural or social identity of that natural person&quot;.
@@ -904,13 +904,13 @@ Bei mündlichen Korpora sind mindestens die Audio- und oder Video-Aufnahmen selb
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/legal-and-ethics/sensitive-data-privacy_law">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/legal-and-ethics/sensitive-data-privacy_law">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>sensitive-data-privacy_law</key>
 		<path>spokencorpus_dfg/legal-and-ethics/sensitive-data-privacy_law</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/legal-and-ethics"/>
 		<is_collection>False</is_collection>
 		<order>22</order>
 		<title lang="en">Data protection</title>
@@ -922,16 +922,16 @@ Bei mündlichen Korpora sind mindestens die Audio- und oder Video-Aufnahmen selb
 		<verbose_name lang="de"/>
 		<verbose_name_plural lang="de"/>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/personal_data"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/personal_data"/>
 		</conditions>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/legal-and-ethics/sensitive-data-privacy_law/privacy_law">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/legal-and-ethics/sensitive-data-privacy_law/privacy_law">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>privacy_law</key>
 		<path>spokencorpus_dfg/legal-and-ethics/sensitive-data-privacy_law/privacy_law</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/legal_aspects/sensitive_data/privacy_law"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/legal-and-ethics/sensitive-data-privacy_law"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/legal-and-ethics/sensitive-data-privacy_law"/>
 		<is_collection>True</is_collection>
 		<order>0</order>
 		<help lang="en">Opening clauses in the General Data Protection Regulation are the basis for national data protection laws in the EU. It depends on the kind of institution which law applies. Federal public bodies and private institutions are subject to the Federal Data Protection Act (BDSG). To public bodies of the states (e.g. universities), the respective State Data Protection Acts apply (exact demarcation see § 1 BDSG). In some areas, field-specific laws apply. These override the Federal and State Data Protection Acts. For example, the Tenth Social Code (§ 75 SBG X) is applicable to social data; scientific research in schools can be regulated in the respective school law of the state (for example in § 120 Education Act NRW).</help>
@@ -950,17 +950,17 @@ Landesdatenschutzgesetz (genaue Abgrenzung siehe § 1 BDSG). In bestimmten Berei
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/data_protection_laws"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/data_protection_laws"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/legal-and-ethics/sensitive-data-personal_data">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/legal-and-ethics/sensitive-data-personal_data">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>sensitive-data-personal_data</key>
 		<path>spokencorpus_dfg/legal-and-ethics/sensitive-data-personal_data</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/legal-and-ethics"/>
 		<is_collection>True</is_collection>
 		<order>24</order>
 		<title lang="en">Sensitive data</title>
@@ -972,16 +972,16 @@ Landesdatenschutzgesetz (genaue Abgrenzung siehe § 1 BDSG). In bestimmten Berei
 		<verbose_name lang="de">Datensatz</verbose_name>
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/personal_data"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/personal_data"/>
 		</conditions>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/legal-and-ethics/sensitive-data-personal_data/dsgvo_9">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/legal-and-ethics/sensitive-data-personal_data/dsgvo_9">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>dsgvo_9</key>
 		<path>spokencorpus_dfg/legal-and-ethics/sensitive-data-personal_data/dsgvo_9</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sensitive_data/personal_data/bdsg_3_9"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/legal-and-ethics/sensitive-data-personal_data"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/legal-and-ethics/sensitive-data-personal_data"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">These kinds of data are considered particularly sensitive and require even more extensive safeguards. If you answer this question with &quot;Yes&quot;, please get in touch with the data protection officer of your institution to check which additional protection measures are necessary.</help>
@@ -1001,13 +1001,13 @@ Landesdatenschutzgesetz (genaue Abgrenzung siehe § 1 BDSG). In bestimmten Berei
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/legal-and-ethics/sensitive-data-personal_data/anonymization">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/legal-and-ethics/sensitive-data-personal_data/anonymization">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>anonymization</key>
 		<path>spokencorpus_dfg/legal-and-ethics/sensitive-data-personal_data/anonymization</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sensitive_data/personal_data/anonymization"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/legal-and-ethics/sensitive-data-personal_data"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/legal-and-ethics/sensitive-data-personal_data"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en">From the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/guidelines_review_board_linguistics_corpora.pdf target=_blank&gt;Guidelines for Building Language Corpora Under German Law&lt;/a&gt;:
@@ -1038,17 +1038,17 @@ Bei Video-Daten würde eine weitreichende Anonymisierung der Bilddaten (bspw. du
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_anonymisation"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_anonymisation"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/legal-and-ethics/sensitive-data-personal_data/extent">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/legal-and-ethics/sensitive-data-personal_data/extent">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>extent</key>
 		<path>spokencorpus_dfg/legal-and-ethics/sensitive-data-personal_data/extent</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sensitive_data/personal_data/consent/extent"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/legal-and-ethics/sensitive-data-personal_data"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/legal-and-ethics/sensitive-data-personal_data"/>
 		<is_collection>False</is_collection>
 		<order>3</order>
 		<help lang="en">Basically, the collection, processing, archiving and publication of personal data is only admissible, when the “informed consent” of the person in question has been obtained. However, there are a number of exceptions, some of which are described in Art. 6 of the General Data Protection Regulation or which have been made possible by law. For example, § 17 Datenschutzgesetz Nordrhein-Westfalen (DSG-NRW, 17 Mai 2018) allows the processing of personal data for scientific or historical research purposes or for statistical purposes even without consent if processing for these purposes is necessary and protected interests of the person concerned do not prevail.</help>
@@ -1066,17 +1066,17 @@ Bei Video-Daten würde eine weitreichende Anonymisierung der Bilddaten (bspw. du
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/informed_consent_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/informed_consent_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/legal-and-ethics/sensitive-data-personal_data/statement">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/legal-and-ethics/sensitive-data-personal_data/statement">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>statement</key>
 		<path>spokencorpus_dfg/legal-and-ethics/sensitive-data-personal_data/statement</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sensitive_data/personal_data/consent/statement"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/legal-and-ethics/sensitive-data-personal_data"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/legal-and-ethics/sensitive-data-personal_data"/>
 		<is_collection>False</is_collection>
 		<order>4</order>
 		<help lang="en"/>
@@ -1096,13 +1096,13 @@ Bei Video-Daten würde eine weitreichende Anonymisierung der Bilddaten (bspw. du
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/legal-and-ethics/intellectual-property-rights-yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/legal-and-ethics/intellectual-property-rights-yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>intellectual-property-rights-yesno</key>
 		<path>spokencorpus_dfg/legal-and-ethics/intellectual-property-rights-yesno</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/legal-and-ethics"/>
 		<is_collection>False</is_collection>
 		<order>30</order>
 		<title lang="en">Intellectual property rights I</title>
@@ -1115,13 +1115,13 @@ Bei Video-Daten würde eine weitreichende Anonymisierung der Bilddaten (bspw. du
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/legal-and-ethics/intellectual-property-rights-yesno/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/legal-and-ethics/intellectual-property-rights-yesno/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>spokencorpus_dfg/legal-and-ethics/intellectual-property-rights-yesno/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/legal_aspects/ipr/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/legal-and-ethics/intellectual-property-rights-yesno"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/legal-and-ethics/intellectual-property-rights-yesno"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<help lang="en">From the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/guidelines_review_board_linguistics_corpora.pdf&quot; target=_blank&gt;Guidelines for Building Language Corpora Under German Law&lt;/a&gt;:
@@ -1159,13 +1159,13 @@ Sobald eine Verwendung dieser Materialien im Wissenschaftsbetrieb mit Handlungen
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/legal-and-ethics/intellectual-property-rights-dataset">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/legal-and-ethics/intellectual-property-rights-dataset">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>intellectual-property-rights-dataset</key>
 		<path>spokencorpus_dfg/legal-and-ethics/intellectual-property-rights-dataset</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/legal-and-ethics"/>
 		<is_collection>True</is_collection>
 		<order>31</order>
 		<title lang="en">Intellectual property rights II</title>
@@ -1177,16 +1177,16 @@ Sobald eine Verwendung dieser Materialien im Wissenschaftsbetrieb mit Handlungen
 		<verbose_name lang="de">Datensatz</verbose_name>
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/intellectual_property_rights"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/intellectual_property_rights"/>
 		</conditions>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/legal-and-ethics/intellectual-property-rights-dataset/copyrights">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/legal-and-ethics/intellectual-property-rights-dataset/copyrights">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>copyrights</key>
 		<path>spokencorpus_dfg/legal-and-ethics/intellectual-property-rights-dataset/copyrights</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/ipr/copyrights"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
 		<is_collection>True</is_collection>
 		<order>0</order>
 		<help lang="en">From the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/guidelines_review_board_linguistics_corpora.pdf target=_blank&gt;Guidelines for Building Language Corpora Under German Law&lt;/a&gt;:</help>
@@ -1204,17 +1204,17 @@ Sobald eine Verwendung dieser Materialien im Wissenschaftsbetrieb mit Handlungen
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_copyright_laws"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_copyright_laws"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/legal-and-ethics/intellectual-property-rights-dataset/other_rights">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/legal-and-ethics/intellectual-property-rights-dataset/other_rights">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>other_rights</key>
 		<path>spokencorpus_dfg/legal-and-ethics/intellectual-property-rights-dataset/other_rights</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/ipr/other_rights"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
 		<is_collection>True</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -1232,17 +1232,17 @@ Sobald eine Verwendung dieser Materialien im Wissenschaftsbetrieb mit Handlungen
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_other_rights"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_other_rights"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/legal-and-ethics/intellectual-property-rights-dataset/owner">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/legal-and-ethics/intellectual-property-rights-dataset/owner">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>owner</key>
 		<path>spokencorpus_dfg/legal-and-ethics/intellectual-property-rights-dataset/owner</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/ipr/owner/name"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
 		<is_collection>False</is_collection>
 		<order>3</order>
 		<help lang="en">From the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/guidelines_review_board_linguistics_corpora.pdf&quot; target=_blank&gt;Guidelines for Building Language Corpora Under German Law&lt;/a&gt;:
@@ -1264,17 +1264,17 @@ Große Schwierigkeiten in der Praxis werden dadurch verursacht, dass die relevan
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/yes_with_text_no"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/yes_with_text_no"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/legal-and-ethics/intellectual-property-rights-dataset/status">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/legal-and-ethics/intellectual-property-rights-dataset/status">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>status</key>
 		<path>spokencorpus_dfg/legal-and-ethics/intellectual-property-rights-dataset/status</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/ipr/status"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
 		<is_collection>False</is_collection>
 		<order>4</order>
 		<help lang="en">From the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/guidelines_review_board_linguistics_corpora.pdf&quot; target=_blank&gt;Guidelines for Building Language Corpora Under German Law&lt;/a&gt;:
@@ -1306,23 +1306,23 @@ Besondere Vorsicht ist dann geboten, wenn das zu nutzende urheberrechtlich schut
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/storage-and-long-term-preservation">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/storage-and-long-term-preservation">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>storage-and-long-term-preservation</key>
 		<path>spokencorpus_dfg/storage-and-long-term-preservation</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg"/>
 		<order>10</order>
 		<title lang="en">Storage and long-term preservation</title>
 		<title lang="de">Speicherung und Langzeitarchivierung</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>long-term-preservation-datasets</key>
 		<path>spokencorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/storage-and-long-term-preservation"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/storage-and-long-term-preservation"/>
 		<is_collection>True</is_collection>
 		<order>11</order>
 		<title lang="en">Long-term preservation</title>
@@ -1335,13 +1335,13 @@ Besondere Vorsicht ist dann geboten, wenn das zu nutzende urheberrechtlich schut
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>spokencorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en"/>
@@ -1361,13 +1361,13 @@ Besondere Vorsicht ist dann geboten, wenn das zu nutzende urheberrechtlich schut
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/purpose">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/purpose">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>purpose</key>
 		<path>spokencorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/purpose</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/purpose"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>True</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -1385,17 +1385,17 @@ Besondere Vorsicht ist dann geboten, wenn das zu nutzende urheberrechtlich schut
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/preservation_motivation_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/preservation_motivation_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/duration">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/duration">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>duration</key>
 		<path>spokencorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/duration</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/duration"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>False</is_collection>
 		<order>3</order>
 		<help lang="en"/>
@@ -1415,13 +1415,13 @@ Besondere Vorsicht ist dann geboten, wenn das zu nutzende urheberrechtlich schut
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/repository">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/repository">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>repository</key>
 		<path>spokencorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/repository</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/repository"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/spokencorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/spokencorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>True</is_collection>
 		<order>5</order>
 		<help lang="en">In the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/grundlagen_dfg_foerderung/informationen_fachwissenschaften/geisteswissenschaften/standards_sprachkorpora.pdf&quot; target=_blank&quot;&gt; Recommendations on data technology standards and tools for the collection of corpora &lt;/a&gt; (in German), Part 1, criteria for the selection can be found (see there) and the following data centers in Germany with competences concerning spoken corpora are listed:
@@ -1459,7 +1459,7 @@ Besondere Vorsicht ist dann geboten, wenn das zu nutzende urheberrechtlich schut
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/preservation_repository_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/preservation_repository_options"/>
 		</optionsets>
 		<conditions/>
 	</question>

--- a/shared/fodako/textcorpus_dfg.xml
+++ b/shared/fodako/textcorpus_dfg.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <rdmo xmlns:dc="http://purl.org/dc/elements/1.1/">
-	<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<catalog dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>textcorpus_dfg</key>
 		<dc:comment>Dieser Fragenkatalog ist eine Teilmenge des Katalogs &quot;Alle Fragen&quot; (eine Überarbeitung des Katalogs &quot;RDMO&quot;) und enthält nur die Fragen, die die Anforderungen in den 
 
@@ -18,23 +18,23 @@ abdecken. Die Ausfüllhilfen geben Hinweise für Schriftkorpus-Projekte.</dc:com
 		<title lang="en">DFG 104 Text corpus</title>
 		<title lang="de">DFG 104 Textkorpus</title>
 	</catalog>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/general">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/general">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>general</key>
 		<path>textcorpus_dfg/general</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg"/>
 		<order>0</order>
 		<title lang="en">General</title>
 		<title lang="de">Allgemein</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/general/other-requirements-yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/general/other-requirements-yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>other-requirements-yesno</key>
 		<path>textcorpus_dfg/general/other-requirements-yesno</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/general"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/general"/>
 		<is_collection>False</is_collection>
 		<order>50</order>
 		<title lang="en">Requirements I</title>
@@ -47,13 +47,13 @@ abdecken. Die Ausfüllhilfen geben Hinweise für Schriftkorpus-Projekte.</dc:com
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/general/other-requirements-yesno/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/general/other-requirements-yesno/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>textcorpus_dfg/general/other-requirements-yesno/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/additional_rdm_policy/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/general/other-requirements-yesno"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/general/other-requirements-yesno"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<help lang="en">For example, the DFG Review Board on Linguistics has published the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/grundlagen_dfg_foerderung/informationen_fachwissenschaften/geisteswissenschaften/standards_sprachkorpora.pdf&quot; target=_blank&quot;&gt; Recommendations on data technology standards and tools for the collection of corpora &lt;/a&gt; (in German). This questionnaire takes into account these recommendations, the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/guidelines_review_board_linguistics_corpora.pdf&quot; target=_blank&gt;Information for Building Language Corpora Under German Law&lt;/a&gt; and the interdisplinary &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/guidelines_research_data.pdf&quot; target=_blank&gt;DFG Guidelines on the Handling of Research Data&lt;/a&gt;.</help>
@@ -71,17 +71,17 @@ abdecken. Die Ausfüllhilfen geben Hinweise für Schriftkorpus-Projekte.</dc:com
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/other_requirements_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/other_requirements_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/general/other-requirements-requirements">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/general/other-requirements-requirements">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>other-requirements-requirements</key>
 		<path>textcorpus_dfg/general/other-requirements-requirements</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/general"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/general"/>
 		<is_collection>False</is_collection>
 		<order>51</order>
 		<title lang="en">Requirements II</title>
@@ -93,16 +93,16 @@ abdecken. Die Ausfüllhilfen geben Hinweise für Schriftkorpus-Projekte.</dc:com
 		<verbose_name lang="de"/>
 		<verbose_name_plural lang="de"/>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/additional_rdm_policy"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/additional_rdm_policy"/>
 		</conditions>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/general/other-requirements-requirements/requirements">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/general/other-requirements-requirements/requirements">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>requirements</key>
 		<path>textcorpus_dfg/general/other-requirements-requirements/requirements</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/additional_rdm_policy/requirements"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/general/other-requirements-requirements"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/general/other-requirements-requirements"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<help lang="en">At least, the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/grundlagen_dfg_foerderung/informationen_fachwissenschaften/geisteswissenschaften/standards_sprachkorpora.pdf&quot; target=_blank&quot;&gt;Empfehlungen zu datentechnischen Standards und Tools bei der Erhebung von Sprachkorpora&lt;/a&gt; (in German, Part 2) should be mentioned here, which is concerned with the creation of text corpora by compiling existing text resources (e.g. from digital text collections, Web pages, blogs, news groups,...) or by digitalization of carriers of written record (i.e. primarily of manuscripts, newspapers/journals as well as printed literature). 
@@ -134,13 +134,13 @@ Beachten Sie bitte auch
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/general/support">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/general/support">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>support</key>
 		<path>textcorpus_dfg/general/support</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/general"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/general"/>
 		<is_collection>False</is_collection>
 		<order>61</order>
 		<title lang="en">Support</title>
@@ -153,13 +153,13 @@ Beachten Sie bitte auch
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/general/support/datamanagement">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/general/support/datamanagement">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>datamanagement</key>
 		<path>textcorpus_dfg/general/support/datamanagement</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/support"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/general/support"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/general/support"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">From the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/guidelines_review_board_linguistics_corpora.pdf&quot; target=_blank&gt;Guidelines for Building Language Corpora Under German Law&lt;/a&gt;:
@@ -183,23 +183,23 @@ Möglichst früh in der Planungsphase sollte &lt;i&gt;Kontakt zu einem Zentrum&l
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/content-classification">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/content-classification">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>content-classification</key>
 		<path>textcorpus_dfg/content-classification</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg"/>
 		<order>1</order>
 		<title lang="en">Content classification</title>
 		<title lang="de">Inhaltliche Einordnung</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/content-classification/data-dataset">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/content-classification/data-dataset">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-dataset</key>
 		<path>textcorpus_dfg/content-classification/data-dataset</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/content-classification"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/content-classification"/>
 		<is_collection>True</is_collection>
 		<order>1</order>
 		<title lang="en">Datasets</title>
@@ -212,13 +212,13 @@ Möglichst früh in der Planungsphase sollte &lt;i&gt;Kontakt zu einem Zentrum&l
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/content-classification/data-dataset/description">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/content-classification/data-dataset/description">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>description</key>
 		<path>textcorpus_dfg/content-classification/data-dataset/description</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/description"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/content-classification/data-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/content-classification/data-dataset"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">Please briefly describe the data type and / or the method used to create or collect the data. From the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/grundlagen_dfg_foerderung/informationen_fachwissenschaften/geisteswissenschaften/standards_sprachkorpora.pdf&quot; target=_blank&quot;&gt; Recommendations on data technology standards and tools for the collection of writing corpora &lt;/a&gt; (in German):
@@ -266,13 +266,13 @@ Aus den &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/grundlagen_d
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/content-classification/data-reuse">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/content-classification/data-reuse">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-reuse</key>
 		<path>textcorpus_dfg/content-classification/data-reuse</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/content-classification"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/content-classification"/>
 		<is_collection>True</is_collection>
 		<order>3</order>
 		<title lang="en">Reuse</title>
@@ -285,13 +285,13 @@ Aus den &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/grundlagen_d
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/content-classification/data-reuse/scenario">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/content-classification/data-reuse/scenario">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>scenario</key>
 		<path>textcorpus_dfg/content-classification/data-reuse/scenario</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/reuse_scenario"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/content-classification/data-reuse"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/content-classification/data-reuse"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">From the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/grundlagen_dfg_foerderung/informationen_fachwissenschaften/geisteswissenschaften/standards_sprachkorpora.pdf&quot; target=_blank&quot;&gt; recommendations on data technology standards and tools for the collection of writing corpora &lt;/a&gt; (in German):
@@ -319,23 +319,23 @@ Für (historische) Korpusprojekte sollte dargelegt werden, inwiefern ein gewähl
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/technical-classification">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/technical-classification">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>technical-classification</key>
 		<path>textcorpus_dfg/technical-classification</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg"/>
 		<order>2</order>
 		<title lang="en">Technical classification</title>
 		<title lang="de">Technische Einordnung</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/technical-classification/data-formats">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/technical-classification/data-formats">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-formats</key>
 		<path>textcorpus_dfg/technical-classification/data-formats</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/technical-classification"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/technical-classification"/>
 		<is_collection>True</is_collection>
 		<order>3</order>
 		<title lang="en">Formats</title>
@@ -348,13 +348,13 @@ Für (historische) Korpusprojekte sollte dargelegt werden, inwiefern ein gewähl
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/technical-classification/data-formats/format">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/technical-classification/data-formats/format">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>format</key>
 		<path>textcorpus_dfg/technical-classification/data-formats/format</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/format"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/technical-classification/data-formats"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/technical-classification/data-formats"/>
 		<is_collection>False</is_collection>
 		<order>4</order>
 		<help lang="en">From the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/grundlagen_dfg_foerderung/informationen_fachwissenschaften/geisteswissenschaften/standards_sprachkorpora.pdf&quot; target=_blank&gt; Recommendations on data technology standards and tools for the collection of writing corpora &lt;/a&gt; (in German):
@@ -452,13 +452,13 @@ Nicht nur für den Annotationsprozess, sondern auch für viele Arten der &lt;i&g
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/technical-classification/data-tools">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/technical-classification/data-tools">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-tools</key>
 		<path>textcorpus_dfg/technical-classification/data-tools</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/technical-classification"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/technical-classification"/>
 		<is_collection>False</is_collection>
 		<order>4</order>
 		<title lang="en">Tools</title>
@@ -471,13 +471,13 @@ Nicht nur für den Annotationsprozess, sondern auch für viele Arten der &lt;i&g
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/technical-classification/data-tools/creation_methods">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/technical-classification/data-tools/creation_methods">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>creation_methods</key>
 		<path>textcorpus_dfg/technical-classification/data-tools/creation_methods</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/creation_methods"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/technical-classification/data-tools"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/technical-classification/data-tools"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">From the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/grundlagen_dfg_foerderung/informationen_fachwissenschaften/geisteswissenschaften/standards_sprachkorpora.pdf&quot; target=_blank&gt; Recommendations on data technology standards and tools for the collection of writing corpora &lt;/a&gt; (in German):
@@ -531,13 +531,13 @@ Die  Annotation der  Korpustexte sollte sowohl die Auszeichnung struktureller Me
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/technical-classification/data-versioning">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/technical-classification/data-versioning">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-versioning</key>
 		<path>textcorpus_dfg/technical-classification/data-versioning</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/technical-classification"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/technical-classification"/>
 		<is_collection>True</is_collection>
 		<order>5</order>
 		<title lang="en">Versioning</title>
@@ -550,13 +550,13 @@ Die  Annotation der  Korpustexte sollte sowohl die Auszeichnung struktureller Me
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/technical-classification/data-versioning/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/technical-classification/data-versioning/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>textcorpus_dfg/technical-classification/data-versioning/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/versioning_yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/technical-classification/data-versioning"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/technical-classification/data-versioning"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">From the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/grundlagen_dfg_foerderung/informationen_fachwissenschaften/geisteswissenschaften/standards_sprachkorpora.pdf&quot; target=_blank&quot;&gt; Recommendations on data technology standards and tools for the collection of writing corpora &lt;/a&gt; (in German):
@@ -580,13 +580,13 @@ Sowohl Korpora als auch Tools liegen oftmals in verschiedenen Versionen vor, die
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/technical-classification/data-versioning/strategy">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/technical-classification/data-versioning/strategy">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>strategy</key>
 		<path>textcorpus_dfg/technical-classification/data-versioning/strategy</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/versioning_strategy"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/technical-classification/data-versioning"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/technical-classification/data-versioning"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en">Please briefly describe the project-internal regulations for the versioning of data sets (e.g.: What kind of changes require a new version? How are changes documented? What are the naming rules for different versions?)
@@ -614,23 +614,23 @@ Auch die in einem Tool ggf. verwendeten, aber separaten, dynamischen Komponenten
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/data-usage">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/data-usage">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-usage</key>
 		<path>textcorpus_dfg/data-usage</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg"/>
 		<order>3</order>
 		<title lang="en">Data usage</title>
 		<title lang="de">Datennutzung</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/data-usage/data-storage-and-security-storage">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/data-usage/data-storage-and-security-storage">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-storage-and-security-storage</key>
 		<path>textcorpus_dfg/data-usage/data-storage-and-security-storage</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/data-usage"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/data-usage"/>
 		<is_collection>True</is_collection>
 		<order>11</order>
 		<title lang="en">Data organisation</title>
@@ -643,13 +643,13 @@ Auch die in einem Tool ggf. verwendeten, aber separaten, dynamischen Komponenten
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/data-usage/data-storage-and-security-storage/type">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/data-usage/data-storage-and-security-storage/type">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>type</key>
 		<path>textcorpus_dfg/data-usage/data-storage-and-security-storage/type</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/storage/type"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/data-usage/data-storage-and-security-storage"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/data-usage/data-storage-and-security-storage"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">If parts of the documentation or related software (custom development) are not stored with the data, also indicate where they are stored. This applies to the documentation of the software too.</help>
@@ -669,13 +669,13 @@ Auch die in einem Tool ggf. verwendeten, aber separaten, dynamischen Komponenten
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/data-usage/data-sharing-and-re-use-publication">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/data-usage/data-sharing-and-re-use-publication">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data-sharing-and-re-use-publication</key>
 		<path>textcorpus_dfg/data-usage/data-sharing-and-re-use-publication</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/data-usage"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/data-usage"/>
 		<is_collection>True</is_collection>
 		<order>52</order>
 		<title lang="en">Data sharing and re-use</title>
@@ -688,13 +688,13 @@ Auch die in einem Tool ggf. verwendeten, aber separaten, dynamischen Komponenten
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/data-usage/data-sharing-and-re-use-publication/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/data-usage/data-sharing-and-re-use-publication/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>textcorpus_dfg/data-usage/data-sharing-and-re-use-publication/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sharing/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/data-usage/data-sharing-and-re-use-publication"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/data-usage/data-sharing-and-re-use-publication"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">From the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/grundlagen_dfg_foerderung/informationen_fachwissenschaften/geisteswissenschaften/standards_sprachkorpora.pdf&quot; target=_blank&quot;&gt; Recommendations on data technology standards and tools for the collection of writing corpora &lt;/a&gt; (in German):
@@ -724,17 +724,17 @@ Im Falle von Zweit- oder Parallelveröffentlichungen (beispielsweise im Zusammen
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_sharing_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_sharing_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/data-usage/data-sharing-and-re-use-publication/explanation">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/data-usage/data-sharing-and-re-use-publication/explanation">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>explanation</key>
 		<path>textcorpus_dfg/data-usage/data-sharing-and-re-use-publication/explanation</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sharing/explanation"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/data-usage/data-sharing-and-re-use-publication"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/data-usage/data-sharing-and-re-use-publication"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -754,13 +754,13 @@ Im Falle von Zweit- oder Parallelveröffentlichungen (beispielsweise im Zusammen
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/data-usage/data-sharing-and-re-use-publication/conditions">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/data-usage/data-sharing-and-re-use-publication/conditions">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>conditions</key>
 		<path>textcorpus_dfg/data-usage/data-sharing-and-re-use-publication/conditions</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sharing/conditions"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/data-usage/data-sharing-and-re-use-publication"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/data-usage/data-sharing-and-re-use-publication"/>
 		<is_collection>True</is_collection>
 		<order>3</order>
 		<help lang="en">The options refer to the licenses of the &lt;a href=&quot;https://creativecommons.org/share-your-work/licensing-types-examples/&quot; target=_blank&quot;&gt;Creative Commons family&lt;/a&gt;.
@@ -799,17 +799,17 @@ Empfehlungen für den Entwurf von Lizenzverträgen finden sich in Perkuhn et al.
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_license_types"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_license_types"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/data-usage/data-sharing-and-re-use-publication/data_publication_date">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/data-usage/data-sharing-and-re-use-publication/data_publication_date">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>data_publication_date</key>
 		<path>textcorpus_dfg/data-usage/data-sharing-and-re-use-publication/data_publication_date</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/data_publication_date"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/data-usage/data-sharing-and-re-use-publication"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/data-usage/data-sharing-and-re-use-publication"/>
 		<is_collection>False</is_collection>
 		<order>6</order>
 		<help lang="en"/>
@@ -828,16 +828,16 @@ Empfehlungen für den Entwurf von Lizenzverträgen finden sich in Perkuhn et al.
 		<unit/>
 		<optionsets/>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/data_sharing"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/data_sharing"/>
 		</conditions>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/data-usage/quality-assurance-dataset">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/data-usage/quality-assurance-dataset">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>quality-assurance-dataset</key>
 		<path>textcorpus_dfg/data-usage/quality-assurance-dataset</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/data-usage"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/data-usage"/>
 		<is_collection>True</is_collection>
 		<order>61</order>
 		<title lang="en">Quality assurance</title>
@@ -850,13 +850,13 @@ Empfehlungen für den Entwurf von Lizenzverträgen finden sich in Perkuhn et al.
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/data-usage/quality-assurance-dataset/measures">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/data-usage/quality-assurance-dataset/measures">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>measures</key>
 		<path>textcorpus_dfg/data-usage/quality-assurance-dataset/measures</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/quality_assurance"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/data-usage/quality-assurance-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/data-usage/quality-assurance-dataset"/>
 		<is_collection>False</is_collection>
 		<order>7</order>
 		<help lang="en">From the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/grundlagen_dfg_foerderung/informationen_fachwissenschaften/geisteswissenschaften/standards_sprachkorpora.pdf&quot; target=_blank&quot;&gt; Recommendations on data technology standards and tools for the collection of writing corpora &lt;/a&gt; (in German):
@@ -906,23 +906,23 @@ Bei der Nachnutzung von ,born digital’ Texten sollte die Änderbarkeit der Que
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/doc">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/doc">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>doc</key>
 		<path>textcorpus_dfg/doc</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg"/>
 		<order>4</order>
 		<title lang="en">Documentation</title>
 		<title lang="de">Dokumentation</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/doc/metadata-dataset">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/doc/metadata-dataset">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>metadata-dataset</key>
 		<path>textcorpus_dfg/doc/metadata-dataset</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/doc"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/doc"/>
 		<is_collection>True</is_collection>
 		<order>10</order>
 		<title lang="en">Metadata and data documentation</title>
@@ -935,13 +935,13 @@ Bei der Nachnutzung von ,born digital’ Texten sollte die Änderbarkeit der Que
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/doc/metadata-dataset/standards">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/doc/metadata-dataset/standards">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>standards</key>
 		<path>textcorpus_dfg/doc/metadata-dataset/standards</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/metadata/standards"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/doc/metadata-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/doc/metadata-dataset"/>
 		<is_collection>True</is_collection>
 		<order>1</order>
 		<help lang="en">From the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/grundlagen_dfg_foerderung/informationen_fachwissenschaften/geisteswissenschaften/standards_sprachkorpora.pdf&quot; target=_blank&quot;&gt; Recommendations on data technology standards and tools for the collection of writing corpora &lt;/a&gt; (in German):
@@ -997,17 +997,17 @@ Als Primärformat für die Erfassung von Metadaten ist ein verbreitetes, standar
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/metadata_standards"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/metadata_standards"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/doc/metadata-dataset/documentation">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/doc/metadata-dataset/documentation">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>documentation</key>
 		<path>textcorpus_dfg/doc/metadata-dataset/documentation</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/documentation"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/doc/metadata-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/doc/metadata-dataset"/>
 		<is_collection>False</is_collection>
 		<order>4</order>
 		<help lang="en">From the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/grundlagen_dfg_foerderung/informationen_fachwissenschaften/geisteswissenschaften/standards_sprachkorpora.pdf&quot; target=_blank&quot;&gt; Recommendations on data technology standards and tools for the collection of writing corpora &lt;/a&gt; (in German):
@@ -1065,23 +1065,23 @@ In Fällen, in denen ist nicht möglich ist, ausreichend Rechte einzuholen, um e
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/referencing">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/referencing">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>referencing</key>
 		<path>textcorpus_dfg/referencing</path>
 		<dc:comment>der Abschnitt &quot;Metadaten und Referenzierung&quot; des Katalogs &quot;RDMO&quot; wurde in die beiden Abschnitte &quot;Metadaten und Datendokumentation&quot; und &quot;Referenzierung&quot; aufgeteilt.</dc:comment>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg"/>
 		<order>5</order>
 		<title lang="en">Referencing</title>
 		<title lang="de">Referenzierung</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/referencing/structure-granularity-and-referencing-pids">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/referencing/structure-granularity-and-referencing-pids">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>structure-granularity-and-referencing-pids</key>
 		<path>textcorpus_dfg/referencing/structure-granularity-and-referencing-pids</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/referencing"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/referencing"/>
 		<is_collection>True</is_collection>
 		<order>21</order>
 		<title lang="en">Persistent Identifiers (PIDs)</title>
@@ -1094,13 +1094,13 @@ In Fällen, in denen ist nicht möglich ist, ausreichend Rechte einzuholen, um e
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/referencing/structure-granularity-and-referencing-pids/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/referencing/structure-granularity-and-referencing-pids/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>textcorpus_dfg/referencing/structure-granularity-and-referencing-pids/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/pids/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/referencing/structure-granularity-and-referencing-pids"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/referencing/structure-granularity-and-referencing-pids"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<help lang="en">From the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/grundlagen_dfg_foerderung/informationen_fachwissenschaften/geisteswissenschaften/standards_sprachkorpora.pdf&quot; target=_blank&quot;&gt; Recommendations on data technology standards and tools for the collection of writing corpora &lt;/a&gt; (in German):
@@ -1124,13 +1124,13 @@ Ein besonders nachhaltiges Verfahren für Versionsangaben ist die Registrierung 
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/referencing/structure-granularity-and-referencing-pids/subentities">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/referencing/structure-granularity-and-referencing-pids/subentities">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>subentities</key>
 		<path>textcorpus_dfg/referencing/structure-granularity-and-referencing-pids/subentities</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/pids/subentities"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/referencing/structure-granularity-and-referencing-pids"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/referencing/structure-granularity-and-referencing-pids"/>
 		<is_collection>False</is_collection>
 		<order>3</order>
 		<help lang="en">From the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/grundlagen_dfg_foerderung/informationen_fachwissenschaften/geisteswissenschaften/standards_sprachkorpora.pdf&quot; target=_blank&quot;&gt; Recommendations on data technology standards and tools for the collection of writing corpora &lt;/a&gt; (in German):
@@ -1154,23 +1154,23 @@ Bei  Standoff-Annotationen kann jede Annotationsschicht als eine separate Ressou
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/legal-and-ethics">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/legal-and-ethics">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>legal-and-ethics</key>
 		<path>textcorpus_dfg/legal-and-ethics</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg"/>
 		<order>6</order>
 		<title lang="en">Legal and ethics</title>
 		<title lang="de">Rechtliche und ethische Fragen</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/legal-and-ethics/sensitive-data-personal_data_yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/legal-and-ethics/sensitive-data-personal_data_yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>sensitive-data-personal_data_yesno</key>
 		<path>textcorpus_dfg/legal-and-ethics/sensitive-data-personal_data_yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/legal-and-ethics"/>
 		<is_collection>True</is_collection>
 		<order>21</order>
 		<title lang="en">Personal data</title>
@@ -1183,13 +1183,13 @@ Bei  Standoff-Annotationen kann jede Annotationsschicht als eine separate Ressou
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/legal-and-ethics/sensitive-data-personal_data_yesno/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/legal-and-ethics/sensitive-data-personal_data_yesno/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>textcorpus_dfg/legal-and-ethics/sensitive-data-personal_data_yesno/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sensitive_data/personal_data_yesno/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/legal-and-ethics/sensitive-data-personal_data_yesno"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/legal-and-ethics/sensitive-data-personal_data_yesno"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">The EU General Data Protection Regulation (GDPR) defines in Art. 4 personal data as &quot;any information relating to an identified or identifiable natural person&quot;. An identifiable natural person is &quot;one who can be identified, directly or indirectly, in particular by reference to an identifier such as a name, an identification number, location data, an online identifier or to one or more factors specific to the physical, physiological, genetic, mental, economic, cultural or social identity of that natural person&quot;.
@@ -1217,13 +1217,13 @@ Auch bei der Zusammenstellung und Verfügbarmachung schriftlicher Korpora könne
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/legal-and-ethics/sensitive-data-privacy_law">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/legal-and-ethics/sensitive-data-privacy_law">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>sensitive-data-privacy_law</key>
 		<path>textcorpus_dfg/legal-and-ethics/sensitive-data-privacy_law</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/legal-and-ethics"/>
 		<is_collection>False</is_collection>
 		<order>22</order>
 		<title lang="en">Data protection</title>
@@ -1235,16 +1235,16 @@ Auch bei der Zusammenstellung und Verfügbarmachung schriftlicher Korpora könne
 		<verbose_name lang="de"/>
 		<verbose_name_plural lang="de"/>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/personal_data"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/personal_data"/>
 		</conditions>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/legal-and-ethics/sensitive-data-privacy_law/privacy_law">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/legal-and-ethics/sensitive-data-privacy_law/privacy_law">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>privacy_law</key>
 		<path>textcorpus_dfg/legal-and-ethics/sensitive-data-privacy_law/privacy_law</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/legal_aspects/sensitive_data/privacy_law"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/legal-and-ethics/sensitive-data-privacy_law"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/legal-and-ethics/sensitive-data-privacy_law"/>
 		<is_collection>True</is_collection>
 		<order>0</order>
 		<help lang="en">Opening clauses in the General Data Protection Regulation are the basis for national data protection laws in the EU. It depends on the kind of institution which law applies. Federal public bodies and private institutions are subject to the Federal Data Protection Act (BDSG). To public bodies of the states (e.g. universities), the respective State Data Protection Acts apply (exact demarcation see § 1 BDSG). In some areas, field-specific laws apply. These override the Federal and State Data Protection Acts. For example, the Tenth Social Code (§ 75 SBG X) is applicable to social data; scientific research in schools can be regulated in the respective school law of the state (for example in § 120 Education Act NRW).</help>
@@ -1263,17 +1263,17 @@ Landesdatenschutzgesetz (genaue Abgrenzung siehe § 1 BDSG). In bestimmten Berei
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/data_protection_laws"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/data_protection_laws"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/legal-and-ethics/sensitive-data-personal_data">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/legal-and-ethics/sensitive-data-personal_data">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>sensitive-data-personal_data</key>
 		<path>textcorpus_dfg/legal-and-ethics/sensitive-data-personal_data</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/legal-and-ethics"/>
 		<is_collection>True</is_collection>
 		<order>24</order>
 		<title lang="en">Sensitive data</title>
@@ -1285,16 +1285,16 @@ Landesdatenschutzgesetz (genaue Abgrenzung siehe § 1 BDSG). In bestimmten Berei
 		<verbose_name lang="de">Datensatz</verbose_name>
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/personal_data"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/personal_data"/>
 		</conditions>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/legal-and-ethics/sensitive-data-personal_data/dsgvo_9">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/legal-and-ethics/sensitive-data-personal_data/dsgvo_9">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>dsgvo_9</key>
 		<path>textcorpus_dfg/legal-and-ethics/sensitive-data-personal_data/dsgvo_9</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sensitive_data/personal_data/bdsg_3_9"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/legal-and-ethics/sensitive-data-personal_data"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/legal-and-ethics/sensitive-data-personal_data"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en">These kinds of data are considered particularly sensitive and require even more extensive safeguards. If you answer this question with &quot;Yes&quot;, please get in touch with the data protection officer of your institution to check which additional protection measures are necessary.</help>
@@ -1314,13 +1314,13 @@ Landesdatenschutzgesetz (genaue Abgrenzung siehe § 1 BDSG). In bestimmten Berei
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/legal-and-ethics/sensitive-data-personal_data/anonymization">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/legal-and-ethics/sensitive-data-personal_data/anonymization">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>anonymization</key>
 		<path>textcorpus_dfg/legal-and-ethics/sensitive-data-personal_data/anonymization</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sensitive_data/personal_data/anonymization"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/legal-and-ethics/sensitive-data-personal_data"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/legal-and-ethics/sensitive-data-personal_data"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -1338,17 +1338,17 @@ Landesdatenschutzgesetz (genaue Abgrenzung siehe § 1 BDSG). In bestimmten Berei
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_anonymisation"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_anonymisation"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/legal-and-ethics/sensitive-data-personal_data/extent">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/legal-and-ethics/sensitive-data-personal_data/extent">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>extent</key>
 		<path>textcorpus_dfg/legal-and-ethics/sensitive-data-personal_data/extent</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sensitive_data/personal_data/consent/extent"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/legal-and-ethics/sensitive-data-personal_data"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/legal-and-ethics/sensitive-data-personal_data"/>
 		<is_collection>False</is_collection>
 		<order>3</order>
 		<help lang="en">Basically, the collection, processing, archiving and publication of personal data is only admissible, when the “informed consent” of the person in question has been obtained. However, there are a number of exceptions, some of which are described in Art. 6 of the General Data Protection Regulation or which have been made possible by law. For example, § 17 Datenschutzgesetz Nordrhein-Westfalen (DSG-NRW, 17 Mai 2018) allows the processing of personal data for scientific or historical research purposes or for statistical purposes even without consent if processing for these purposes is necessary and protected interests of the person concerned do not prevail.</help>
@@ -1366,17 +1366,17 @@ Landesdatenschutzgesetz (genaue Abgrenzung siehe § 1 BDSG). In bestimmten Berei
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/informed_consent_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/informed_consent_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/legal-and-ethics/sensitive-data-personal_data/statement">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/legal-and-ethics/sensitive-data-personal_data/statement">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>statement</key>
 		<path>textcorpus_dfg/legal-and-ethics/sensitive-data-personal_data/statement</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sensitive_data/personal_data/consent/statement"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/legal-and-ethics/sensitive-data-personal_data"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/legal-and-ethics/sensitive-data-personal_data"/>
 		<is_collection>False</is_collection>
 		<order>4</order>
 		<help lang="en"/>
@@ -1396,13 +1396,13 @@ Landesdatenschutzgesetz (genaue Abgrenzung siehe § 1 BDSG). In bestimmten Berei
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/legal-and-ethics/intellectual-property-rights-yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/legal-and-ethics/intellectual-property-rights-yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>intellectual-property-rights-yesno</key>
 		<path>textcorpus_dfg/legal-and-ethics/intellectual-property-rights-yesno</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/legal-and-ethics"/>
 		<is_collection>False</is_collection>
 		<order>30</order>
 		<title lang="en">Intellectual property rights I</title>
@@ -1415,13 +1415,13 @@ Landesdatenschutzgesetz (genaue Abgrenzung siehe § 1 BDSG). In bestimmten Berei
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/legal-and-ethics/intellectual-property-rights-yesno/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/legal-and-ethics/intellectual-property-rights-yesno/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>textcorpus_dfg/legal-and-ethics/intellectual-property-rights-yesno/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/legal_aspects/ipr/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/legal-and-ethics/intellectual-property-rights-yesno"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/legal-and-ethics/intellectual-property-rights-yesno"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<help lang="en">From the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/guidelines_review_board_linguistics_corpora.pdf&quot; target=_blank&gt;Guidelines for Building Language Corpora Under German Law&lt;/a&gt;:
@@ -1469,13 +1469,13 @@ Allen Leistungsschutzrechten ist neben der kürzeren Laufzeit im Vergleich zum U
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/legal-and-ethics/intellectual-property-rights-dataset">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/legal-and-ethics/intellectual-property-rights-dataset">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>intellectual-property-rights-dataset</key>
 		<path>textcorpus_dfg/legal-and-ethics/intellectual-property-rights-dataset</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/legal-and-ethics"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/legal-and-ethics"/>
 		<is_collection>True</is_collection>
 		<order>31</order>
 		<title lang="en">Intellectual property rights II</title>
@@ -1487,16 +1487,16 @@ Allen Leistungsschutzrechten ist neben der kürzeren Laufzeit im Vergleich zum U
 		<verbose_name lang="de">Datensatz</verbose_name>
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions>
-			<condition dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/conditions/intellectual_property_rights"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/intellectual_property_rights"/>
 		</conditions>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/legal-and-ethics/intellectual-property-rights-dataset/copyrights">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/legal-and-ethics/intellectual-property-rights-dataset/copyrights">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>copyrights</key>
 		<path>textcorpus_dfg/legal-and-ethics/intellectual-property-rights-dataset/copyrights</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/ipr/copyrights"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
 		<is_collection>True</is_collection>
 		<order>0</order>
 		<help lang="en">From the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/guidelines_review_board_linguistics_corpora.pdf&quot; target=_blank&gt;Guidelines for Building Language Corpora Under German Law&lt;/a&gt;:
@@ -1526,17 +1526,17 @@ Keine Bearbeitung mehr, sondern ein eigenständiges neues Werk liegt dann vor, w
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_copyright_laws"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_copyright_laws"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/legal-and-ethics/intellectual-property-rights-dataset/other_rights">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/legal-and-ethics/intellectual-property-rights-dataset/other_rights">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>other_rights</key>
 		<path>textcorpus_dfg/legal-and-ethics/intellectual-property-rights-dataset/other_rights</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/ipr/other_rights"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
 		<is_collection>True</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -1554,17 +1554,17 @@ Keine Bearbeitung mehr, sondern ein eigenständiges neues Werk liegt dann vor, w
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/dataset_other_rights"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_other_rights"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/legal-and-ethics/intellectual-property-rights-dataset/owner">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/legal-and-ethics/intellectual-property-rights-dataset/owner">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>owner</key>
 		<path>textcorpus_dfg/legal-and-ethics/intellectual-property-rights-dataset/owner</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/ipr/owner/name"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
 		<is_collection>False</is_collection>
 		<order>3</order>
 		<help lang="en"/>
@@ -1582,17 +1582,17 @@ Keine Bearbeitung mehr, sondern ein eigenständiges neues Werk liegt dann vor, w
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/yes_with_text_no"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/yes_with_text_no"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/legal-and-ethics/intellectual-property-rights-dataset/status">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/legal-and-ethics/intellectual-property-rights-dataset/status">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>status</key>
 		<path>textcorpus_dfg/legal-and-ethics/intellectual-property-rights-dataset/status</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/ipr/status"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/legal-and-ethics/intellectual-property-rights-dataset"/>
 		<is_collection>False</is_collection>
 		<order>4</order>
 		<help lang="en">From the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/guidelines_review_board_linguistics_corpora.pdf&quot; target=_blank&gt;Guidelines for Building Language Corpora Under German Law&lt;/a&gt;:
@@ -1616,23 +1616,23 @@ Die für Textkorpora relevanten Regelungen des Urheberrechtsgesetz betreffen vor
 		<optionsets/>
 		<conditions/>
 	</question>
-	<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/storage-and-long-term-preservation">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<section dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/storage-and-long-term-preservation">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>storage-and-long-term-preservation</key>
 		<path>textcorpus_dfg/storage-and-long-term-preservation</path>
 		<dc:comment/>
-		<catalog dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg"/>
+		<catalog dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg"/>
 		<order>10</order>
 		<title lang="en">Storage and long-term preservation</title>
 		<title lang="de">Speicherung und Langzeitarchivierung</title>
 	</section>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/storage-and-long-term-preservation/selection-criteria">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/storage-and-long-term-preservation/selection-criteria">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>selection-criteria</key>
 		<path>textcorpus_dfg/storage-and-long-term-preservation/selection-criteria</path>
 		<dc:comment/>
 		<attribute/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/storage-and-long-term-preservation"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/storage-and-long-term-preservation"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<title lang="en">Selection</title>
@@ -1645,13 +1645,13 @@ Die für Textkorpora relevanten Regelungen des Urheberrechtsgesetz betreffen vor
 		<verbose_name_plural lang="de"/>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/storage-and-long-term-preservation/selection-criteria/selection_criteria">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/storage-and-long-term-preservation/selection-criteria/selection_criteria">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>selection_criteria</key>
 		<path>textcorpus_dfg/storage-and-long-term-preservation/selection-criteria/selection_criteria</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/preservation/selection_criteria"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/storage-and-long-term-preservation/selection-criteria"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/storage-and-long-term-preservation/selection-criteria"/>
 		<is_collection>False</is_collection>
 		<order>0</order>
 		<help lang="en">From the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/grundlagen_dfg_foerderung/informationen_fachwissenschaften/geisteswissenschaften/standards_sprachkorpora.pdf&quot; target=_blank&quot;&gt; Recommendations on data technology standards and tools for the collection of writing corpora &lt;/a&gt; (in German):
@@ -1681,13 +1681,13 @@ Für die Konzeption des angestrebten Korpus sollten die Faktoren der Korpusgrö�
 		<optionsets/>
 		<conditions/>
 	</question>
-	<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>long-term-preservation-datasets</key>
 		<path>textcorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
-		<section dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/storage-and-long-term-preservation"/>
+		<section dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/storage-and-long-term-preservation"/>
 		<is_collection>True</is_collection>
 		<order>11</order>
 		<title lang="en">Long-term preservation</title>
@@ -1700,13 +1700,13 @@ Für die Konzeption des angestrebten Korpus sollten die Faktoren der Korpusgrö�
 		<verbose_name_plural lang="de">Datensätze</verbose_name_plural>
 		<conditions/>
 	</questionset>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/yesno">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/yesno">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>yesno</key>
 		<path>textcorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/yesno</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/yesno"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<help lang="en"/>
@@ -1726,13 +1726,13 @@ Für die Konzeption des angestrebten Korpus sollten die Faktoren der Korpusgrö�
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/purpose">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/purpose">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>purpose</key>
 		<path>textcorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/purpose</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/purpose"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>True</is_collection>
 		<order>2</order>
 		<help lang="en"/>
@@ -1750,17 +1750,17 @@ Für die Konzeption des angestrebten Korpus sollten die Faktoren der Korpusgrö�
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/preservation_motivation_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/preservation_motivation_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/duration">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/duration">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>duration</key>
 		<path>textcorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/duration</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/duration"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>False</is_collection>
 		<order>3</order>
 		<help lang="en"/>
@@ -1780,13 +1780,13 @@ Für die Konzeption des angestrebten Korpus sollten die Faktoren der Korpusgrö�
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/repository">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/repository">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>repository</key>
 		<path>textcorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/repository</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/repository"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>True</is_collection>
 		<order>5</order>
 		<help lang="en">In the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/grundlagen_dfg_foerderung/informationen_fachwissenschaften/geisteswissenschaften/standards_sprachkorpora.pdf&quot; target=_blank&quot;&gt; Recommendations on data technology standards and tools for the collection of writing corpora &lt;/a&gt; (in German), criteria for the selection can be found (see there) and the following repositories are recommended:
@@ -1842,17 +1842,17 @@ Für Schulprojekte kommt der &lt;a href=&quot;https://www.forschungsdaten-bildun
 		<step/>
 		<unit/>
 		<optionsets>
-			<optionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/options/preservation_repository_options"/>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/preservation_repository_options"/>
 		</optionsets>
 		<conditions/>
 	</question>
-	<question dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/access_authentication">
-		<uri_prefix>https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo</uri_prefix>
+	<question dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/access_authentication">
+		<uri_prefix>https://rdmo.fodako.nrw</uri_prefix>
 		<key>access_authentication</key>
 		<path>textcorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets/access_authentication</path>
 		<dc:comment>Original from H2020 FAIR Data Management Plan</dc:comment>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/access_authentication"/>
-		<questionset dc:uri="https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo/questions/textcorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmo.fodako.nrw/questions/textcorpus_dfg/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>False</is_collection>
 		<order>9</order>
 		<help lang="en">From the &lt;a href=&quot;https://www.dfg.de/download/pdf/foerderung/antragstellung/forschungsdaten/guidelines_review_board_linguistics_corpora.pdf target=_blank&gt;Guidelines for Building Language Corpora Under German Law&lt;/a&gt;, section 2.3.2:


### PR DESCRIPTION
This PR replaces `https://ed45a26fb17322518ab44517596c99f815c6df14.rdmo` with `https://rdmo.fodako.nrw` as uri prefix for the content in `shared/fodako` and fixes references to `https://rdmorganiser.github.io/terms` optionsets and conditions.