### PR TITLE
Corrections in new attributes

### DIFF
--- a/rdmorganiser/domain/rdmo.xml
+++ b/rdmorganiser/domain/rdmo.xml
@@ -459,7 +459,7 @@
 		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
 		<key>documentation_on_request</key>
 		<path>project/dataset/documentation_on_request</path>
-		<dc:comment>Added for the question which data documention is only available on request. The question was of relevance for DFG projects in educational research until 2021, see Petra Stanat, Bereitstellung und Nutzung quantitativer Forschungsdaten in der Bildungsforschung: Memorandum des Fachkollegiums &quot;Erziehungswissenschaft&quot; der DFG, 2015, https://www.dfg.de/download/pdf/foerderung/grundlagen_dfg_foerderung/forschungsdaten/richtlinien_forschungsdaten_bildungsforschung.pdf.</dc:comment>
+		<dc:comment>Added for the question &quot;Which data documention is only available on request?&quot; The question was of relevance for DFG projects in educational research until 2021, see Petra Stanat, Bereitstellung und Nutzung quantitativer Forschungsdaten in der Bildungsforschung: Memorandum des Fachkollegiums &quot;Erziehungswissenschaft&quot; der DFG, 2015, https://www.dfg.de/download/pdf/foerderung/grundlagen_dfg_foerderung/forschungsdaten/richtlinien_forschungsdaten_bildungsforschung.pdf.</dc:comment>
 		<parent dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset"/>
 	</attribute>
 	<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/format">


### PR DESCRIPTION
This pull request adds fixes to https://github.com/rdmorganiser/rdmo-catalog/commit/b890c28f46d90ce2f3337f6aa169fcb1f05c1aab

Parent corrected in attributes
  - project/costs/other_research_output/non_personnel and 
  - project/costs/other_research_output/non_personnelproject/costs/other_research_output/personnel
to project/costs/other_research_output

Corrections in comments:
  - German quotations marks replaces by &quot;
  - Unvalid DFG web links renewed
  - Comments improved, especially for attibute project/dataset/reuse_existing: required by Horizon Europe