### PR TITLE
Add help text to `technical-classification/data-volume/volume`

### DIFF
--- a/rdmorganiser/questions/rdmo.xml
+++ b/rdmorganiser/questions/rdmo.xml
@@ -1415,8 +1415,8 @@ Altri tipi di dati sono di per sé unici e non possono essere rigenerati. Questo
 		<text lang="de">Was ist die tatsächliche oder erwartete Größe des Datensatzes?</text>
 		<verbose_name lang="de"/>
 		<verbose_name_plural lang="de"/>
-		<help lang="fr">Dans le cas où des grandes quantités de données jouent un rôle, on devrait avoir à disposition des ressources économiques adapté pour garantir l'infrastructure (voire aussi le chapitre «&#8239;Financement&#8239;»).</help>
-		<help lang="it">Qualora siano coinvolte grandi quantità di dati, si dovrebbero avere a disposizione richiedere risorse economiche adeguate per l'adeguamento dell'infrastruttura (vedi Sezione "Finanziamento").</help>
+		<help lang="fr">Dans le cas où des grandes quantités de données jouent un rôle, on devrait avoir à disposition des ressources économiques suffisantes pour garantir l'infrastructure nécessaire (voire aussi le chapitre «&#8239;Financement&#8239;»).</help>
+		<help lang="it">Qualora siano coinvolte grandi quantità di dati, si dovrebbero avere a disposizione richiedere risorse economiche sufficienti a coprire l'infrastruttura necessaria (vedi Sezione "Finanziamento").</help>
 		<text lang="fr">Quelle est la taille actuelle ou attendue du jeu de données&#8239;?</text>
 		<text lang="it">Qual è il volume reale o atteso dei dati?</text>
 		<verbose_name lang="fr"/>

--- a/rdmorganiser/questions/rdmo.xml
+++ b/rdmorganiser/questions/rdmo.xml
@@ -1415,8 +1415,8 @@ Altri tipi di dati sono di per sé unici e non possono essere rigenerati. Questo
 		<text lang="de">Was ist die tatsächliche oder erwartete Größe des Datensatzes?</text>
 		<verbose_name lang="de"/>
 		<verbose_name_plural lang="de"/>
-		<help lang="fr"/>
-		<help lang="it"/>
+		<help lang="fr">Dans le cas où des grandes quantités de données jouent un rôle, on devrait avoir à disposition des ressources économiques adapté pour garantir l'infrastructure (voire aussi le chapitre «&#8239;Financement&#8239;»).</help>
+		<help lang="it">Qualora siano coinvolte grandi quantità di dati, si dovrebbero avere a disposizione richiedere risorse economiche adeguate per l'adeguamento dell'infrastruttura (vedi Sezione "Finanziamento").</help>
 		<text lang="fr">Quelle est la taille actuelle ou attendue du jeu de données&#8239;?</text>
 		<text lang="it">Qual è il volume reale o atteso dei dati?</text>
 		<verbose_name lang="fr"/>

--- a/rdmorganiser/questions/rdmo.xml
+++ b/rdmorganiser/questions/rdmo.xml
@@ -1407,11 +1407,11 @@ Altri tipi di dati sono di per sé unici e non possono essere rigenerati. Questo
 		<questionset dc:uri="https://rdmorganiser.github.io/terms/questions/rdmo/technical-classification/data-volume"/>
 		<is_collection>False</is_collection>
 		<order>1</order>
-		<help lang="en"/>
+		<help lang="en">If large amounts of data are involved, financial resources for the provision of the infrastructure should be considered (see also section "Funding").</help>
 		<text lang="en">What is the actual or expected size of the dataset?</text>
 		<verbose_name lang="en"/>
 		<verbose_name_plural lang="en"/>
-		<help lang="de"/>
+		<help lang="de">Wenn große Datenmengen anfallen, sollten finanzielle Mittel zur Bereitstellung der Infrastruktur berücksichtigt werden (siehe auch Abschnitt „Förderung“).</help>
 		<text lang="de">Was ist die tatsächliche oder erwartete Größe des Datensatzes?</text>
 		<verbose_name lang="de"/>
 		<verbose_name_plural lang="de"/>
@@ -1443,16 +1443,16 @@ Altri tipi di dati sono di per sé unici e non possono essere rigenerati. Questo
 		<questionset dc:uri="https://rdmorganiser.github.io/terms/questions/rdmo/technical-classification/data-volume"/>
 		<is_collection>False</is_collection>
 		<order>2</order>
-		<help lang="en">Optional. This is only of concern if the data production rate reaches TB scale.</help>
+		<help lang="en"/>
 		<text lang="en">How much data are produced per year?</text>
 		<verbose_name lang="en"/>
 		<verbose_name_plural lang="en"/>
-		<help lang="de">Optional. Dies ist nur relevant, wenn das Wachstum die TB-Größenordnung erreicht.</help>
+		<help lang="de"/>
 		<text lang="de">Wie hoch ist die erwartete Erzeugungsrate der Daten pro Jahr?</text>
 		<verbose_name lang="de"/>
 		<verbose_name_plural lang="de"/>
-		<help lang="fr">Optionnel. Cela n'est concerné que si le taux de production des données atteint l'échelle de TB.</help>
-		<help lang="it">Opzionale. Questo è rilevante solo se il tasso di produzione dei dati raggiunge l'ordine dei TB.</help>
+		<help lang="fr"/>
+		<help lang="it"/>
 		<text lang="fr">Combien de données sont produites par an&#8239;?</text>
 		<text lang="it">Quanti dati vengono prodotti in un anno?</text>
 		<verbose_name lang="fr"/>


### PR DESCRIPTION
Removed help text of question `technical-classification/data-volume/rate` and added help text to question `technical-classification/data-volume/volume` as suggested in #109.

An italian and french translation cannot be provided.