### PR TITLE
Fix syntax errors in the dmptool view

### DIFF
--- a/rdmorganiser/views/dmptool.xml
+++ b/rdmorganiser/views/dmptool.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<rdmo created="2021-09-28T14:11:04.158776+02:00" xmlns:dc="http://purl.org/dc/elements/1.1/">
+<rdmo created="2021-10-06T10:23:37.435503+02:00" xmlns:dc="http://purl.org/dc/elements/1.1/">
 	<view dc:uri="https://rdmorganiser.github.io/terms/views/dmptool">
 		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
 		<key>dmptool</key>
@@ -203,7 +203,7 @@
 
 {% for dataset in datasets %}
 &lt;p&gt;
-	{% render_set_value dataset'project/dataset/preservation/access_authentication' %}
+	{% render_set_value dataset 'project/dataset/preservation/access_authentication' %}
 &lt;/p&gt;
 {% endfor %}
 
@@ -256,9 +256,9 @@
 	&quot;Informed consent&quot; will be obtained from the person(s) concerned:
 	{% render_set_value dataset 'project/dataset/sensitive_data/personal_data/consent/extent' %}
 &lt;/p&gt;
-{% endif %}
 {% endfor %}
-			
+{% endif %}
+
 &lt;p&gt;
 	&lt;b&gt;What have you done to comply with your obligations in your IRB Protocol?&lt;/b&gt;
 &lt;/p&gt;


### PR DESCRIPTION
Something went wrong with the dmptool.xml. The older version on rdmo.aip.de (with outdated attributes) works, but the current one here is broken.