### PR TITLE
Corrections in Horizon Europe catalog

### DIFF
--- a/rdmorganiser/options/rdmo.xml
+++ b/rdmorganiser/options/rdmo.xml
@@ -254,7 +254,7 @@
 		<order>9</order>
 		<text lang="en">Generated data: from transformation/analysis of other data</text>
 		<text lang="de">Selbst erzeugte Daten: durch Transformation / Analyse anderer Daten</text>
-		<text lang="es">Datos generados: a partid de tranformación o análisis de otros datos</text>
+		<text lang="es">Datos generados: a partir de transformación o análisis de otros datos</text>
 		<text lang="fr">Données produites&#8239;: à partir de l'analyse ou du raffinement de données existantes</text>
 		<text lang="it">Dati generati: dalla trasformazione o analisi di dati esistenti</text>
 		<additional_input>True</additional_input>
@@ -450,7 +450,7 @@
 		<order>2</order>
 		<text lang="en">Information on methodology used for data cleaning and analysis</text>
 		<text lang="de">Information zu Verfahren der Datenbereinigung und -analyse</text>
-		<text lang="es">Información sobre la metodología utilizada para la lselección y el análisis de los datos</text>
+		<text lang="es">Información sobre la metodología utilizada para la selección y el análisis de los datos</text>
 		<text lang="fr">Information sur la méthodologie employée pour la filtration et l'analyse des données</text>
 		<text lang="it">Informazioni sui metodi usati per la selezione e l'analisi dei dati</text>
 		<additional_input>True</additional_input>

--- a/rdmorganiser/options/rdmo.xml
+++ b/rdmorganiser/options/rdmo.xml
@@ -16,6 +16,7 @@
 		<order>1</order>
 		<text lang="en">Users are required to register in order to use the repository</text>
 		<text lang="de">Nutzende müssen sich registrieren, um das Repositorium nutzen zu können.</text>
+		<text lang="es">Los usuarios deben registrarse para acceder al repositorio</text>
 		<text lang="fr">Les utilisateurs doivent s'inscrire pour accéder au dépôt</text>
 		<text lang="it">Gli utenti devono registrarsi per poter accedere al repositorio</text>
 		<additional_input>False</additional_input>
@@ -29,6 +30,7 @@
 		<order>2</order>
 		<text lang="en">If necessary, an authentication system or a data on demand function will be provided</text>
 		<text lang="de">Wenn notwendig, ein System für die Authentifizierung oder eine Datenabfragefunktion wird etabliert</text>
+		<text lang="es">Si es necesario, se proporcionará un sistema de identificación o una función de consulta de datos</text>
 		<text lang="fr">Si nécessaire, un système d'identification ou une fonction de requête sur demande seront fournis</text>
 		<text lang="it">Se necessario, sarà allestito un sistema di autenticazione o una funzione di accesso su richiesta</text>
 		<additional_input>False</additional_input>
@@ -42,6 +44,7 @@
 		<order>3</order>
 		<text lang="en">Other</text>
 		<text lang="de">Sonstiges</text>
+		<text lang="es">Otro</text>
 		<text lang="fr">Autre</text>
 		<text lang="it">Altro</text>
 		<additional_input>True</additional_input>
@@ -55,6 +58,7 @@
 		<order>4</order>
 		<text lang="en">There is no need to ascertain the identity of persons accessing the data</text>
 		<text lang="de">Es besteht keine Notwendigkeit, die Identität von Personen zu prüfen, die auf die Daten zugreifen wollen</text>
+		<text lang="es">No es necesario verificar la identidad de las personas que acceden a los datos</text>
 		<text lang="fr">La vérification de l'identité des personnes accédant aux données n'est pas nécessaire</text>
 		<text lang="it">Non è necessaria un'identificazione di persone che ottengono l'accesso ai dati</text>
 		<additional_input>False</additional_input>
@@ -75,6 +79,7 @@
 		<order>1</order>
 		<text lang="en">Other scientists (from the own or another field)</text>
 		<text lang="de">Andere Wissenschaftlerinnen und Wissenschaftler (aus dem eigenen oder anderen Forschungsfeldern)</text>
+		<text lang="es">Otros científicos (del mismo campo o de otro)</text>
 		<text lang="fr">Scientifiques autres (du même domaine ou non)</text>
 		<text lang="it">Altri ricercatori (nello stesso o in un altro campo)</text>
 		<additional_input>True</additional_input>
@@ -88,6 +93,7 @@
 		<order>2</order>
 		<text lang="en">Stakeholders from industry / economy</text>
 		<text lang="de">Entscheidungsträger aus Industrie / Wirtschaft</text>
+		<text lang="es">Actores de la industria o de la economía</text>
 		<text lang="fr">Acteurs industriels ou de l'économie</text>
 		<text lang="it">Attori dal mondo dell'industria o dell'economia</text>
 		<additional_input>True</additional_input>
@@ -101,6 +107,7 @@
 		<order>3</order>
 		<text lang="en">Standardisation bodies</text>
 		<text lang="de">Normungsgremien</text>
+		<text lang="es">Organismos normativos</text>
 		<text lang="fr">Organismes de normalisation</text>
 		<text lang="it">Enti normativi</text>
 		<additional_input>True</additional_input>
@@ -114,6 +121,7 @@
 		<order>4</order>
 		<text lang="en">Politics / Decision makers</text>
 		<text lang="de">Politik / Entscheidungsträger</text>
+		<text lang="es">Responsables políticos o de la toma de decisiones</text>
 		<text lang="fr">Représentants politiques ou décideurs</text>
 		<text lang="it">Politici o decisori</text>
 		<additional_input>True</additional_input>
@@ -127,6 +135,7 @@
 		<order>5</order>
 		<text lang="en">Citizens</text>
 		<text lang="de">Öffentlichkeit</text>
+		<text lang="es">Ciudadanos</text>
 		<text lang="fr">Citoyens</text>
 		<text lang="it">Cittadini</text>
 		<additional_input>True</additional_input>
@@ -147,7 +156,8 @@
 		<order>1</order>
 		<text lang="en">Existing data: project own data</text>
 		<text lang="de">Bereits existierende Daten: projekteigene Daten</text>
-		<text lang="fr">Données existantes : elles appartiennent au projet</text>
+		<text lang="es">Datos existentes: datos específicos del proyecto</text>
+		<text lang="fr">Données existantes&#8239;: elles appartiennent au projet</text>
 		<text lang="it">Dati esistenti: disponibili internamente al progetto</text>
 		<additional_input>True</additional_input>
 	</option>
@@ -160,7 +170,8 @@
 		<order>2</order>
 		<text lang="en">Existing data: internal data of the project partners</text>
 		<text lang="de">Bereits existierende Daten: von Projektpartner geliefert</text>
-		<text lang="fr">Données existantes : elles appartiennent à certains partenaires du projet</text>
+		<text lang="es">Datos existentes: datos internos de los socios del proyecto</text>
+		<text lang="fr">Données existantes&#8239;: elles appartiennent à certains partenaires du projet</text>
 		<text lang="it">Dati esistenti: forniti da membri del progetto</text>
 		<additional_input>True</additional_input>
 	</option>
@@ -173,7 +184,8 @@
 		<order>3</order>
 		<text lang="en">Existing data: publicly available data</text>
 		<text lang="de">Bereits existierende Daten: öffentlich zugängliche Daten</text>
-		<text lang="fr">Données existantes : elles sont déjà ouvertes au publique</text>
+		<text lang="es">Datos existentes: datos disponibles públicamente</text>
+		<text lang="fr">Données existantes&#8239;: elles sont déjà ouvertes au publique</text>
 		<text lang="it">Dati esistenti: già pubblicati</text>
 		<additional_input>True</additional_input>
 	</option>
@@ -186,7 +198,8 @@
 		<order>5</order>
 		<text lang="en">Generated data: from experiments</text>
 		<text lang="de">Selbst erzeugte Daten: aus Experimenten</text>
-		<text lang="fr">Données produites : à partir d'expériences</text>
+		<text lang="es">Datos generados: a partir de experimentos</text>
+		<text lang="fr">Données produites&#8239;: à partir d'expériences</text>
 		<text lang="it">Dati generati: da esperimenti</text>
 		<additional_input>True</additional_input>
 	</option>
@@ -199,7 +212,8 @@
 		<order>6</order>
 		<text lang="en">Generated data: from simulations</text>
 		<text lang="de">Selbst erzeugte Daten: aus Simulationen</text>
-		<text lang="fr">Données produites : à partir de simulations</text>
+		<text lang="es">Datos generados: a partir de simulaciones</text>
+		<text lang="fr">Données produites&#8239;: à partir de simulations</text>
 		<text lang="it">Dati generati: da simulazioni</text>
 		<additional_input>True</additional_input>
 	</option>
@@ -212,7 +226,8 @@
 		<order>7</order>
 		<text lang="en">Generated data: from observations</text>
 		<text lang="de">Selbst erzeugte Daten: aus Beobachtungen</text>
-		<text lang="fr">Données produites : à partir d'observations</text>
+		<text lang="es">Datos generados: a partir de observaciones</text>
+		<text lang="fr">Données produites&#8239;: à partir d'observations</text>
 		<text lang="it">Dati generati: da studi osservativi</text>
 		<additional_input>True</additional_input>
 	</option>
@@ -225,7 +240,8 @@
 		<order>8</order>
 		<text lang="en">Generated data: from surveys</text>
 		<text lang="de">Selbst erzeugte Daten: aus Umfragen</text>
-		<text lang="fr">Données produites : à partir de questionnaires ou sondages</text>
+		<text lang="es">Datos generados: a partir de encuestas</text>
+		<text lang="fr">Données produites&#8239;: à partir de questionnaires ou sondages</text>
 		<text lang="it">Dati generati: da questionari o sondaggi</text>
 		<additional_input>True</additional_input>
 	</option>
@@ -238,7 +254,8 @@
 		<order>9</order>
 		<text lang="en">Generated data: from transformation/analysis of other data</text>
 		<text lang="de">Selbst erzeugte Daten: durch Transformation / Analyse anderer Daten</text>
-		<text lang="fr">Données produites : à partir de l'analyse ou du raffinement de données existantes</text>
+		<text lang="es">Datos generados: a partid de tranformación o análisis de otros datos</text>
+		<text lang="fr">Données produites&#8239;: à partir de l'analyse ou du raffinement de données existantes</text>
 		<text lang="it">Dati generati: dalla trasformazione o analisi di dati esistenti</text>
 		<additional_input>True</additional_input>
 	</option>
@@ -251,6 +268,7 @@
 		<order>10</order>
 		<text lang="en">Other</text>
 		<text lang="de">Sonstiges</text>
+		<text lang="es">Otro</text>
 		<text lang="fr">Autre</text>
 		<text lang="it">Altro</text>
 		<additional_input>True</additional_input>
@@ -271,8 +289,9 @@
 		<order>1</order>
 		<text lang="en">Legal restrictions: Permission is required to access the data or the researched object, and the grantors do not consent to the data being disseminated</text>
 		<text lang="de">Rechtliche Hinderungsgründe: Für den Zugang zu den Daten oder zum beforschten Objekt ist eine Genehmigung erforderlich und die Erteiler der Genehmigung sind mit einer Weitergabe der Daten nicht einverstanden</text>
-		<text lang="fr">Restrictions juridiques : les données sont soumises au consentement d'un tiers, qui n'a pas accordé leur ouverture au publique</text>
-		<text lang="it">Restrizioni legali: dati ottenuti con l'autorizzazione di un soggetto terzo, che non ha acconsentito alla loro diffusione pubblica</text>
+		<text lang="es">Restricciones legales: el acceso a los datos es condicionado a un permiso, pero el responsable de eso no no aceptó poner los datos a disposición del público</text>
+		<text lang="fr">Restrictions juridiques&#8239;: une autorisation est nécessaire pour l'accès aux données, mais le responsable n'a pas accordé leur ouverture au publique</text>
+		<text lang="it">Restrizioni legali: l'accesso ai dati avviene previa autorizzazione, ma il responsabile  non ha acconsentito alla loro diffusione pubblica</text>
 		<additional_input>True</additional_input>
 	</option>
 	<option dc:uri="https://rdmorganiser.github.io/terms/options/dataset_sharing_restrictions/privacy">
@@ -282,10 +301,11 @@
 		<dc:comment/>
 		<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_sharing_restrictions"/>
 		<order>2</order>
-		<text lang="en">Legal restrictions: sharing the data could reveal personal data for whose dissemination there is no consent</text>
-		<text lang="de">Rechtliche Hinderungsgründe: durch das Teilen der Daten könnten personenbezogene Daten preisgegeben werden, für deren Weitergabe es keine Einwilligung gibt</text>
-		<text lang="fr">Restrictions juridiques : le partage des données peut révéler l'identité d'un fabricant ou d'autres informations confidentiels</text>
-		<text lang="it">Restrizioni legali: la condivisione dei dati potrebbe rivelare l'identità di un fornitore o altre informazioni confidenziali</text>
+		<text lang="en">Legal restrictions: sharing the data might reveal personal information for whose dissemination there is no consent</text>
+		<text lang="de">Rechtliche Hinderungsgründe: durch das Teilen der Daten könnten personenbezogene Informationen preisgegeben werden, für deren Weitergabe es keine Einwilligung gibt</text>
+		<text lang="es">Restricciones legales: El intercambio de datos podría revelar informaciones personales, para cuya condivisión no hay un acuerdo</text>
+		<text lang="fr">Restrictions juridiques&#8239;: le partage des données pourrait révéler des informations personnelles, dont la condivision n'est pas réglé par un accord</text>
+		<text lang="it">Restrizioni legali: la condivisione dei dati potrebbe rivelare informazioni personali sulla cui condivisione non è stato raggiunto un accordo</text>
 		<additional_input>True</additional_input>
 	</option>
 	<option dc:uri="https://rdmorganiser.github.io/terms/options/dataset_sharing_restrictions/ipr">
@@ -295,10 +315,11 @@
 		<dc:comment/>
 		<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_sharing_restrictions"/>
 		<order>3</order>
-		<text lang="en">Legal restrictions: Parts of the data are intellectual property of third parties or a partner and the project does not own the right to disseminate the data</text>
-		<text lang="de">Rechtliche Hinderungsgründe: Teile der Daten sind geistiges Eigentum Dritter oder eines Partners und das Projekt besitzt nicht das Recht zur Weitergabe der Daten</text>
-		<text lang="fr">Restrictions juridiques : les données contiennent des informations relevant du secret des affaires et leur partage peut fragiliser la propriété intellectuelle de certains partenaires</text>
-		<text lang="it">Restrizioni legali: i dati contengono informazioni coperte dal segreto commerciale e la loro condivisione potrebbe indebolire la proprietà intellettuale di un partner</text>
+		<text lang="en">Legal restrictions: Parts of the data are intellectual property of a partner or of third parties and the project does not own the right to disseminate them</text>
+		<text lang="de">Rechtliche Hinderungsgründe: Teile der Daten sind geistiges Eigentum eines Partners oder Dritter und das Projekt besitzt nicht das Recht zu deren Weitergabe</text>
+		<text lang="es">Restricciones legales: una parte de los datos es propiedad intelectual de un socio o de terceros y el proyecto no conseguió autorización para compartirlos</text>
+		<text lang="fr">Restrictions juridiques&#8239;: une partie des données est propriété intellectuelle d'un partnenaire o de tiers et le projet n'a pas obtenu l'autorisation pour les partager</text>
+		<text lang="it">Restrizioni legali: una parte dei dati è proprietà intellettuale di un partner o di terzi e il progetto non è autorizzato a condividerli</text>
 		<additional_input>True</additional_input>
 	</option>
 	<option dc:uri="https://rdmorganiser.github.io/terms/options/dataset_sharing_restrictions/law">
@@ -310,7 +331,8 @@
 		<order>4</order>
 		<text lang="en">Legal restrictions: Risk of possible violation of (inter)national law or any constraints from the Grant Agreement</text>
 		<text lang="de">Rechtliche Hinderungsgründe: Risiko einer möglichen Verletzung (inter)nationalen Rechts oder von Bedingungen im Fördervertrag</text>
-		<text lang="fr">Restrictions juridiques : il existe un risque de violation d'une loi (y compris à l'étranger) ou d'une régle de l'accord de subvention</text>
+		<text lang="es">Restricciones legales: Riesgo de posible violación de la legislación (inter)nacional o de cualquier restricción del acuerdo de subvención</text>
+		<text lang="fr">Restrictions juridiques&#8239;: il existe un risque de violation d'une loi (y compris à l'étranger) ou d'une régle de l'accord de subvention</text>
 		<text lang="it">Restrizioni legali: rischio di possibile violazione di una legge (anche estera) o di una regola dell'accordo di finanziamento</text>
 		<additional_input>True</additional_input>
 	</option>
@@ -323,6 +345,7 @@
 		<order>5</order>
 		<text lang="en">Ethical restrictions, e.g. prevention of dual use, protection of vulnerable groups or endangered species, exclusion of stolen cultural assets</text>
 		<text lang="de">Ethische Hinderungsgründe, z.B. Beschränkung militärischer Nachnutzung, Schutz vulnerabler Gruppe oder gefährdeter Spezies, Ausschluss geraubter Kulturgüter</text>
+		<text lang="es">Restricciones éticas, por ejemplo, prevención del doble uso, protección de grupos vulnerables o especies en peligro, exclusión de bienes culturales robados</text>
 		<text lang="fr">Restrictions éthiques concernant par exemple des applications militaires, des groupes vulnérables, des espèces protégées ou l'exclusion de biens culturels volés</text>
 		<text lang="it">Restrizioni etiche: es. impedimento di riutilizzi militari, protezione di gruppi vulnerabili o specie protette, esclusione di beni culturali rubati</text>
 		<additional_input>True</additional_input>
@@ -336,7 +359,8 @@
 		<order>6</order>
 		<text lang="en">Voluntary restrictions: Data economy and better comprehensibility (no publication of pre-processed data without a clear reason for doing so)</text>
 		<text lang="de">Freiwillige Beschränkungen: Datensparsamkeit und bessere Verständlichkeit (keine Veröffentlichung von Zwischenergebnissen ohnen einen triftigen Grund)</text>
-		<text lang="fr">Restrictions propres : économie de données et cohérence (aucune publication de données intermédiaires sans raison clairement valable)</text>
+		<text lang="es">Restricciones voluntarias: Economía de datos y mayor comprensibilidad (no se publican datos preprocesados sin una razón clara para hacerlo)</text>
+		<text lang="fr">Restrictions propres&#8239;: économie de données et cohérence (aucune publication de données intermédiaires sans raison clairement valable)</text>
 		<text lang="it">Restrizioni volontarie: economia e comprensibilità (non pubblicazione di risultati intermedi senza una ragione specifica)</text>
 		<additional_input>True</additional_input>
 	</option>
@@ -349,7 +373,8 @@
 		<order>7</order>
 		<text lang="en">Voluntary restrictions: Use of results taken from past publications for confirmatory reasons only</text>
 		<text lang="de">Freiwillige Beschränkungen: Verwendung von Ergebnissen früherer Veröffentlichungen nur zu Bestätigungszwecken</text>
-		<text lang="fr">Restrictions propres : les résultats publiés existants ne sont utilisés que pour comparaison</text>
+		<text lang="es">Restricciones voluntarias: Utilización de resultados tomados de publicaciones anteriores sólo por razones de confirmación</text>
+		<text lang="fr">Restrictions propres&#8239;: les résultats publiés existants ne sont utilisés que pour comparaison</text>
 		<text lang="it">Restrizioni volontarie: utilizzo di risultati da pubblicazioni precedenti unicamente per confronto o conferma dei risultati</text>
 		<additional_input>True</additional_input>
 	</option>
@@ -362,7 +387,8 @@
 		<order>8</order>
 		<text lang="en">Voluntary restrictions: No direct relevance of the data for the main topic of the publication</text>
 		<text lang="de">Freiwillige Beschränkungen: keine direkte Relevanz der Daten für das Hauptthema der Textpublikation</text>
-		<text lang="fr">Restrictions propres : aucune pertinence des données pour le sujet principal de la publication</text>
+		<text lang="es">Restricciones voluntarias: No hay relevancia directa de los datos para el tema principal de la publicación</text>
+		<text lang="fr">Restrictions propres&#8239;: aucune pertinence des données pour le sujet principal de la publication</text>
 		<text lang="it">Restrizioni volontarie: mancata pertinenza dei dati rispetto al soggetto principale della pubblicazione</text>
 		<additional_input>True</additional_input>
 	</option>
@@ -375,7 +401,8 @@
 		<order>10</order>
 		<text lang="en">Voluntary restrictions: Redundancy of the data with the information already made available within a textual publication</text>
 		<text lang="de">Freiwillige Beschränkungen: Redundanz der Daten, wobei die Daten bereits in einer Textpublikation mit zur Verfügung gestellt worden sind</text>
-		<text lang="fr">Restrictions propres : redondance des données avec l'information rendue disponible dans une publication écrite</text>
+		<text lang="es">Restricciones voluntarias: Redundancia de los datos con la información ya disponible dentro de una publicación textual</text>
+		<text lang="fr">Restrictions propres&#8239;: redondance des données avec l'information rendue disponible dans une publication écrite</text>
 		<text lang="it">Restrizioni volontarie: ridondanza dei dati con l'informazione già contenuta in una pubblicazione testuale</text>
 		<additional_input>True</additional_input>
 	</option>
@@ -388,6 +415,7 @@
 		<order>11</order>
 		<text lang="en">Other restrictions</text>
 		<text lang="de">Andere Hinderungsgründe</text>
+		<text lang="es">Otras restricciones</text>
 		<text lang="fr">Autres restrictions</text>
 		<text lang="it">Altre restrizioni</text>
 		<additional_input>True</additional_input>
@@ -408,6 +436,7 @@
 		<order>1</order>
 		<text lang="en">Information on methodology used for data generation (creation or re-use) and transformation</text>
 		<text lang="de">Information zu Verfahren der Datenerzeugung und Weiterverarbeitung der Daten (auch bei Nachnutzung)</text>
+		<text lang="es">Información sobre la metodología utilizada para la generación (creación o reutilización) y transformación de datos</text>
 		<text lang="fr">Information sur la méthodologie employée pour la génération des données (création ou réutilisation) et leur transformation</text>
 		<text lang="it">Informazioni sui metodi usati per la creazione e la trasformazione dei dati</text>
 		<additional_input>True</additional_input>
@@ -421,6 +450,7 @@
 		<order>2</order>
 		<text lang="en">Information on methodology used for data cleaning and analysis</text>
 		<text lang="de">Information zu Verfahren der Datenbereinigung und -analyse</text>
+		<text lang="es">Información sobre la metodología utilizada para la lselección y el análisis de los datos</text>
 		<text lang="fr">Information sur la méthodologie employée pour la filtration et l'analyse des données</text>
 		<text lang="it">Informazioni sui metodi usati per la selezione e l'analisi dei dati</text>
 		<additional_input>True</additional_input>
@@ -434,6 +464,7 @@
 		<order>3</order>
 		<text lang="en">Description of variables used and respective units of measurement</text>
 		<text lang="de">Beschreibung der verwendeten Variablen und zugehörigen Maßeinheiten</text>
+		<text lang="es">Descripción de las variables utilizadas y sus respectivas unidades de medida</text>
 		<text lang="fr">Description des variables en jeu et leurs unités de mesure respectives</text>
 		<text lang="it">Descrizione delle variabili in gioco e delle rispettive unità di misura</text>
 		<additional_input>True</additional_input>
@@ -447,6 +478,7 @@
 		<order>4</order>
 		<text lang="en">Quality control report</text>
 		<text lang="de">Qualitätskontrollbericht</text>
+		<text lang="es">Reporte de control de calidad</text>
 		<text lang="fr">Rapport de contrôle qualité</text>
 		<text lang="it">Rapporto del controllo qualità</text>
 		<additional_input>True</additional_input>
@@ -460,6 +492,7 @@
 		<order>5</order>
 		<text lang="en">Version information</text>
 		<text lang="de">Versionsinformation</text>
+		<text lang="es">Información sobre la versión</text>
 		<text lang="fr">Information de version</text>
 		<text lang="it">Informazione di versione</text>
 		<additional_input>True</additional_input>
@@ -473,7 +506,8 @@
 		<order>6</order>
 		<text lang="en">For survey data: survey instruments (questionnaires, ...), interviewer instructions, codebooks, scale manuals, technical reports</text>
 		<text lang="de">Für Umfragedaten: Erhebungsinstrumente (Fragebögen, ...), Intervieweranweisungen, Codebücher, Skalenhandbücher, technische Berichte</text>
-		<text lang="fr">En cas d'entrevues : questionnaires, instructions pour les sondeurs, livres de code, manuelles d'échelle, rapports techniques</text>
+		<text lang="es">Para los datos de las encuestas: instrumentos de encuesta (cuestionarios, ...), instrucciones para el entrevistador, libros de códigos, manuales de escalas, informes técnicos</text>
+		<text lang="fr">En cas d'entrevues&#8239;: questionnaires, instructions pour les sondeurs, livres de code, manuelles d'échelle, rapports techniques</text>
 		<text lang="it">In caso di sondaggi: questionari, istruzioni per gli intervistatori, libri di codice, manuali di scala, rapporti tecnici</text>
 		<additional_input>True</additional_input>
 	</option>
@@ -486,6 +520,7 @@
 		<order>10</order>
 		<text lang="en">Other</text>
 		<text lang="de">Sonstiges</text>
+		<text lang="es">Otro</text>
 		<text lang="fr">Autre</text>
 		<text lang="it">Altro</text>
 		<additional_input>True</additional_input>
@@ -506,6 +541,7 @@
 		<order>1</order>
 		<text lang="en">Publication of the results in a peer-reviewed journal</text>
 		<text lang="de">Veröffentlichung der Ergebnisse in einer fachreferierten Zeitschrift</text>
+		<text lang="es">Publicación de los resultados en una revista revisada por expertos</text>
 		<text lang="fr">Publication des résultats dans une revue à comité de lecture</text>
 		<text lang="it">Pubblicazione dei risultati in una rivista con peer review</text>
 		<additional_input>False</additional_input>
@@ -519,6 +555,7 @@
 		<order>2</order>
 		<text lang="en">Achievement of intellectual property rights such as</text>
 		<text lang="de">Erlangung intellektueller Rechte wie</text>
+		<text lang="es">Consecución de derechos de propiedad intelectual como</text>
 		<text lang="fr">Obtention de droits de propriété intellectuelle tels que</text>
 		<text lang="it">Conseguimento di diritti di proprietà intellettuale come</text>
 		<additional_input>True</additional_input>
@@ -532,6 +569,7 @@
 		<order>3</order>
 		<text lang="en">Finishing of a bachelor/master/doctor thesis</text>
 		<text lang="de">Anfertigung einer Abschlussarbeit (Bachelor-, Master- oder Doktor-)</text>
+		<text lang="es">Finalización de una tesis de pregrado/máster/doctorado</text>
 		<text lang="fr">Réalisation d'une thèse (de licence, de master ou de doctorat)</text>
 		<text lang="it">Completamento di una tesi (triennale, specialistica o di dottorato)</text>
 		<additional_input>False</additional_input>
@@ -545,6 +583,7 @@
 		<order>10</order>
 		<text lang="en">Other</text>
 		<text lang="de">Sonstiges</text>
+		<text lang="es">Otro</text>
 		<text lang="fr">Autre</text>
 		<text lang="it">Altro</text>
 		<additional_input>True</additional_input>
@@ -565,6 +604,7 @@
 		<order>1</order>
 		<text lang="en">table</text>
 		<text lang="de">Tabelle</text>
+		<text lang="es">tabla</text>
 		<text lang="fr">tableau</text>
 		<text lang="it">tabella</text>
 		<additional_input>True</additional_input>
@@ -578,6 +618,7 @@
 		<order>2</order>
 		<text lang="en">graphics</text>
 		<text lang="de">Grafik</text>
+		<text lang="es">gráfico</text>
 		<text lang="fr">graphique</text>
 		<text lang="it">grafico</text>
 		<additional_input>True</additional_input>
@@ -591,6 +632,7 @@
 		<order>3</order>
 		<text lang="en">video</text>
 		<text lang="de">Video</text>
+		<text lang="es">video</text>
 		<text lang="fr">vidéo</text>
 		<text lang="it">video</text>
 		<additional_input>True</additional_input>
@@ -604,6 +646,7 @@
 		<order>4</order>
 		<text lang="en">audio</text>
 		<text lang="de">Audio</text>
+		<text lang="es">audio</text>
 		<text lang="fr">audio</text>
 		<text lang="it">audio</text>
 		<additional_input>True</additional_input>
@@ -617,6 +660,7 @@
 		<order>5</order>
 		<text lang="en">text</text>
 		<text lang="de">Text</text>
+		<text lang="es">texto</text>
 		<text lang="fr">texte</text>
 		<text lang="it">testo</text>
 		<additional_input>True</additional_input>
@@ -630,6 +674,7 @@
 		<order>6</order>
 		<text lang="en">database</text>
 		<text lang="de">Datenbank</text>
+		<text lang="es">base de datos</text>
 		<text lang="fr">base de données</text>
 		<text lang="it">banca dati</text>
 		<additional_input>True</additional_input>
@@ -643,6 +688,7 @@
 		<order>7</order>
 		<text lang="en">geospatial data</text>
 		<text lang="de">Geografische Information</text>
+		<text lang="es">datos geoespaciales</text>
 		<text lang="fr">données géospatiales</text>
 		<text lang="it">Dati geospaziali</text>
 		<additional_input>True</additional_input>
@@ -656,6 +702,7 @@
 		<order>8</order>
 		<text lang="en">computer-aided design</text>
 		<text lang="de">Computer Aided Design</text>
+		<text lang="es">diseño asistido por ordenador</text>
 		<text lang="fr">conception assistée par ordinateur</text>
 		<text lang="it">computer-aided design</text>
 		<additional_input>True</additional_input>
@@ -669,6 +716,7 @@
 		<order>9</order>
 		<text lang="en">statistical analysis</text>
 		<text lang="de">Statistische Auswertung</text>
+		<text lang="es">análisis estadístico</text>
 		<text lang="fr">analyse statistique</text>
 		<text lang="it">analisi statistica</text>
 		<additional_input>True</additional_input>
@@ -682,6 +730,7 @@
 		<order>10</order>
 		<text lang="en">Other</text>
 		<text lang="de">Sonstiges</text>
+		<text lang="es">Otro</text>
 		<text lang="fr">Autre</text>
 		<text lang="it">Altro</text>
 		<additional_input>True</additional_input>
@@ -702,6 +751,7 @@
 		<order>1</order>
 		<text lang="en">The generated ontologies and vocabularies for the published data are provided, together with appropriate mappings in an informal, lightweight form (glossaries, alignment tables, …) to more commonly used ontologies</text>
 		<text lang="de">Die generierten Ontologien und Vokabularien für die veröffentlichten Daten werden mitgeliefert, zusammen mit passenden Konkordanzen zu gängiger Terminologie, in einer leichten und informellen Weise (Glossar, Korrespondenztabelle, ...)</text>
+		<text lang="es">Se adjuntan las ontologías y vocabularios generados para los datos publicados. La correspondencia con terminologías de uso común se expresa de forma ligera e informal (glosario, tabla de alineación, ...).</text>
 		<text lang="fr">Les ontologies et vocabulaires générés pour les données publiées sont fournis. Les correspondances appropriées sont disposées de manière informelle et claire (glossaires, tableaux de correspondance, ...)</text>
 		<text lang="it">Le ontologie e i vocabolari generati per i dati pubblicati sono allegati. La corrispondenza a terminologie di uso comune è espressa in modo leggero e informale (glossario, tabella di allineamento, ...)</text>
 		<additional_input>True</additional_input>
@@ -715,6 +765,7 @@
 		<order>2</order>
 		<text lang="en">The generated ontologies and vocabularies for the published data are provided, together with appropriate mappings in a formal, heavyweight form (OWL, RDF, …) to more commonly used ontologies</text>
 		<text lang="de">Die generierten Ontologien und Vokabularien für die veröffentlichten Daten werden mitgeliefert, zusammen mit passenden Konkordanzen zu gängiger Terminologie, in einer vertieften und formellen Weise (OWL-Sprache, RDF-Modell, ...)</text>
+		<text lang="es">Se adjuntan las ontologías y vocabularios generados para los datos publicados. La correspondencia con las terminologías de uso común se expresa de manera formal y detallada (lenguaje OWL, modelo RDF, ...).</text>
 		<text lang="fr">Les ontologies et vocabulaires générés pour les données publiées sont fournis. Les correspondances appropriées sont disposées de manière formelle et détaillée (langage OWL, modèle RDF, ...)</text>
 		<text lang="it">Le ontologie e i vocabolari generati per i dati pubblicati sono allegati. La corrispondenza a terminologie di uso comune è espressa in modo formale e dettagliato (linguaggio OWL, modello RDF, ...)</text>
 		<additional_input>True</additional_input>
@@ -728,6 +779,7 @@
 		<order>3</order>
 		<text lang="en">No mappings are necessary, as the datasets are described using standard terminologies / There is no need for a mapping, since the used terminology is chosen to be compatible with the existing literature</text>
 		<text lang="de">Das Mitliefern von Konkordanzen is nicht notwendig aufgrund der Kompatibilität der verwendeten Terminologie mit der bestehenden Literatur</text>
+		<text lang="es">No es necesario realizar mapeos, ya que los conjuntos de datos se describen utilizando terminologías estándar / No es necesario realizar mapeos, ya que la terminología utilizada se elige para que sea compatible con la literatura existente</text>
 		<text lang="fr">Comme le jeu de données utilise des terminologies de référence ou compatibles avec la littérature existante, aucune correspondance est nécessaire</text>
 		<text lang="it">Non c'è bisogno di riportare corrispondenze, dato cha la terminologia usata è compatibile con la letteratura esistente</text>
 		<additional_input>True</additional_input>
@@ -748,6 +800,7 @@
 		<order>1</order>
 		<text lang="en">Software</text>
 		<text lang="de">Programme</text>
+		<text lang="es">Programas</text>
 		<text lang="fr">Logiciels</text>
 		<text lang="it">Programmi</text>
 		<additional_input>False</additional_input>
@@ -761,6 +814,7 @@
 		<order>2</order>
 		<text lang="en">Workflows</text>
 		<text lang="de">Workflows</text>
+		<text lang="es">Workflows</text>
 		<text lang="fr">Workflows</text>
 		<text lang="it">Workflows</text>
 		<additional_input>False</additional_input>
@@ -774,6 +828,7 @@
 		<order>3</order>
 		<text lang="en">Protocols</text>
 		<text lang="de">Protokolle</text>
+		<text lang="es">Protocolos</text>
 		<text lang="fr">Protocoles</text>
 		<text lang="it">Protocolli</text>
 		<additional_input>False</additional_input>
@@ -787,6 +842,7 @@
 		<order>4</order>
 		<text lang="en">Models</text>
 		<text lang="de">Modelle</text>
+		<text lang="es">Modelos</text>
 		<text lang="fr">Modèles</text>
 		<text lang="it">Modelli</text>
 		<additional_input>False</additional_input>
@@ -800,6 +856,7 @@
 		<order>5</order>
 		<text lang="en">Samples</text>
 		<text lang="de">Proben</text>
+		<text lang="es">Muestras</text>
 		<text lang="fr">Échantillons</text>
 		<text lang="it">Campioni</text>
 		<additional_input>False</additional_input>
@@ -813,6 +870,7 @@
 		<order>6</order>
 		<text lang="en">New materials</text>
 		<text lang="de">Neue Werkstoffe</text>
+		<text lang="es">Nuevos materiales</text>
 		<text lang="fr">Nouveaux matériaux</text>
 		<text lang="it">Nuovi materiali</text>
 		<additional_input>False</additional_input>
@@ -826,6 +884,7 @@
 		<order>7</order>
 		<text lang="en">New chemical substances (reagents, ...)</text>
 		<text lang="de">Neue chemische Substanzen (Reagenzien, ...)</text>
+		<text lang="es">Nuevas sustancias químicas (reactivos, ...)</text>
 		<text lang="fr">Nouvelles substances chimiques (réactants, ...)</text>
 		<text lang="it">Nuove sostanze chimiche (reagenti, ...)</text>
 		<additional_input>False</additional_input>
@@ -839,6 +898,7 @@
 		<order>8</order>
 		<text lang="en">New biological substances (antibodies, ...)</text>
 		<text lang="de">Neue biologische Substanzen (Antikörper, ...)</text>
+		<text lang="es">Nuevas sustancias biológicas (anticuerpos, ...)</text>
 		<text lang="fr">Nouvelles substances biologiques (anticorps, ...)</text>
 		<text lang="it">Nuove sostanze biologiche (anticorpi, ...)</text>
 		<additional_input>False</additional_input>
@@ -852,6 +912,7 @@
 		<order>10</order>
 		<text lang="en">Other</text>
 		<text lang="de">Sonstiges</text>
+		<text lang="es">Otro</text>
 		<text lang="fr">Autre</text>
 		<text lang="it">Altro</text>
 		<additional_input>True</additional_input>
@@ -872,6 +933,7 @@
 		<order>1</order>
 		<text lang="en">The repository</text>
 		<text lang="de">Das Repositorium</text>
+		<text lang="es">El repositorio</text>
 		<text lang="fr">Le dépôt</text>
 		<text lang="it">Il repositorio</text>
 		<additional_input>False</additional_input>
@@ -885,6 +947,7 @@
 		<order>2</order>
 		<text lang="en">The institutional library</text>
 		<text lang="de">Die Bibliothek des Instituts</text>
+		<text lang="es">La biblioteca institucional</text>
 		<text lang="fr">Le centre de documentation de l'institution</text>
 		<text lang="it">La biblioteca dell’istituto</text>
 		<additional_input>False</additional_input>
@@ -898,6 +961,7 @@
 		<order>3</order>
 		<text lang="en">The IT department of the institute</text>
 		<text lang="de">Das Rechenzentrum des Instituts</text>
+		<text lang="es">El departamento de informática del instituto</text>
 		<text lang="fr">Le service informatique de l'institution</text>
 		<text lang="it">Il centro di calcolo dell’istituto</text>
 		<additional_input>False</additional_input>
@@ -911,6 +975,7 @@
 		<order>4</order>
 		<text lang="en">The project coordinator</text>
 		<text lang="de">Der Projektkoordinator</text>
+		<text lang="es">El coordinador del proyecto</text>
 		<text lang="fr">Le coordinateur du projet</text>
 		<text lang="it">Il coordinatore del progetto</text>
 		<additional_input>False</additional_input>
@@ -924,6 +989,7 @@
 		<order>5</order>
 		<text lang="en">The data coordinator</text>
 		<text lang="de">Der Datenkoordinator</text>
+		<text lang="es">El responsable de los datos</text>
 		<text lang="fr">Le responsable des données</text>
 		<text lang="it">Il responsabile dei dati</text>
 		<additional_input>False</additional_input>
@@ -937,6 +1003,7 @@
 		<order>10</order>
 		<text lang="en">Other</text>
 		<text lang="de">Sonstiges</text>
+		<text lang="es">Otro</text>
 		<text lang="fr">Autre</text>
 		<text lang="it">Altro</text>
 		<additional_input>True</additional_input>
@@ -957,6 +1024,7 @@
 		<order>1</order>
 		<text lang="en">Yes, the data include qualified references to other datasets from the same project</text>
 		<text lang="de">Ja, die Daten enthalten qualifizierte Referenzen zu anderen Datensätzen desselben Projekts</text>
+		<text lang="es">Sí, los datos incluyen referencias cualificadas a otros conjuntos de datos del mismo proyecto</text>
 		<text lang="fr">Oui, les données se réfèrent à d'autres jeux de données du même projet</text>
 		<text lang="it">Sì, i dati contengono riferimenti qualificati ad altre raccolte di dati dello stesso progetto</text>
 		<additional_input>True</additional_input>
@@ -970,6 +1038,7 @@
 		<order>2</order>
 		<text lang="en">Yes, the data include qualified references to other datasets from previous research</text>
 		<text lang="de">Ja, die Daten enthalten qualifizierte Referenzen zu anderen Datensätzen aus vorherigen Forschungsaktivitäten</text>
+		<text lang="es">Sí, los datos incluyen referencias cualificadas a otros conjuntos de datos de investigaciones anteriores</text>
 		<text lang="fr">Oui, les données se réfèrent à d'autres jeux de données de recherches antérieurs</text>
 		<text lang="it">Sì, i dati contengono riferimenti qualificati ad altre raccolte di dati da ricerche precedenti</text>
 		<additional_input>True</additional_input>
@@ -983,6 +1052,7 @@
 		<order>3</order>
 		<text lang="en">No, the data do not include any references to other data</text>
 		<text lang="de">Nein, die Daten enthalten keine Referenzen anderer Daten</text>
+		<text lang="es">No, los datos no incluyen ninguna referencia a otros datos</text>
 		<text lang="fr">Non, les données ne font pas référence à d'autres données</text>
 		<text lang="it">No, i dati non fanno riferimenti ad altri dati</text>
 		<additional_input>True</additional_input>
@@ -1003,6 +1073,7 @@
 		<order>1</order>
 		<text lang="en">Completeness check</text>
 		<text lang="de">Prüfung auf Vollständigkeit</text>
+		<text lang="es">Control de integridad de los datos</text>
 		<text lang="fr">Contrôle d'intégralité des données</text>
 		<text lang="it">Controllo di integrità dei dati</text>
 		<additional_input>True</additional_input>
@@ -1016,6 +1087,7 @@
 		<order>2</order>
 		<text lang="en">Data reconciliation</text>
 		<text lang="de">Datenabgleich</text>
+		<text lang="es">Reconciliación de datos</text>
 		<text lang="fr">Réconciliation des données</text>
 		<text lang="it">Riconciliazione dei dati</text>
 		<additional_input>True</additional_input>
@@ -1029,6 +1101,7 @@
 		<order>3</order>
 		<text lang="en">Sampling procedures</text>
 		<text lang="de">Vorgehen bei der Probennahme</text>
+		<text lang="es">Procedimientos de muestreo</text>
 		<text lang="fr">Procédures d'échantillonnage</text>
 		<text lang="it">Procedure di campionamento</text>
 		<additional_input>True</additional_input>
@@ -1042,6 +1115,7 @@
 		<order>4</order>
 		<text lang="en">Repeated or comparative measurements</text>
 		<text lang="de">Wiederholte und vergleichbare Messungen</text>
+		<text lang="es">Mediciones repetidas o comparativas</text>
 		<text lang="fr">Mesures répétées ou comparées</text>
 		<text lang="it">Misure ripetute o comparative</text>
 		<additional_input>True</additional_input>
@@ -1055,6 +1129,7 @@
 		<order>5</order>
 		<text lang="en">Adherence to standard procedures for data recording</text>
 		<text lang="de">Konformität zu Standardprozeduren zur Datenaufnahme</text>
+		<text lang="es">Cumplimiento de los procedimientos estándar de registro de datos</text>
 		<text lang="fr">Acquisition des données en cohérence avec des procédures de référence</text>
 		<text lang="it">Acquisizione dei dati conforme a procedure standard</text>
 		<additional_input>True</additional_input>
@@ -1068,6 +1143,7 @@
 		<order>6</order>
 		<text lang="en">Use of controlled vocabularies and standard terminology</text>
 		<text lang="de">Verwendung kontrollierter Vokabulare und von Standard-Ausdrucksweise</text>
+		<text lang="es">Uso de vocabularios controlados y terminología estándar</text>
 		<text lang="fr">Utilisation de vocabulaires réglementés et d'une terminologie de référence</text>
 		<text lang="it">Uso di vocabolari controllati e terminologia standard</text>
 		<additional_input>True</additional_input>
@@ -1081,6 +1157,7 @@
 		<order>7</order>
 		<text lang="en">Metrological characterisation of the measurement set-up</text>
 		<text lang="de">Metrologische Charakterisierung des Messaufbaus</text>
+		<text lang="es">Caracterización metrológica del equipo de medición</text>
 		<text lang="fr">Charactérisation métrologique du procédé de mesure</text>
 		<text lang="it">Caratterizzazione metrologica dei procedimenti di misura</text>
 		<additional_input>True</additional_input>
@@ -1094,6 +1171,7 @@
 		<order>8</order>
 		<text lang="en">Data validation</text>
 		<text lang="de">Datenvalidierung</text>
+		<text lang="es">Validación de datos</text>
 		<text lang="fr">Validation des données</text>
 		<text lang="it">Validazione dei dati</text>
 		<additional_input>True</additional_input>
@@ -1107,6 +1185,7 @@
 		<order>9</order>
 		<text lang="en">Provision of test results along with the data</text>
 		<text lang="de">Verfügbarmachung von Testergebnissen zusammen mit den Daten</text>
+		<text lang="es">Suministro de los resultados de las pruebas junto con los datos</text>
 		<text lang="fr">Fourniture avec les données de résultats de tests</text>
 		<text lang="it">Disponibilità dei risultati di tests insieme con i dati</text>
 		<additional_input>True</additional_input>
@@ -1120,6 +1199,7 @@
 		<order>10</order>
 		<text lang="en">Peer review of textual publications based on the data</text>
 		<text lang="de">Peer-Review von Textpublikationen basierend auf den Daten</text>
+		<text lang="es">Revisión de las publicaciones textuales basadas en los datos</text>
 		<text lang="fr">Relecture par des paires de publication (textuel) se basant sur les données</text>
 		<text lang="it">Revisione di pubblicazioni testuali basate sui dati</text>
 		<additional_input>True</additional_input>
@@ -1133,6 +1213,7 @@
 		<order>20</order>
 		<text lang="en">Other</text>
 		<text lang="de">Sonstiges</text>
+		<text lang="es">Otro</text>
 		<text lang="fr">Autre</text>
 		<text lang="it">Altro</text>
 		<additional_input>True</additional_input>
@@ -1153,6 +1234,7 @@
 		<order>1</order>
 		<text lang="en">Yes, because of the big size of the data</text>
 		<text lang="de">Ja, wegen des großen Datenvolumens</text>
+		<text lang="es">Sí, debido al gran tamaño de los datos</text>
 		<text lang="fr">Oui, en raison de la quantité élevée de données</text>
 		<text lang="it">Sì, a causa della grande quantità dei dati</text>
 		<additional_input>True</additional_input>
@@ -1166,6 +1248,7 @@
 		<order>2</order>
 		<text lang="en">Yes, because of the particular format of the data</text>
 		<text lang="de">Ja, wegen des speziellen Datenformats</text>
+		<text lang="es">Sí, debido al formato particular de los datos</text>
 		<text lang="fr">Oui, en raison du format particulier des données</text>
 		<text lang="it">Sì, a causa della grande quantità dei dati</text>
 		<additional_input>True</additional_input>
@@ -1179,6 +1262,7 @@
 		<order>3</order>
 		<text lang="en">Yes, because the data are confidential</text>
 		<text lang="de">Ja, weil die Daten vertraulich sind</text>
+		<text lang="es">Sí, porque los datos son confidenciales</text>
 		<text lang="fr">Oui, parce que les données sont confidencielles</text>
 		<text lang="it">Sì, perché i dati sono confidenziali</text>
 		<additional_input>True</additional_input>
@@ -1192,6 +1276,7 @@
 		<order>4</order>
 		<text lang="en">Yes, because of legal issues related to the data</text>
 		<text lang="de">Ja, wegen rechtlicher Probleme mit den Daten</text>
+		<text lang="es">Sí, por cuestiones legales relacionadas con los datos</text>
 		<text lang="fr">Oui, pour des raisons juridiques en lien avec les données</text>
 		<text lang="it">Sì, a causa di problemi legali collegati ai dati</text>
 		<additional_input>True</additional_input>
@@ -1205,6 +1290,7 @@
 		<order>5</order>
 		<text lang="en">Yes, for other reasons</text>
 		<text lang="de">Ja, aus anderen Gründen</text>
+		<text lang="es">Sí, por otras razones</text>
 		<text lang="fr">Oui, pour d'autres raisons</text>
 		<text lang="it">Sì, per altri motivi</text>
 		<additional_input>True</additional_input>
@@ -1218,6 +1304,7 @@
 		<order>6</order>
 		<text lang="en">No, the data will be uploaded via a standard procedure and require no special arrangements</text>
 		<text lang="de">Nein, die Daten werden mit Hilfe einer Standardprozedur hochgeladen und erfordern keine speziellen Vorbereitungen</text>
+		<text lang="es">No, los datos se cargarán a través de un procedimiento estándar y no requieren ningún acuerdo especial</text>
 		<text lang="fr">Non, les données seront téléversées en suivant une procédure et non pas besoin d'ajustement particulier</text>
 		<text lang="it">No, i dati si possono caricare con una procedura standard e non necessitano accordi particolari</text>
 		<additional_input>True</additional_input>
@@ -1238,7 +1325,8 @@
 		<order>1</order>
 		<text lang="en">The repository meets the basic expectations of a research data repository: easy and free access while observing legal and ethical barriers, detailed metadata, protection against unauthorized access</text>
 		<text lang="de">Das Repositorium erfüllt die grundsätzlichen Erwartungen an ein Forschungsdatenrepositorium: leichter und kostenfreier Zugang bei Beachtung rechtlicher und ethischer Schranken, detaillierte Metadaten, Schutz gegen unautorisierten Zugriff</text>
-		<text lang="fr">Le dépôt remplit les attentes minimales en terme de stockage de données de recherche : accès simple et gratuit, tout en proposant des barrières juridiques et ethiques, des métadonnées détaillées, et une protection contre les accès prohibés.</text>
+		<text lang="es">El repositorio cumple con las expectativas básicas de un repositorio de datos de investigación: acceso fácil y gratuito respetando las barreras legales y éticas, metadatos detallados, protección contra el acceso no autorizado</text>
+		<text lang="fr">Le dépôt remplit les attentes minimales en terme de stockage de données de recherche&#8239;: accès simple et gratuit, tout en proposant des barrières juridiques et ethiques, des métadonnées détaillées, et une protection contre les accès prohibés.</text>
 		<text lang="it">Il repositorio soddisfa le richieste minime per la conservazione dei dati della ricerca: accesso agevole e gratuito pur nel rispetto delle barriere legali ed etiche, metadati dettagliati, protezione contro l'accesso non autorizzati</text>
 		<additional_input>True</additional_input>
 	</option>
@@ -1251,6 +1339,7 @@
 		<order>1</order>
 		<text lang="en">Machine-actionable and standardised metadata are used, e.g. Dublin Core</text>
 		<text lang="de">Maschinenlesbare und standardisierte Metadaten werden verwendet, z.B. Dublin Core</text>
+		<text lang="es">Se utilizan metadatos estandarizados y procesables por máquina, por ejemplo, Dublin Core</text>
 		<text lang="fr">Sont utilisées des métadonnées lisibles et exploitables par les machines (« machine-actionable ») et standardisées telles que « Dublin Core »</text>
 		<text lang="it">Sono utilizzati metadati leggibili e riutilizzabili da una macchina  («machine-actionable») e conformi a uno standard, es. Dublin Core</text>
 		<additional_input>True</additional_input>
@@ -1264,6 +1353,7 @@
 		<order>1</order>
 		<text lang="en">The repository can provide persistent identifiers, e.g. a DOI</text>
 		<text lang="de">Das Repositorium kann persistente Identifikatoren vergeben (z.B. einen DOI)</text>
+		<text lang="es">El repositorio puede proporcionar identificadores persistentes, por ejemplo, un DOI</text>
 		<text lang="fr">Le dépôt fournit des identificateurs persistents, par ex. des DOI</text>
 		<text lang="it">Il repositorio fornisce identificatori persistenti, es. DOI</text>
 		<additional_input>True</additional_input>
@@ -1277,6 +1367,7 @@
 		<order>1</order>
 		<text lang="en">The repository checks the quality of the data</text>
 		<text lang="de">Das Repositorium prüft die Qualität der Daten</text>
+		<text lang="es">El depósito comprueba la calidad de los datos</text>
 		<text lang="fr">Le dépôt contrôle la qualité des données</text>
 		<text lang="it">Il repositorio controlla la qualità dei dati</text>
 		<additional_input>True</additional_input>
@@ -1290,6 +1381,7 @@
 		<order>1</order>
 		<text lang="en">The repository offers expert curation for the long-term archivation</text>
 		<text lang="de">Das Repositorium bietet eine Datenpflege für die Langzeitarchivierung durch Experten an</text>
+		<text lang="es">El repositorio ofrece la curación de expertos para el archivo a largo plazo</text>
 		<text lang="fr">Le dépôt a une expertise en conservation et propose un archivage durable</text>
 		<text lang="it">Il repositorio offre un servizio professionale di cura dei dati per la conservazione a lungo termine</text>
 		<additional_input>True</additional_input>
@@ -1303,6 +1395,7 @@
 		<order>1</order>
 		<text lang="en">The repository offers services and mechanisms that go beyond the usual data download, which facilitate the subsequent use of the data, e.g. visualization, analysis tools.</text>
 		<text lang="de">Das Repositorium bietet über den üblichen Daten-Download hinausgehende Dienste und Mechanismen an, die die Nachnutzung der Daten erleichtern, z.B. Visualisierung, Analysetools</text>
+		<text lang="es">El repositorio ofrece servicios y mecanismos que van más allá de la habitual descarga de datos, que facilitan el uso posterior de los mismos, por ejemplo, visualización, herramientas de análisis.</text>
 		<text lang="fr">Au-delà du simple téléchargement, le dépôt propose des services ou des outils facilitant les manipulations ultérieures des données, permettant par exemple une visualisation ou une analyse</text>
 		<text lang="it">Oltre allo scaricamento dei dati, il repositorio offre servizi aggiuntivi che facilitano il riutilizzo dei dati, per esempio la visualizazione o l'analisi</text>
 		<additional_input>True</additional_input>
@@ -1316,6 +1409,7 @@
 		<order>1</order>
 		<text lang="en">The repository holds a certification</text>
 		<text lang="de">Das Repositorium ist zertifiziert</text>
+		<text lang="es">El depósito tiene una certificación</text>
 		<text lang="fr">Le dépôt a une certification à jour</text>
 		<text lang="it">Il repositorio possiede una certificazione ufficiale</text>
 		<additional_input>True</additional_input>
@@ -1329,6 +1423,7 @@
 		<order>2</order>
 		<text lang="en">The repository is internationally acknowledged for the a specific discipline/domain</text>
 		<text lang="de">Das Repositorium ist auf dem Fachgebiet international anerkannt</text>
+		<text lang="es">El repositorio está reconocido internacionalmente para una disciplina/dominio específico</text>
 		<text lang="fr">Le dépôt est reconnu internationallement pour un domaine particulier</text>
 		<text lang="it">Il repositorio gode di un riconoscimento internazionale per una disciplina o dominio specifico</text>
 		<additional_input>True</additional_input>
@@ -1342,6 +1437,7 @@
 		<order>3</order>
 		<text lang="en">The repository is managed by a trustworthy institution</text>
 		<text lang="de">Das Repositorium wird von einer vertrauenswürdigen Institution verwaltet</text>
+		<text lang="es">El depósito está gestionado por una institución de confianza</text>
 		<text lang="fr">Le dépôt est géré par un organisme de confiance</text>
 		<text lang="it">Il repositorio è gestito da un'istituzione considerata affidabile</text>
 		<additional_input>True</additional_input>
@@ -1355,6 +1451,7 @@
 		<order>4</order>
 		<text lang="en">The repository's policy is available online</text>
 		<text lang="de">Die Nutzungsbedingungen des Repositoriums sind online verfügbar</text>
+		<text lang="es">La política del depósito está disponible en línea</text>
 		<text lang="fr">La politique du dépôt est disponible en ligne</text>
 		<text lang="it">La regolamentazione del repositorio è disponibile in linea</text>
 		<additional_input>True</additional_input>
@@ -1375,6 +1472,7 @@
 		<order>1</order>
 		<text lang="en">Protection against unauthorized access</text>
 		<text lang="de">Schutz vor unerlaubtem Zugriff</text>
+		<text lang="es">Protección contra el acceso no autorizado</text>
 		<text lang="fr">Protection contre les accès indésirables</text>
 		<text lang="it">Protezione contro accessi indesiserati</text>
 		<additional_input>True</additional_input>
@@ -1388,7 +1486,8 @@
 		<order>2</order>
 		<text lang="en">Data robustness: checksum</text>
 		<text lang="de">Datenrobustheit: Checksumme</text>
-		<text lang="fr">Robustesse de données : somme de contrôle</text>
+		<text lang="es">Solidez de los datos: suma de comprobación</text>
+		<text lang="fr">Robustesse de données&#8239;: somme de contrôle</text>
 		<text lang="it">Robustezza dei dati: checksum</text>
 		<additional_input>True</additional_input>
 	</option>
@@ -1401,7 +1500,8 @@
 		<order>3</order>
 		<text lang="en">Data robustness: encryption</text>
 		<text lang="de">Datenrobustheit: Verschlüsselung</text>
-		<text lang="fr">Robustesse de données : chiffrement</text>
+		<text lang="es">Solidez de los datos: cifrado</text>
+		<text lang="fr">Robustesse de données&#8239;: chiffrement</text>
 		<text lang="it">Robustezza dei dati: cifratura</text>
 		<additional_input>True</additional_input>
 	</option>
@@ -1414,7 +1514,8 @@
 		<order>4</order>
 		<text lang="en">Data recovery: backups</text>
 		<text lang="de">Datenwiederherstellung: Backups</text>
-		<text lang="fr">Récupération de données : sauvegardes</text>
+		<text lang="es">Recuperación de datos: copias de seguridad</text>
+		<text lang="fr">Récupération de données&#8239;: sauvegardes</text>
 		<text lang="it">Recupero dei dati: backup</text>
 		<additional_input>True</additional_input>
 	</option>
@@ -1427,7 +1528,8 @@
 		<order>5</order>
 		<text lang="en">Data recovery: multiple replicas in a distributed file system</text>
 		<text lang="de">Datenwiederherstellung: redundante Kopien in einem verteilten Dateisystem</text>
-		<text lang="fr">Récupération de données : plusieures copies dans un système de fichier distribué</text>
+		<text lang="es">Recuperación de datos: múltiples réplicas en un sistema de archivos distribuido</text>
+		<text lang="fr">Récupération de données&#8239;: plusieures copies dans un système de fichier distribué</text>
 		<text lang="it">Recupero dei dati: copie multiple in un sistema distribuito di cartelle</text>
 		<additional_input>True</additional_input>
 	</option>
@@ -1440,7 +1542,8 @@
 		<order>6</order>
 		<text lang="en">Sensitive data: anonymisation or pseudonymisation</text>
 		<text lang="de">Sensible Daten: Anonymisierung oder Pseudonymisierung</text>
-		<text lang="fr">Données sensibles : anonymisation ou pseudonymisation</text>
+		<text lang="es">Datos sensibles: anonimización o seudonimización</text>
+		<text lang="fr">Données sensibles&#8239;: anonymisation ou pseudonymisation</text>
 		<text lang="it">Dati sensibili: anonimizzazione o pseudonimizzazione</text>
 		<additional_input>True</additional_input>
 	</option>
@@ -1453,6 +1556,7 @@
 		<order>10</order>
 		<text lang="en">Other</text>
 		<text lang="de">Sonstiges</text>
+		<text lang="es">Otro</text>
 		<text lang="fr">Autre</text>
 		<text lang="it">Altro</text>
 		<additional_input>True</additional_input>
@@ -1474,6 +1578,7 @@
 		<order>1</order>
 		<text lang="en">free software</text>
 		<text lang="de">Freie Software</text>
+		<text lang="es">software gratuito</text>
 		<text lang="fr">Logiciel libre</text>
 		<text lang="it">programma libero</text>
 		<additional_input>True</additional_input>
@@ -1487,6 +1592,7 @@
 		<order>2</order>
 		<text lang="en">common commercial software</text>
 		<text lang="de">Gängige kommerzielle Software</text>
+		<text lang="es">software comercial común</text>
 		<text lang="fr">Logiciel commercial propriétaire</text>
 		<text lang="it">programma commerciale</text>
 		<additional_input>True</additional_input>
@@ -1500,6 +1606,7 @@
 		<order>3</order>
 		<text lang="en">self-generated software or script</text>
 		<text lang="de">Selbsterzeugte Software oder Skript</text>
+		<text lang="es">software o script autogenerado</text>
 		<text lang="fr">Logiciel ou script auto-généré</text>
 		<text lang="it">programma o script autoprodotto</text>
 		<additional_input>True</additional_input>
@@ -1513,6 +1620,7 @@
 		<order>5</order>
 		<text lang="en">Other</text>
 		<text lang="de">Sonstiges</text>
+		<text lang="es">Otro</text>
 		<text lang="fr">Autre</text>
 		<text lang="it">Altro</text>
 		<additional_input>True</additional_input>
@@ -1533,6 +1641,7 @@
 		<order>0</order>
 		<text lang="en">Calibration procedure</text>
 		<text lang="de">Kalibrierverfahren</text>
+		<text lang="es">Procedimiento de calibración</text>
 		<text lang="fr">Procédure de calibrage</text>
 		<text lang="it">Procedura di calibrazione</text>
 		<additional_input>True</additional_input>
@@ -1546,6 +1655,7 @@
 		<order>1</order>
 		<text lang="en">Repeated measurements</text>
 		<text lang="de">Wiederholte Messungen</text>
+		<text lang="es">Mediciones repetidas</text>
 		<text lang="fr">Mesures répétées</text>
 		<text lang="it">Misure ripetute</text>
 		<additional_input>True</additional_input>
@@ -1559,6 +1669,7 @@
 		<order>2</order>
 		<text lang="en">Standards for data recording</text>
 		<text lang="de">Datenaufzeichnungsstandards</text>
+		<text lang="es">Normas para el registro de datos</text>
 		<text lang="fr">Normes d'enregistrement des données</text>
 		<text lang="it">Standard per il salvataggio dei dati</text>
 		<additional_input>True</additional_input>
@@ -1572,6 +1683,7 @@
 		<order>3</order>
 		<text lang="en">Controlled vocabularies or standard terminology</text>
 		<text lang="de">Kontrollierte Vokabulare oder standardisierte Terminologien</text>
+		<text lang="es">Vocabularios controlados o terminología estándar</text>
 		<text lang="fr">Vocabulaires contrôlés ou terminologie standard</text>
 		<text lang="it">Vocabolari controllati o terminologia standard</text>
 		<additional_input>True</additional_input>
@@ -1585,6 +1697,7 @@
 		<order>4</order>
 		<text lang="en">Validation of the data collection</text>
 		<text lang="de">Validierung der Datenerfassung</text>
+		<text lang="es">Validación de la recogida de datos</text>
 		<text lang="fr">Validation de la collecte des données</text>
 		<text lang="it">Validazione dell’acquisizione dati</text>
 		<additional_input>True</additional_input>
@@ -1598,6 +1711,7 @@
 		<order>5</order>
 		<text lang="en">Peer reviews of the data</text>
 		<text lang="de">Peer reviews der Daten</text>
+		<text lang="es">Control "peer review" de los datos</text>
 		<text lang="fr">Examen des données par des pairs</text>
 		<text lang="it">Controllo "peer review" dei dati</text>
 		<additional_input>True</additional_input>
@@ -1611,6 +1725,7 @@
 		<order>6</order>
 		<text lang="en">Others</text>
 		<text lang="de">Sonstiges</text>
+		<text lang="es">Otros</text>
 		<text lang="fr">Autres</text>
 		<text lang="it">Altro</text>
 		<additional_input>True</additional_input>
@@ -1631,6 +1746,7 @@
 		<order>1</order>
 		<text lang="en">Bundesdatenschutzgesetz (BDSG, Federal Data Protection Act)</text>
 		<text lang="de">Bundesdatenschutzgesetz (BDSG)</text>
+		<text lang="es">Bundesdatenschutzgesetz (BDSG, Ley Federal alemana de Protección de Datos)</text>
 		<text lang="fr">Loi allemande sur la protection des données (BDSG pour Bundesdatenschutzgesetz)</text>
 		<text lang="it">Bundesdatenschutzgesetz (BDSG, legge federale sulla protezione dei dati)</text>
 		<additional_input>False</additional_input>
@@ -1644,6 +1760,7 @@
 		<order>2</order>
 		<text lang="en">Landesdatenschutzgesetz Baden-Württemberg (State Data Protection Act of Baden-Württemberg)</text>
 		<text lang="de">Landesdatenschutzgesetz Baden-Württemberg</text>
+		<text lang="es">Ley estatal de protección de datos de Baden-Württemberg</text>
 		<text lang="fr">Loi sur la protection des données du Bade-Wurtemberg</text>
 		<text lang="it">Legge sulla protezione dei dati del Baden-Württenberg</text>
 		<additional_input>False</additional_input>
@@ -1657,6 +1774,7 @@
 		<order>3</order>
 		<text lang="en">Landesdatenschutzgesetz Bayern (State Data Protection Act of Bavaria)</text>
 		<text lang="de">Landesdatenschutzgesetz Bayern</text>
+		<text lang="es">Ley estatal de protección de datos de Baviera</text>
 		<text lang="fr">Loi sur la protection des données de la Bavière</text>
 		<text lang="it">Legge sulla protezione dei dati della Baviera</text>
 		<additional_input>False</additional_input>
@@ -1670,6 +1788,7 @@
 		<order>4</order>
 		<text lang="en">Landesdatenschutzgesetz Berlin (State Data Protection Act of Berlin)</text>
 		<text lang="de">Landesdatenschutzgesetz Berlin</text>
+		<text lang="es">Ley estatal de protección de datos de Berlín</text>
 		<text lang="fr">Loi sur la protection des données de Berlin</text>
 		<text lang="it">Legge sulla protezione dei dati di Berlino</text>
 		<additional_input>False</additional_input>
@@ -1683,6 +1802,7 @@
 		<order>5</order>
 		<text lang="en">Landesdatenschutzgesetz Bremen (State Data Protection Act of Bremen)</text>
 		<text lang="de">Landesdatenschutzgesetz Bremen</text>
+		<text lang="es">Ley estatal de protección de datos de Bremen</text>
 		<text lang="fr">Loi sur la protection des données de Brême</text>
 		<text lang="it">Legge sulla protezione dei dati di Brema</text>
 		<additional_input>False</additional_input>
@@ -1696,6 +1816,7 @@
 		<order>6</order>
 		<text lang="en">Landesdatenschutzgesetz Brandenburg (State Data Protection Act of Brandenburg)</text>
 		<text lang="de">Landesdatenschutzgesetz Brandenburg</text>
+		<text lang="es">Ley estatal de protección de datos de Brandemburgo</text>
 		<text lang="fr">Loi sur la protection des données du Brandebourg</text>
 		<text lang="it">Legge sulla protezione dei dati del Brandeburgo</text>
 		<additional_input>False</additional_input>
@@ -1709,6 +1830,7 @@
 		<order>7</order>
 		<text lang="en">Landesdatenschutzgesetz Hamburg (State Data Protection Act of Hamburg)</text>
 		<text lang="de">Landesdatenschutzgesetz Hamburg</text>
+		<text lang="es">Ley estatal de protección de datos de Hamburgo</text>
 		<text lang="fr">Loi sur la protection des données de Hambourg</text>
 		<text lang="it">Legge sulla protezione dei dati di Amburgo</text>
 		<additional_input>False</additional_input>
@@ -1722,6 +1844,7 @@
 		<order>8</order>
 		<text lang="en">Landesdatenschutzgesetz Mecklenburg-Vorpommern (State Data Protection Act of Mecklenburg-Vorpommern)</text>
 		<text lang="de">Landesdatenschutzgesetz Mecklenburg-Vorpommern</text>
+		<text lang="es">Ley estatal de protección de datos de Mecklemburgo-Pomerania Occidental</text>
 		<text lang="fr">Loi sur la protection des données du Mecklembourg-Poméranie-Occidentale</text>
 		<text lang="it">Legge sulla protezione dei dati del Meclemburgo-Pomerania Anteriore</text>
 		<additional_input>False</additional_input>
@@ -1735,6 +1858,7 @@
 		<order>9</order>
 		<text lang="en">Landesdatenschutzgesetz Hessen (State Data Protection Act of Hesse)</text>
 		<text lang="de">Landesdatenschutzgesetz Hessen</text>
+		<text lang="es">Ley estatal de protección de datos de Hesse</text>
 		<text lang="fr">Loi sur la protection des données de la Hesse</text>
 		<text lang="it">Legge sulla protezione dei dati dell'Assia</text>
 		<additional_input>False</additional_input>
@@ -1748,6 +1872,7 @@
 		<order>10</order>
 		<text lang="en">Landesdatenschutzgesetz Nordrhein-Westfalen (State Data Protection Act of North Rhine-Westphalia)</text>
 		<text lang="de">Landesdatenschutzgesetz Nordrhein-Westfalen</text>
+		<text lang="es">Ley estatal de protección de datos de Renania del Norte-Westfalia</text>
 		<text lang="fr">Loi sur la protection des données de la Rhénanie-du-Nord-Westphalie</text>
 		<text lang="it">Legge sulla protezione dei dati della Renania Settentrionale-Vestfalia</text>
 		<additional_input>False</additional_input>
@@ -1761,6 +1886,7 @@
 		<order>11</order>
 		<text lang="en">Landesdatenschutzgesetz Rheinland-Pfalz (State Data Protection Act of Rhineland-Palatinate)</text>
 		<text lang="de">Landesdatenschutzgesetz Rheinland-Pfalz</text>
+		<text lang="es">Ley estatal de protección de datos de Renania-Palatinado</text>
 		<text lang="fr">Loi sur la protection des données de la Rhénanie-Palatinat</text>
 		<text lang="it">Legge sulla protezione dei dati della Renania-Palatinato</text>
 		<additional_input>False</additional_input>
@@ -1774,6 +1900,7 @@
 		<order>12</order>
 		<text lang="en">Landesdatenschutzgesetz Niedersachsen (State Data Protection Act of Lower Saxony)</text>
 		<text lang="de">Landesdatenschutzgesetz Niedersachsen</text>
+		<text lang="es">Ley estatal de protección de datos de Baja Sajonia</text>
 		<text lang="fr">Loi sur la protection des données de la Basse-Saxe</text>
 		<text lang="it">Legge sulla protezione dei dati della Bassa-Sassonia</text>
 		<additional_input>False</additional_input>
@@ -1787,6 +1914,7 @@
 		<order>13</order>
 		<text lang="en">Landesdatenschutzgesetz Saarland (State Data Protection Act of Saarland)</text>
 		<text lang="de">Landesdatenschutzgesetz Saarland</text>
+		<text lang="es">Ley estatal de protección de datos del Sarre</text>
 		<text lang="fr">Loi sur la protection des données de la Sarre</text>
 		<text lang="it">Legge sulla protezione dei dati della Saarland</text>
 		<additional_input>False</additional_input>
@@ -1800,6 +1928,7 @@
 		<order>14</order>
 		<text lang="en">Landesdatenschutzgesetz Sachsen (State Data Protection Act of Saxony)</text>
 		<text lang="de">Landesdatenschutzgesetz Sachsen</text>
+		<text lang="es">Ley estatal de protección de datos de Sajonia</text>
 		<text lang="fr">Loi sur la protection des données de la Saxe</text>
 		<text lang="it">Legge sulla protezione dei dati della Sassonia</text>
 		<additional_input>False</additional_input>
@@ -1813,6 +1942,7 @@
 		<order>15</order>
 		<text lang="en">Landesdatenschutzgesetz Sachsen-Anhalt (State Data Protection Act of Saxony-Anhalt)</text>
 		<text lang="de">Landesdatenschutzgesetz Sachsen-Anhalt</text>
+		<text lang="es">Ley estatal de protección de datos de Sajonia-Anhalt</text>
 		<text lang="fr">Loi sur la protection des données de la Saxe-Anhalt</text>
 		<text lang="it">Legge sulla protezione dei dati della Sassonia-Anhalt</text>
 		<additional_input>False</additional_input>
@@ -1826,6 +1956,7 @@
 		<order>16</order>
 		<text lang="en">Landesdatenschutzgesetz Schleswig-Holstein (State Data Protection Act of Schleswig-Holstein)</text>
 		<text lang="de">Landesdatenschutzgesetz Schleswig-Holstein</text>
+		<text lang="es">Ley estatal de protección de datos de Schleswig-Holstein</text>
 		<text lang="fr">Loi sur la protection des données du Schleswig-Holstein</text>
 		<text lang="it">Legge sulla protezione dei dati dello Schleswig-Holstein</text>
 		<additional_input>False</additional_input>
@@ -1839,6 +1970,7 @@
 		<order>17</order>
 		<text lang="en">Landesdatenschutzgesetz Thüringen (State Data Protection Act of Thuringia)</text>
 		<text lang="de">Landesdatenschutzgesetz Thüringen</text>
+		<text lang="es">Ley estatal de protección de datos de Turingia</text>
 		<text lang="fr">Loi sur la protection des données de la Thuringe</text>
 		<text lang="it">Legge sulla protezione dei dati della Turingia</text>
 		<additional_input>False</additional_input>
@@ -1850,10 +1982,11 @@
 		<dc:comment/>
 		<optionset dc:uri="https://rdmorganiser.github.io/terms/options/data_protection_laws"/>
 		<order>18</order>
-		<text lang="en">Sozialgesetzbuch X (Social Security Act X), e.g. for medical data</text>
+		<text lang="en">Sozialgesetzbuch X (Volume X of the German Social Insurance Code), e.g. for medical data</text>
 		<text lang="de">Sozialgesetzbuch X (z.B. für medizinische Daten)</text>
-		<text lang="fr">Loi allemande sur la sécurité sociale X (Sozialgesetzbuch X), par ex. pour la protection des données médicales</text>
-		<text lang="it">Sozialgesetzbuch X (legge X sulla sicurezza sociale), es. per i dati medici</text>
+		<text lang="es">Sozialgesetzbuch X (libro X del Código alemán de Seguridad Social), por ejemplo, para los datos médicos</text>
+		<text lang="fr">Sozialgesetzbuch X (Livre X du Code allemand de la sécurité sociale), par ex. pour la protection des données médicales</text>
+		<text lang="it">Sozialgesetzbuch X (tomo X del codice tedesco di previdenza sociale), es. per i dati medici</text>
 		<additional_input>False</additional_input>
 	</option>
 	<option dc:uri="https://rdmorganiser.github.io/terms/options/data_protection_laws/39">
@@ -1863,10 +1996,11 @@
 		<dc:comment/>
 		<optionset dc:uri="https://rdmorganiser.github.io/terms/options/data_protection_laws"/>
 		<order>19</order>
-		<text lang="en">Bundesstatistikgesetz (Federal Statistics Act), e.g. for census data</text>
+		<text lang="en">Bundesstatistikgesetz (German Federal Statistics Act), e.g. for census data</text>
 		<text lang="de">Bundesstatistikgesetz (z.B. für Zensusdaten)</text>
-		<text lang="fr">Loi allemande sur la statistique (Bundesstatistikgesetz), par ex. pour la protection des données de recensement</text>
-		<text lang="it">Bundesstatistikgesetz (legge federale sulla statistica), es. per i dati di censimento</text>
+		<text lang="es">Bundesstatistikgesetz (Ley Federal alemana de Estadística), por ejemplo, para los datos del censo</text>
+		<text lang="fr">Bundesstatistikgesetz (Loi fédérale allemande sur la statistique), par ex. pour la protection des données de recensement</text>
+		<text lang="it">Bundesstatistikgesetz (legge federale tedesca sulla statistica), es. per i dati di censimento</text>
 		<additional_input>False</additional_input>
 	</option>
 	<option dc:uri="https://rdmorganiser.github.io/terms/options/data_protection_laws/155">
@@ -1878,6 +2012,7 @@
 		<order>100</order>
 		<text lang="en">Other</text>
 		<text lang="de">Sonstiges</text>
+		<text lang="es">Otro</text>
 		<text lang="fr">Autre</text>
 		<text lang="it">Altro</text>
 		<additional_input>True</additional_input>
@@ -1898,6 +2033,7 @@
 		<order>1</order>
 		<text lang="en">Yes, during the collection</text>
 		<text lang="de">Ja, während der Erhebung</text>
+		<text lang="es">Sí, durante la recogida</text>
 		<text lang="fr">Oui, lors de la collecte</text>
 		<text lang="it">Sì, durante la raccolta</text>
 		<additional_input>False</additional_input>
@@ -1911,6 +2047,7 @@
 		<order>2</order>
 		<text lang="en">Yes, before / at the beginning of the data analysis</text>
 		<text lang="de">Ja, vor / zu Beginn der Datenanalyse</text>
+		<text lang="es">Sí, antes / al comienzo del análisis de datos</text>
 		<text lang="fr">Oui, avant ou au début de l'analyse des données</text>
 		<text lang="it">Sì, prima / all'inizio dell'analisi dati</text>
 		<additional_input>False</additional_input>
@@ -1924,6 +2061,7 @@
 		<order>3</order>
 		<text lang="en">Yes, after the data analysis / before publication</text>
 		<text lang="de">Ja, nach der Datenanalyse / vor der Publikation</text>
+		<text lang="es">Sí, después del análisis de los datos / antes de la publicación</text>
 		<text lang="fr">Oui, après l'analyse des données ou avant la publication</text>
 		<text lang="it">Sì, dopo l'analisi dei dati / prima della pubblicazione</text>
 		<additional_input>False</additional_input>
@@ -1937,6 +2075,7 @@
 		<order>4</order>
 		<text lang="en">No</text>
 		<text lang="de">Nein</text>
+		<text lang="es">No</text>
 		<text lang="fr">Non</text>
 		<text lang="it">No</text>
 		<additional_input>False</additional_input>
@@ -1957,6 +2096,7 @@
 		<order>1</order>
 		<text lang="en">Yes, by several persons at various institutions</text>
 		<text lang="de">Ja, von mehreren Personen an verschiedenen Institutionen</text>
+		<text lang="es">Sí, por varias personas en varias instituciones</text>
 		<text lang="fr">Oui, par plusieurs personnes dans divers établissements</text>
 		<text lang="it">Sì, da parte di più persone in diverse istituzioni</text>
 		<additional_input>False</additional_input>
@@ -1970,6 +2110,7 @@
 		<order>2</order>
 		<text lang="en">Yes, by multiple persons of the same workgroup at the same institution</text>
 		<text lang="de">Ja, von mehreren Personen derselben Arbeitsgruppe an derselben Institution</text>
+		<text lang="es">Sí, por varias personas del mismo grupo de trabajo en la misma institución</text>
 		<text lang="fr">Oui, par plusieurs personnes du même groupe de travail dans la même institution</text>
 		<text lang="it">Sì, da parte di più persone dello stesso gruppo di lavoro nella stessa istituzione</text>
 		<additional_input>False</additional_input>
@@ -1983,6 +2124,7 @@
 		<order>3</order>
 		<text lang="en">No</text>
 		<text lang="de">Nein</text>
+		<text lang="es">No</text>
 		<text lang="fr">Non</text>
 		<text lang="it">No</text>
 		<additional_input>False</additional_input>
@@ -2003,6 +2145,7 @@
 		<order>1</order>
 		<text lang="en">work of literature, scholarship or the arts</text>
 		<text lang="de">Werk der Literatur, Wissenschaft oder Kunst</text>
+		<text lang="es">obra literaria, académica o artística</text>
 		<text lang="fr">œuvre littéraire, universitaire ou artistique</text>
 		<text lang="it">opera letteraria, accademica o artistica</text>
 		<additional_input>False</additional_input>
@@ -2016,6 +2159,7 @@
 		<order>2</order>
 		<text lang="en">translation or other edition of a work</text>
 		<text lang="de">Übersetzung oder andere Bearbeitung eines Werkes</text>
+		<text lang="es">traducción u otra edición de una obra</text>
 		<text lang="fr">traduction ou autre édition d'une œuvre</text>
 		<text lang="it">traduzione o riedizione di un'opera</text>
 		<additional_input>False</additional_input>
@@ -2029,6 +2173,7 @@
 		<order>3</order>
 		<text lang="en">collected edition or database work</text>
 		<text lang="de">Sammelwerk oder Datenbankwerk</text>
+		<text lang="es">edición recopilada o trabajo de base de datos</text>
 		<text lang="fr">édition collectée ou travail de base de données</text>
 		<text lang="it">raccolta o banca dati</text>
 		<additional_input>False</additional_input>
@@ -2042,6 +2187,7 @@
 		<order>6</order>
 		<text lang="en">Other</text>
 		<text lang="de">Andere</text>
+		<text lang="es">Otros</text>
 		<text lang="fr">Autres</text>
 		<text lang="it">Altri</text>
 		<additional_input>True</additional_input>
@@ -2055,6 +2201,7 @@
 		<order>7</order>
 		<text lang="en">No</text>
 		<text lang="de">Nein</text>
+		<text lang="es">No</text>
 		<text lang="fr">Non</text>
 		<text lang="it">No</text>
 		<additional_input>False</additional_input>
@@ -2075,6 +2222,7 @@
 		<order>1</order>
 		<text lang="en">The dataset adheres to standardised formats</text>
 		<text lang="de">Für den Datensatz werden standardisierte Formate genutzt</text>
+		<text lang="es">El conjunto de datos se adhiere a formatos estandarizados</text>
 		<text lang="fr">Le jeu de données adhère à des formats standardisés</text>
 		<text lang="it">La raccolta di dati aderisce a formati standard</text>
 		<additional_input>True</additional_input>
@@ -2088,6 +2236,7 @@
 		<order>2</order>
 		<text lang="en">The dataset is usable with available (open) software applications or software applications that are established and widely used in the respective community</text>
 		<text lang="de">Der Datensatz ist mit verfügbarer (offener) Software bzw. mit in der jeweiligen Community etablierter und vielgenutzter Software nutzbar</text>
+		<text lang="es">El conjunto de datos se puede utilizar con aplicaciones de software disponibles (abiertas) o con aplicaciones de software establecidas y ampliamente utilizadas en la comunidad respectiva</text>
 		<text lang="fr">Le jeu de données est utilisable avec des logiciels accessibles (de licence ouvertes) ou qui sont répendues dans la communauté en question</text>
 		<text lang="it">La raccolta di dati si lascia aprire con programmi liberamente disponibili o per lo meno di largo utilizzo nella comunità scientifica di diferimento</text>
 		<additional_input>True</additional_input>
@@ -2101,6 +2250,7 @@
 		<order>3</order>
 		<text lang="en">The dataset can easily be re-combined with different datasets from different origins</text>
 		<text lang="de">Der Datensatz kann ohne großen Aufwand mit verschiedenen anderen Datensätzen aus unterschiedlichen Quellen rekombiniert werden</text>
+		<text lang="es">El conjunto de datos puede recombinarse fácilmente con otros conjuntos de datos de diferentes orígenes</text>
 		<text lang="fr">Le jeu de données peut facilement être re-combiné avec différents ensembles de données d'origines différentes</text>
 		<text lang="it">La raccolta di dati si lascia ricombinare con una larga varietà di dati di diversa provenienza</text>
 		<additional_input>True</additional_input>
@@ -2114,6 +2264,7 @@
 		<order>4</order>
 		<text lang="en">Other aspects in terms of interoperability</text>
 		<text lang="de">Weitere für die Interoperabilität wichtige Aspekte</text>
+		<text lang="es">Otros aspectos en materia de interoperabilidad</text>
 		<text lang="fr">Autres aspects sur l'interopérabilité</text>
 		<text lang="it">Altri aspetti dell’interoperatività</text>
 		<additional_input>True</additional_input>
@@ -2134,6 +2285,7 @@
 		<order>0</order>
 		<text lang="en">The dataset will be published under the followig license:</text>
 		<text lang="de">Der Datensatz wird unter folgender Lizenz veröffentlicht:</text>
+		<text lang="es">El conjunto de datos se publicará bajo la siguiente licencia:</text>
 		<text lang="fr">Le jeu de données sera publié sous la licence suivante&#8239;:</text>
 		<text lang="it">La raccolta dati verrà pubblicata con la seguente licenza:</text>
 		<additional_input>True</additional_input>
@@ -2147,6 +2299,7 @@
 		<order>1</order>
 		<text lang="en">Yet to be determined</text>
 		<text lang="de">Noch zu klären</text>
+		<text lang="es">Aún por determinar</text>
 		<text lang="fr">À déterminer</text>
 		<text lang="it">Da chiarire</text>
 		<additional_input>False</additional_input>
@@ -2162,78 +2315,84 @@
 		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
 		<key>71</key>
 		<path>dataset_license_types/71</path>
-		<dc:comment/>
+		<dc:comment>https://creativecommons.org/licenses/by/4.0/legalcode</dc:comment>
 		<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_license_types"/>
 		<order>1</order>
-		<text lang="en">&lt;a href=&quot;https://creativecommons.org/licenses/by/4.0/legalcode.en&quot; target=&quot;_blank&quot;&gt;Creative Commons Attribution (CC-BY)&lt;/a&gt;</text>
-		<text lang="de">&lt;a href=&quot;https://creativecommons.org/licenses/by/4.0/legalcode.de&quot; target=&quot;_blank&quot;&gt;Creative Commons Namensnennung (CC-BY)&lt;/a&gt;</text>
-		<text lang="fr">&lt;a href=&quot;https://creativecommons.org/licenses/by/4.0/legalcode.fr&quot; target=&quot;_blank&quot;&gt;Creative Commons Attribution (CC-BY)&lt;/a&gt;</text>
-		<text lang="it">&lt;a href=&quot;https://creativecommons.org/licenses/by/4.0/legalcode.it&quot; target=&quot;_blank&quot;&gt;Creative Commons Attribuzione (CC-BY)&lt;/a&gt;</text>
+		<text lang="en">Creative Commons Attribution (CC-BY)</text>
+		<text lang="de">Creative Commons Namensnennung (CC-BY)</text>
+		<text lang="es">Creative Commons Atribución/Reconocimiento (CC-BY)</text>
+		<text lang="fr">Creative Commons Attribution (CC-BY)</text>
+		<text lang="it">Creative Commons Attribuzione (CC-BY)</text>
 		<additional_input>False</additional_input>
 	</option>
 	<option dc:uri="https://rdmorganiser.github.io/terms/options/dataset_license_types/73">
 		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
 		<key>73</key>
 		<path>dataset_license_types/73</path>
-		<dc:comment/>
+		<dc:comment>https://creativecommons.org/licenses/by-nc/4.0/legalcode</dc:comment>
 		<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_license_types"/>
 		<order>2</order>
-		<text lang="en">&lt;a href=&quot;https://creativecommons.org/licenses/by-nc/4.0/legalcode.en&quot; target=&quot;_blank&quot;&gt;Creative Commons Attribution-NonCommercial (CC-BY-NC)&lt;/a&gt;</text>
-		<text lang="de">&lt;a href=&quot;https://creativecommons.org/licenses/by-nc/4.0/legalcode.de&quot; target=&quot;_blank&quot;&gt;Creative Commons Namensnennung-Nicht kommerziell (CC-BY-NC)&lt;/a&gt;</text>
-		<text lang="fr">&lt;a href=&quot;https://creativecommons.org/licenses/by-nc/4.0/legalcode.fr&quot; target=&quot;_blank&quot;&gt;Creative Commons Attribution - Utilisation non commerciale (CC-BY-NC)&lt;/a&gt;</text>
-		<text lang="it">&lt;a href=&quot;https://creativecommons.org/licenses/by-nc/4.0/legalcode.it&quot; target=&quot;_blank&quot;&gt;Creative Commons Attribuzione-NonCommerciale (CC-BY-NC)&lt;/a&gt;</text>
+		<text lang="en">Creative Commons Attribution-NonCommercial (CC-BY-NC)</text>
+		<text lang="de">Creative Commons Namensnennung-Nicht kommerziell (CC-BY-NC)</text>
+		<text lang="es">Creative Commons Atribución/Reconocimiento-NoComercial (CC-BY-NC)</text>
+		<text lang="fr">Creative Commons Attribution - Utilisation non commerciale (CC-BY-NC)</text>
+		<text lang="it">Creative Commons Attribuzione-NonCommerciale (CC-BY-NC)</text>
 		<additional_input>False</additional_input>
 	</option>
 	<option dc:uri="https://rdmorganiser.github.io/terms/options/dataset_license_types/74">
 		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
 		<key>74</key>
 		<path>dataset_license_types/74</path>
-		<dc:comment/>
+		<dc:comment>https://creativecommons.org/licenses/by-nd/4.0/legalcode</dc:comment>
 		<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_license_types"/>
 		<order>3</order>
-		<text lang="en">&lt;a href=&quot;https://creativecommons.org/licenses/by-nd/4.0/legalcode.en&quot; target=&quot;_blank&quot;&gt;Creative Commons Attribution-NoDerivatives (CC-BY-ND)&lt;/a&gt;</text>
-		<text lang="de">&lt;a href=&quot;https://creativecommons.org/licenses/by-nd/4.0/legalcode.de&quot; target=&quot;_blank&quot;&gt;Creative Commons Namensnennung-Keine Bearbeitungen (CC-BY-ND)&lt;/a&gt;</text>
-		<text lang="fr">&lt;a href=&quot;https://creativecommons.org/licenses/by-nd/4.0/legalcode.fr&quot; target=&quot;_blank&quot;&gt;Creative Commons Attribution - Pas d'Œuvre dérivée (CC-BY-ND)&lt;/a&gt;</text>
-		<text lang="it">&lt;a href=&quot;https://creativecommons.org/licenses/by-nd/4.0/legalcode.it&quot; target=&quot;_blank&quot;&gt;Creative Commons Attribuzione-NonOpereDerivate (CC-BY-ND)&lt;/a&gt;</text>
+		<text lang="en">Creative Commons Attribution-NoDerivatives (CC-BY-ND)</text>
+		<text lang="de">Creative Commons Namensnennung-Keine Bearbeitungen (CC-BY-ND)</text>
+		<text lang="es">Creative Commons Atribución/Reconocimiento-SinDerivados (CC-BY-ND)</text>
+		<text lang="fr">Creative Commons Attribution - Pas d'Œuvre dérivée (CC-BY-ND)</text>
+		<text lang="it">Creative Commons Attribuzione-NonOpereDerivate (CC-BY-ND)</text>
 		<additional_input>False</additional_input>
 	</option>
 	<option dc:uri="https://rdmorganiser.github.io/terms/options/dataset_license_types/75">
 		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
 		<key>75</key>
 		<path>dataset_license_types/75</path>
-		<dc:comment/>
+		<dc:comment>https://creativecommons.org/licenses/by-sa/4.0/legalcode</dc:comment>
 		<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_license_types"/>
 		<order>4</order>
-		<text lang="en">&lt;a href=&quot;https://creativecommons.org/licenses/by-sa/4.0/legalcode.en&quot; target=&quot;_blank&quot;&gt;Creative Commons Attribution-ShareAlike (CC-BY-SA)&lt;/a&gt;</text>
-		<text lang="de">&lt;a href=&quot;https://creativecommons.org/licenses/by-sa/4.0/legalcode.de&quot; target=&quot;_blank&quot;&gt;Creative Commons Namensnennung-ShareAlike (CC-BY-SA)&lt;/a&gt;</text>
-		<text lang="fr">&lt;a href=&quot;https://creativecommons.org/licenses/by-sa/4.0/legalcode.fr&quot; target=&quot;_blank&quot;&gt;Creative Commons Attribution - Partage dans les mêmes conditions (CC-BY-SA)&lt;/a&gt;</text>
-		<text lang="it">&lt;a href=&quot;https://creativecommons.org/licenses/by-sa/4.0/legalcode.it&quot; target=&quot;_blank&quot;&gt;Creative Commons Attribuzione-CondividiAlloStessoModo (CC-BY-SA)&lt;/a&gt;</text>
+		<text lang="en">Creative Commons Attribution-ShareAlike (CC-BY-SA)</text>
+		<text lang="de">Creative Commons Namensnennung-ShareAlike (CC-BY-SA)</text>
+		<text lang="es">Creative Commons Atribución/Reconocimiento-CompartirIgual (CC-BY-SA)</text>
+		<text lang="fr">Creative Commons Attribution - Partage dans les mêmes conditions (CC-BY-SA)</text>
+		<text lang="it">Creative Commons Attribuzione-CondividiAlloStessoModo (CC-BY-SA)</text>
 		<additional_input>False</additional_input>
 	</option>
 	<option dc:uri="https://rdmorganiser.github.io/terms/options/dataset_license_types/ODC-By">
 		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
 		<key>ODC-By</key>
 		<path>dataset_license_types/ODC-By</path>
-		<dc:comment/>
+		<dc:comment>https://opendatacommons.org/licenses/by/1-0/</dc:comment>
 		<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_license_types"/>
 		<order>5</order>
-		<text lang="en">&lt;a href=&quot;https://opendatacommons.org/licenses/by/1-0/&quot; target=&quot;_blank&quot;&gt;Open Data Commons Attribution&lt;/a&gt;</text>
-		<text lang="de">&lt;a href=&quot;https://opendatacommons.org/licenses/by/1-0/&quot; target=&quot;_blank&quot;&gt;Open Data Commons Attribution&lt;/a&gt;</text>
-		<text lang="fr">&lt;a href=&quot;https://opendatacommons.org/licenses/by/1-0/&quot; target=&quot;_blank&quot;&gt;Open Data Commons Attribution&lt;/a&gt;</text>
-		<text lang="it">&lt;a href=&quot;https://opendatacommons.org/licenses/by/1-0/&quot; target=&quot;_blank&quot;&gt;Open Data Commons Attribution&lt;/a&gt;</text>
+		<text lang="en">Open Data Commons Attribution</text>
+		<text lang="de">Open Data Commons Attribution</text>
+		<text lang="es">Open Data Commons Attribution</text>
+		<text lang="fr">Open Data Commons Attribution</text>
+		<text lang="it">Open Data Commons Attribution</text>
 		<additional_input>True</additional_input>
 	</option>
-		<option dc:uri="https://rdmorganiser.github.io/terms/options/dataset_license_types/ODbl">
+	<option dc:uri="https://rdmorganiser.github.io/terms/options/dataset_license_types/ODbl">
 		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
 		<key>ODbl</key>
 		<path>dataset_license_types/ODbl</path>
-		<dc:comment/>
+		<dc:comment>https://opendatacommons.org/licenses/odbl/1-0/</dc:comment>
 		<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_license_types"/>
 		<order>6</order>
-		<text lang="en">&lt;a href=&quot;https://opendatacommons.org/licenses/odbl/1-0/&quot; target=&quot;_blank&quot;&gt;Open Data Commons Open Database&lt;/a&gt;</text>
-		<text lang="de">&lt;a href=&quot;https://opendatacommons.org/licenses/odbl/1-0/&quot; target=&quot;_blank&quot;&gt;Open Data Commons Open Database&lt;/a&gt;</text>
-		<text lang="fr">&lt;a href=&quot;https://opendatacommons.org/licenses/odbl/1-0/&quot; target=&quot;_blank&quot;&gt;Open Data Commons Open Database&lt;/a&gt;</text>
-		<text lang="it">&lt;a href=&quot;https://opendatacommons.org/licenses/odbl/1-0/&quot; target=&quot;_blank&quot;&gt;Open Data Commons Open Database&lt;/a&gt;</text>
+		<text lang="en">Open Data Commons Open Database</text>
+		<text lang="de">Open Data Commons Open Database</text>
+		<text lang="es">Open Data Commons Open Database</text>
+		<text lang="fr">Open Data Commons Open Database</text>
+		<text lang="it">Open Data Commons Open Database</text>
 		<additional_input>True</additional_input>
 	</option>
 	<option dc:uri="https://rdmorganiser.github.io/terms/options/dataset_license_types/cc0">
@@ -2243,10 +2402,11 @@
 		<dc:comment/>
 		<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_license_types"/>
 		<order>7</order>
-		<text lang="en">&lt;a href=&quot;https://creativecommons.org/publicdomain/zero/1.0/deed.en&quot; target=&quot;_blank&quot;&gt;Public domain (CC0)&lt;/a&gt;</text>
-		<text lang="de">&lt;a href=&quot;https://creativecommons.org/publicdomain/zero/1.0/deed.de&quot; target=&quot;_blank&quot;&gt;Gemeinfrei (CC0)&lt;/a&gt;</text>
-		<text lang="fr">&lt;a href=&quot;https://creativecommons.org/publicdomain/zero/1.0/deed.fr&quot; target=&quot;_blank&quot;&gt;Domaine public (CC0)&lt;/a&gt;</text>
-		<text lang="it">&lt;a href=&quot;https://creativecommons.org/publicdomain/zero/1.0/deed.it&quot; target=&quot;_blank&quot;&gt;Pubblico dominio (CC0)&lt;/a&gt;</text>
+		<text lang="en">Public domain (CC0)</text>
+		<text lang="de">Gemeinfrei (CC0)</text>
+		<text lang="es">Dominio público (CC0)</text>
+		<text lang="fr">Domaine public (CC0)</text>
+		<text lang="it">Pubblico dominio (CC0)</text>
 		<additional_input>False</additional_input>
 	</option>
 	<option dc:uri="https://rdmorganiser.github.io/terms/options/dataset_license_types/233">
@@ -2258,6 +2418,7 @@
 		<order>8</order>
 		<text lang="en">Other, or exact designation - if known</text>
 		<text lang="de">Andere, bzw. genaue Bezeichnung - falls bekannt</text>
+		<text lang="es">Otros</text>
 		<text lang="fr">Autre, ou dénomination exacte - si connue</text>
 		<text lang="it">Altra, o denominazione esatta - qualora nota</text>
 		<additional_input>True</additional_input>
@@ -2278,6 +2439,7 @@
 		<order>1</order>
 		<text lang="en">Created</text>
 		<text lang="de">Erzeugt</text>
+		<text lang="es">Creado</text>
 		<text lang="fr">Créé</text>
 		<text lang="it">Creato</text>
 		<additional_input>False</additional_input>
@@ -2291,6 +2453,7 @@
 		<order>2</order>
 		<text lang="en">Re-used</text>
 		<text lang="de">Nachgenutzt</text>
+		<text lang="es">Reutilizado</text>
 		<text lang="fr">Réutilisé</text>
 		<text lang="it">Riutilizzato</text>
 		<additional_input>False</additional_input>
@@ -2304,6 +2467,7 @@
 		<order>3</order>
 		<text lang="en">Both (combination of re-used and newly generated data)</text>
 		<text lang="de">Beides (Kombination aus nachgenutzten und neu erzeugten Daten)</text>
+		<text lang="es">Ambos (combinación de datos reutilizados y generados recientemente)</text>
 		<text lang="fr">Les deux (combination de données créées et réutilisées)</text>
 		<text lang="it">Tutti e due (combinazione di dati creati e riutilizzati)</text>
 		<additional_input>False</additional_input>
@@ -2324,6 +2488,7 @@
 		<order>1</order>
 		<text lang="en">patent</text>
 		<text lang="de">Patent</text>
+		<text lang="es">Patente</text>
 		<text lang="fr">brevet</text>
 		<text lang="it">Brevetto</text>
 		<additional_input>False</additional_input>
@@ -2337,6 +2502,7 @@
 		<order>2</order>
 		<text lang="en">utility model</text>
 		<text lang="de">Gebrauchsmuster</text>
+		<text lang="es">modelo de utilidad</text>
 		<text lang="fr">modèle d'utilité</text>
 		<text lang="it">modello di utilità</text>
 		<additional_input>False</additional_input>
@@ -2350,6 +2516,7 @@
 		<order>3</order>
 		<text lang="en">trademark</text>
 		<text lang="de">Marke</text>
+		<text lang="es">marca registrada</text>
 		<text lang="fr">marque déposée</text>
 		<text lang="it">Marchio depositato</text>
 		<additional_input>False</additional_input>
@@ -2363,6 +2530,7 @@
 		<order>4</order>
 		<text lang="en">plant variety rights protection</text>
 		<text lang="de">Sortenschutz</text>
+		<text lang="es">protección de las obtenciones vegetales</text>
 		<text lang="fr">protection des droits sur la variété végétale</text>
 		<text lang="it">protezione dei diritti su varietà vegetali</text>
 		<additional_input>False</additional_input>
@@ -2376,6 +2544,7 @@
 		<order>5</order>
 		<text lang="en">integrated circuit layout design protection</text>
 		<text lang="de">Halbleiterschutz</text>
+		<text lang="es">protección del diseño de circuitos integrados</text>
 		<text lang="fr">protection de la conception de la disposition des circuits intégrés</text>
 		<text lang="it">protezione del design di circuiti integrati</text>
 		<additional_input>False</additional_input>
@@ -2389,6 +2558,7 @@
 		<order>6</order>
 		<text lang="en">geographical indication</text>
 		<text lang="de">geographische Herkunftsangabe</text>
+		<text lang="es">indicación geográfica</text>
 		<text lang="fr">indication géographique</text>
 		<text lang="it">indicazione geografica di origine</text>
 		<additional_input>False</additional_input>
@@ -2402,6 +2572,7 @@
 		<order>7</order>
 		<text lang="en">registered design</text>
 		<text lang="de">eingetragenes Design</text>
+		<text lang="es">diseño registrado</text>
 		<text lang="fr">conception déposé</text>
 		<text lang="it">marchio depositato</text>
 		<additional_input>False</additional_input>
@@ -2415,6 +2586,7 @@
 		<order>10</order>
 		<text lang="en">Other</text>
 		<text lang="de">Andere</text>
+		<text lang="es">Otros</text>
 		<text lang="fr">Autres</text>
 		<text lang="it">Altri</text>
 		<additional_input>True</additional_input>
@@ -2428,6 +2600,7 @@
 		<order>11</order>
 		<text lang="en">No</text>
 		<text lang="de">Nein</text>
+		<text lang="es">No</text>
 		<text lang="fr">Non</text>
 		<text lang="it">No</text>
 		<additional_input>False</additional_input>
@@ -2448,6 +2621,7 @@
 		<order>0</order>
 		<text lang="en">yes, with little effort</text>
 		<text lang="de">ja, mit geringem Aufwand</text>
+		<text lang="es">sí, con poco esfuerzo</text>
 		<text lang="fr">oui, avec peu d'effort</text>
 		<text lang="it">sì, con poco sforzo</text>
 		<additional_input>False</additional_input>
@@ -2461,6 +2635,7 @@
 		<order>1</order>
 		<text lang="en">yes, with moderate, but reasonable effort</text>
 		<text lang="de">ja, mit mäßigem, aber vertretbarem Auswand</text>
+		<text lang="es">sí, con un esfuerzo moderado, pero razonable</text>
 		<text lang="fr">oui, avec un effort modéré mais raisonnable</text>
 		<text lang="it">sì, con uno sforzo moderato ma accettabile</text>
 		<additional_input>False</additional_input>
@@ -2474,6 +2649,7 @@
 		<order>2</order>
 		<text lang="en">no or only with disproportionate cost or effort</text>
 		<text lang="de">nein bzw. nur mit unverhältnismäßig großem Aufwand</text>
+		<text lang="es">no o sólo con un coste o esfuerzo desproporcionado</text>
 		<text lang="fr">non ou seulement avec un coût ou un effort disproportionné</text>
 		<text lang="it">no oppure con uno sforzo sproporzionato</text>
 		<additional_input>False</additional_input>
@@ -2487,6 +2663,7 @@
 		<order>3</order>
 		<text lang="en">no, the data is not reproducible per se</text>
 		<text lang="de">nein, die Daten sind per se nicht reproduzierbar</text>
+		<text lang="es">no, los datos no son reproducibles per se</text>
 		<text lang="fr">non, les données ne sont pas reproductibles en soi</text>
 		<text lang="it">no, i dati sono intrinsecamente non riproducibili</text>
 		<additional_input>False</additional_input>
@@ -2507,6 +2684,7 @@
 		<order>4</order>
 		<text lang="en">Yes, internally with everyone, as long as they don't pass on the data</text>
 		<text lang="de">Ja, intern mit allen, solange sie die Daten nicht veröffentlichen oder nach außen weitergeben</text>
+		<text lang="es">Sí, internamente con todos, siempre que no pasen los datos</text>
 		<text lang="fr">Oui, en interne avec tout le monde, tant qu'ils ne transmettent pas les données</text>
 		<text lang="it">Sì, internamente con tutti, a condizione che i dati non vengano diffusi al pubblico</text>
 		<additional_input>False</additional_input>
@@ -2520,6 +2698,7 @@
 		<order>3</order>
 		<text lang="en">Yes, externally limited with individual approval</text>
 		<text lang="de">Ja, extern in begrenztem Umfang mit individueller Freigabe</text>
+		<text lang="es">Sí, limitado externamente con aprobación individual</text>
 		<text lang="fr">Oui, limité en externe avec approbation individuelle</text>
 		<text lang="it">Sì, esternamente in una cerchia ristretta con approvazione individuale</text>
 		<additional_input>False</additional_input>
@@ -2533,6 +2712,7 @@
 		<order>1</order>
 		<text lang="en">Yes, externally for everyone</text>
 		<text lang="de">Ja, extern für alle</text>
+		<text lang="es">Sí, externamente para todos</text>
 		<text lang="fr">Oui, en externe pour tout le monde</text>
 		<text lang="it">Sì, esternamente per tutti</text>
 		<additional_input>False</additional_input>
@@ -2546,6 +2726,7 @@
 		<order>4</order>
 		<text lang="en">No</text>
 		<text lang="de">Nein</text>
+		<text lang="es">No</text>
 		<text lang="fr">Non</text>
 		<text lang="it">No</text>
 		<additional_input>False</additional_input>
@@ -2566,6 +2747,7 @@
 		<order>1</order>
 		<text lang="en">less than 1 GB</text>
 		<text lang="de">weniger als ein GB</text>
+		<text lang="es">menos de 1 GB</text>
 		<text lang="fr">moins de 1 Go</text>
 		<text lang="it">meno di 1 GB</text>
 		<additional_input>False</additional_input>
@@ -2579,6 +2761,7 @@
 		<order>1</order>
 		<text lang="en">between 1 GB and 1 TB</text>
 		<text lang="de">zwischen 1 GB und 1 TB</text>
+		<text lang="es">entre 1 GB y 1 TB</text>
 		<text lang="fr">entre 1 Go et 1 To</text>
 		<text lang="it">tra 1 GB e 1 TB</text>
 		<additional_input>False</additional_input>
@@ -2592,6 +2775,7 @@
 		<order>2</order>
 		<text lang="en">between 1 TB and 100 TB</text>
 		<text lang="de">zwischen 1 TB und 100 TB</text>
+		<text lang="es">entre 1 TB y 100 TB</text>
 		<text lang="fr">entre 1 To et 100 To</text>
 		<text lang="it">tra 1 TB e 100 TB</text>
 		<additional_input>False</additional_input>
@@ -2605,6 +2789,7 @@
 		<order>3</order>
 		<text lang="en">more than 100 TB</text>
 		<text lang="de">mehr als 100 TB</text>
+		<text lang="es">más de 100 TB</text>
 		<text lang="fr">plus que 100 To</text>
 		<text lang="it">più di 100 TB</text>
 		<additional_input>False</additional_input>
@@ -2618,6 +2803,7 @@
 		<order>4</order>
 		<text lang="en">exact size</text>
 		<text lang="de">genau</text>
+		<text lang="es">tamaño exacto</text>
 		<text lang="fr">taille exacte</text>
 		<text lang="it">dimensione esatta</text>
 		<additional_input>True</additional_input>
@@ -2638,6 +2824,7 @@
 		<order>1</order>
 		<text lang="en">Simple copying</text>
 		<text lang="de">Einfaches Kopieren</text>
+		<text lang="es">Copia simple</text>
 		<text lang="fr">Copie simple</text>
 		<text lang="it">Copia semplice</text>
 		<additional_input>False</additional_input>
@@ -2651,6 +2838,7 @@
 		<order>2</order>
 		<text lang="en">Version control system</text>
 		<text lang="de">Versionskontrollsystem</text>
+		<text lang="es">Sistema de control de versiones</text>
 		<text lang="fr">Système de contrôle de version</text>
 		<text lang="it">Sistema di controllo di versione</text>
 		<additional_input>True</additional_input>
@@ -2664,6 +2852,7 @@
 		<order>3</order>
 		<text lang="en">Other</text>
 		<text lang="de">Sonstiges</text>
+		<text lang="es">Otro</text>
 		<text lang="fr">Autre</text>
 		<text lang="it">Altro</text>
 		<additional_input>True</additional_input>
@@ -2677,6 +2866,7 @@
 		<order>4</order>
 		<text lang="en">Not yet decided</text>
 		<text lang="de">Noch nicht entschieden</text>
+		<text lang="es">Aún no se ha decidido</text>
 		<text lang="fr">Pas encore décidé</text>
 		<text lang="it">Non ancora deciso</text>
 		<additional_input>False</additional_input>
@@ -2697,6 +2887,7 @@
 		<order>0</order>
 		<text lang="en">Yes, reviewed and approved by the following committee</text>
 		<text lang="de">Ja, positiv begutachtet von folgender Kommission</text>
+		<text lang="es">Sí, revisado y aprobado por el siguiente comité</text>
 		<text lang="fr">Oui, examiné et approuvé par le comité suivant</text>
 		<text lang="it">Sì, esaminato e approvato dal seguente comitato</text>
 		<additional_input>True</additional_input>
@@ -2710,6 +2901,7 @@
 		<order>1</order>
 		<text lang="en">Yes, approved under obligations which will be complied in the following way</text>
 		<text lang="de">Ja, begutachtet mit Auflagen, die folgendermaßen erfüllt werden</text>
+		<text lang="es">Sí, aprobado bajo obligaciones que se cumplirán de la siguiente manera</text>
 		<text lang="fr">Oui, approuvé en vertu d'obligations qui seront respectées de la manière suivante</text>
 		<text lang="it">Sì, approvato con alcune restrizioni, che dovranno essere implementate come segue</text>
 		<additional_input>True</additional_input>
@@ -2723,6 +2915,7 @@
 		<order>2</order>
 		<text lang="en">Not yet, but it is already in the review process</text>
 		<text lang="de">Noch nicht, es befindet sich aber bereits in Begutachtung</text>
+		<text lang="es">Todavía no, pero ya está en proceso de revisión</text>
 		<text lang="fr">Pas encore, mais il est déjà en cours d'examen</text>
 		<text lang="it">Non ancora, ma attualmente in corso d'esame</text>
 		<additional_input>False</additional_input>
@@ -2736,6 +2929,7 @@
 		<order>3</order>
 		<text lang="en">Not yet, it will be handed in for review by</text>
 		<text lang="de">Noch nicht, es wird zur Begutachtung eingereicht bis spätestens</text>
+		<text lang="es">Todavía no, se entregará para su revisión por</text>
 		<text lang="fr">Pas encore, il sera remis pour examen par</text>
 		<text lang="it">Non ancora, ma sarà sottoposto a esame entro</text>
 		<additional_input>True</additional_input>
@@ -2749,6 +2943,7 @@
 		<order>4</order>
 		<text lang="en">No, a review is not necessary, because</text>
 		<text lang="de">Nein, eine Begutachtung ist nicht notwendig, weil</text>
+		<text lang="es">No, no es necesaria una revisión, porque</text>
 		<text lang="fr">Non, un examen n'est pas nécessaire, car</text>
 		<text lang="it">No, una valutazione non è necessaria, perché</text>
 		<additional_input>True</additional_input>
@@ -2769,6 +2964,7 @@
 		<order>0</order>
 		<text lang="en">No</text>
 		<text lang="de">Nein</text>
+		<text lang="es">No</text>
 		<text lang="fr">Non</text>
 		<text lang="it">No</text>
 		<additional_input>False</additional_input>
@@ -2782,6 +2978,7 @@
 		<order>1</order>
 		<text lang="en">Yes. The permit has been received.</text>
 		<text lang="de">Ja. Die Genehmigung liegt bereits vor.</text>
+		<text lang="es">Sí. Se ha recibido el permiso.</text>
 		<text lang="fr">Oui. Le permis a été reçu.</text>
 		<text lang="it">Sì. L'autorizzazione è stata già ricevuta.</text>
 		<additional_input>False</additional_input>
@@ -2795,6 +2992,7 @@
 		<order>2</order>
 		<text lang="en">Yes. The permit has been applied for on</text>
 		<text lang="de">Ja. Die Genehmigung wurde beantragt am/im</text>
+		<text lang="es">Sí. El permiso se ha solicitado el</text>
 		<text lang="fr">Oui. Le permis a été demandé le</text>
 		<text lang="it">Sì. L'autorizzazione è stata richiesta il</text>
 		<additional_input>True</additional_input>
@@ -2808,6 +3006,7 @@
 		<order>3</order>
 		<text lang="en">Yes. The permit will be applied for by</text>
 		<text lang="de">Ja. Die Genehmigung wird beantragt bis spätestens</text>
+		<text lang="es">Sí. El permiso será solicitado por</text>
 		<text lang="fr">Oui. Le permis sera demandé par</text>
 		<text lang="it">Sì. L'autorizzazione verrà richiesta il</text>
 		<additional_input>True</additional_input>
@@ -2828,6 +3027,7 @@
 		<order>1</order>
 		<text lang="en">For analysis / use of the data within the project as well as for re-use</text>
 		<text lang="de">Zur Analyse/Nutzung der Daten im Rahmen des Projektes sowie zur Nachnutzung</text>
+		<text lang="es">Para el análisis/uso de los datos dentro del proyecto, así como para su reutilización</text>
 		<text lang="fr">Pour l'analyse / l'utilisation des données dans le projet ainsi que pour la réutilisation</text>
 		<text lang="it">Per l'analisi/utilizzo dei dati all'interno del progetto, come pure per il loro riutilizzo</text>
 		<additional_input>False</additional_input>
@@ -2841,6 +3041,7 @@
 		<order>2</order>
 		<text lang="en">Only for analysis / use of the data within the project</text>
 		<text lang="de">Nur zur Analyse/Nutzung der Daten im Rahmen des Projektes</text>
+		<text lang="es">Sólo para el análisis/uso de los datos dentro del proyecto</text>
 		<text lang="fr">Uniquement pour l'analyse / l'utilisation des données dans le projet</text>
 		<text lang="it">Esclusivamente per l'analisi/riutilizzo dei dati all'interno del progetto</text>
 		<additional_input>False</additional_input>
@@ -2854,6 +3055,7 @@
 		<order>3</order>
 		<text lang="en">For analysis / use of the data within the project as well as for long-term storage</text>
 		<text lang="de">Zur Analyse/Nutzung der Daten im Rahmen des Projektes sowie zur langfristigen Aufbewahrung</text>
+		<text lang="es">Para el análisis/uso de los datos dentro del proyecto, así como para su almacenamiento a largo plazo</text>
 		<text lang="fr">Pour l'analyse / l'utilisation des données dans le projet ainsi que pour leur conservation dans le long terme</text>
 		<text lang="it">Per l'analisi/utilizzo dei dati all'interno del progetto, come pure per la loro conservazione a lungo termine</text>
 		<additional_input>False</additional_input>
@@ -2867,6 +3069,7 @@
 		<order>4</order>
 		<text lang="en">The "informed consent" is not obtained</text>
 		<text lang="de">Es wird keine "informierte Einwilligung" eingeholt</text>
+		<text lang="es">El "consentimiento informado" no se obtiene</text>
 		<text lang="fr">Le « consentement éclairé » n'est pas obtenu</text>
 		<text lang="it">Il "consenso informato" non è stato richiesto</text>
 		<additional_input>False</additional_input>
@@ -2887,6 +3090,7 @@
 		<order>1</order>
 		<text lang="en">Infrastructure resources of the usual workplace equipment are sufficient.</text>
 		<text lang="de">Die üblichen Infrastrukturressourcen des Arbeitsplatzes reichen aus.</text>
+		<text lang="es">Los recursos de infraestructura del equipo habitual del lugar de trabajo son suficientes.</text>
 		<text lang="fr">Les ressources en infrastructure de l'équipement habituel sur le lieu de travail sont suffisantes.</text>
 		<text lang="it">Le infrastrutture ordinarie presenti sul luogo di lavoro sono sufficienti.</text>
 		<additional_input>False</additional_input>
@@ -2900,6 +3104,7 @@
 		<order>2</order>
 		<text lang="en">Fast read and write of data is required (high performance storage)</text>
 		<text lang="de">Schnelles Lesen und Schreiben von Daten wird benötigt (High-Performance-Speicher)</text>
+		<text lang="es">Se requiere una lectura y escritura rápida de los datos (almacenamiento de alto rendimiento)</text>
 		<text lang="fr">Les données nécessitent une lecture et une écriture rapide (mémoire haute performance)</text>
 		<text lang="it">È necessaria una lettura e scrittura rapida dei dati (memoria ad alta prestazione)</text>
 		<additional_input>False</additional_input>
@@ -2913,6 +3118,7 @@
 		<order>3</order>
 		<text lang="en">The following infrastructure resources are needed</text>
 		<text lang="de">Es werden folgende Infrastrukturressourcen benötigt</text>
+		<text lang="es">Se necesitan los siguientes recursos de infraestructura</text>
 		<text lang="fr">Les ressources d'infrastructure suivantes sont nécessaires</text>
 		<text lang="it">Le seguenti infrastrutture sono necessarie</text>
 		<additional_input>True</additional_input>
@@ -2933,6 +3139,7 @@
 		<order>1</order>
 		<text lang="en">Location</text>
 		<text lang="de">Ort</text>
+		<text lang="es">Ubicación</text>
 		<text lang="fr">Emplacement</text>
 		<text lang="it">Collocazione</text>
 		<additional_input>False</additional_input>
@@ -2946,6 +3153,7 @@
 		<order>2</order>
 		<text lang="en">Content</text>
 		<text lang="de">Inhalt</text>
+		<text lang="es">Contenido</text>
 		<text lang="fr">Contenu</text>
 		<text lang="it">Contenuto</text>
 		<additional_input>False</additional_input>
@@ -2959,6 +3167,7 @@
 		<order>3</order>
 		<text lang="en">Methodology</text>
 		<text lang="de">Methodik</text>
+		<text lang="es">Metodología</text>
 		<text lang="fr">Méthodologie</text>
 		<text lang="it">Metodo</text>
 		<additional_input>False</additional_input>
@@ -2972,6 +3181,7 @@
 		<order>4</order>
 		<text lang="en">Creation process</text>
 		<text lang="de">Erzeugungsprozess</text>
+		<text lang="es">Proceso de creación</text>
 		<text lang="fr">Processus de création</text>
 		<text lang="it">Processo di creazione</text>
 		<additional_input>False</additional_input>
@@ -2985,6 +3195,7 @@
 		<order>5</order>
 		<text lang="en">Technology</text>
 		<text lang="de">Technologie</text>
+		<text lang="es">Tecnología</text>
 		<text lang="fr">Technologie</text>
 		<text lang="it">Tecnologia</text>
 		<additional_input>False</additional_input>
@@ -2998,6 +3209,7 @@
 		<order>6</order>
 		<text lang="en">Documentation of the software necessary to use the data</text>
 		<text lang="de">Dokumentation der zur Nutzung notwendigen Software</text>
+		<text lang="es">Documentación del software necesario para utilizar los datos</text>
 		<text lang="fr">Documentation du logiciel nécessaire à l'utilisation des données</text>
 		<text lang="it">Documentazione dei programmi necessari all'utilizzo dei dati</text>
 		<additional_input>False</additional_input>
@@ -3011,6 +3223,7 @@
 		<order>7</order>
 		<text lang="en">Time</text>
 		<text lang="de">Zeit</text>
+		<text lang="es">Tiempo</text>
 		<text lang="fr">Temps</text>
 		<text lang="it">Tempo</text>
 		<additional_input>False</additional_input>
@@ -3024,6 +3237,7 @@
 		<order>8</order>
 		<text lang="en">Sources</text>
 		<text lang="de">Quellen</text>
+		<text lang="es">Fuentes</text>
 		<text lang="fr">Sources</text>
 		<text lang="it">Fonti</text>
 		<additional_input>False</additional_input>
@@ -3037,6 +3251,7 @@
 		<order>9</order>
 		<text lang="en">Agents</text>
 		<text lang="de">Akteure</text>
+		<text lang="es">Agentes</text>
 		<text lang="fr">Agents</text>
 		<text lang="it">Soggetti coinvolti</text>
 		<additional_input>False</additional_input>
@@ -3050,6 +3265,7 @@
 		<order>10</order>
 		<text lang="en">Identifiers</text>
 		<text lang="de">Identifikatoren</text>
+		<text lang="es">Identificadores</text>
 		<text lang="fr">Identifiants</text>
 		<text lang="it">Identificatori</text>
 		<additional_input>False</additional_input>
@@ -3063,6 +3279,7 @@
 		<order>11</order>
 		<text lang="en">Other</text>
 		<text lang="de">Andere</text>
+		<text lang="es">Otros</text>
 		<text lang="fr">Autres</text>
 		<text lang="it">Altri</text>
 		<additional_input>True</additional_input>
@@ -3083,6 +3300,7 @@
 		<order>1</order>
 		<text lang="en">Automatic check for completeness</text>
 		<text lang="de">Automatische Prüfung auf Vollständigkeit</text>
+		<text lang="es">Comprobación automática de la integridad</text>
 		<text lang="fr">Vérification automatique d'intégralité</text>
 		<text lang="it">Controllo automatico della completezza</text>
 		<additional_input>False</additional_input>
@@ -3096,6 +3314,7 @@
 		<order>2</order>
 		<text lang="en">Manual check for correctness</text>
 		<text lang="de">Manuelle Prüfung auf Korrektheit</text>
+		<text lang="es">Comprobación manual de la corrección</text>
 		<text lang="fr">Vérification manuelle d'exactitude</text>
 		<text lang="it">Controllo manuale dell'esattezza</text>
 		<additional_input>False</additional_input>
@@ -3109,6 +3328,7 @@
 		<order>3</order>
 		<text lang="en">Manual check for completeness</text>
 		<text lang="de">Manuelle Prüfung auf Vollständigkeit</text>
+		<text lang="es">Comprobación manual de la integridad</text>
 		<text lang="fr">Vérification manuelle d'integralité</text>
 		<text lang="it">Controllo manuale della completezza</text>
 		<additional_input>False</additional_input>
@@ -3122,6 +3342,7 @@
 		<order>4</order>
 		<text lang="en">Other</text>
 		<text lang="de">Sonstiges</text>
+		<text lang="es">Otro</text>
 		<text lang="fr">Autre</text>
 		<text lang="it">Altro</text>
 		<additional_input>True</additional_input>
@@ -3142,6 +3363,7 @@
 		<order>1</order>
 		<text lang="en">Discipline-specific standards, classifications etc. are used</text>
 		<text lang="de">Es werden disziplinspezifische Standards, Klassifikationen etc. genutzt</text>
+		<text lang="es">Se utilizan normas, clasificaciones, etc. específicas de cada disciplina</text>
 		<text lang="fr">Des normes spécifiques à la discipline, des classifications ou autres sont utilisées</text>
 		<text lang="it">Si utilizzano standard disciplinari, sistemi di classificazione ecc.</text>
 		<additional_input>True</additional_input>
@@ -3155,6 +3377,7 @@
 		<order>2</order>
 		<text lang="en">A custom description system is used (please briefly outline and, if necessary, indicate where it is documented in more detail)</text>
 		<text lang="de">Es wird ein eigenes Beschreibungssystem genutzt (bitte beschreiben Sie dieses kurz und geben, wenn nötig, an, wo es ausführlicher dokumentiert ist)</text>
+		<text lang="es">Se utiliza un sistema de descripción personalizado (resuma brevemente y, si es necesario, indique dónde está documentado con más detalle)</text>
 		<text lang="fr">Un système de description personnalisé est utilisé (veuillez décrire brièvement et, si nécessaire, indiquer où il est documenté plus en détail)</text>
 		<text lang="it">Si utilizza un proprio sistema di descrizione (si prega di descriverlo brevemente, aggiungendo un riferimento alla documentazione estesa, se necessario)</text>
 		<additional_input>True</additional_input>
@@ -3168,6 +3391,7 @@
 		<order>3</order>
 		<text lang="en">No fixed system for the description is used</text>
 		<text lang="de">Es wird kein festgelegtes System zur Beschreibung genutzt</text>
+		<text lang="es">No se utiliza un sistema fijo para la descripción</text>
 		<text lang="fr">Aucun système fixe pour la description n'est utilisé</text>
 		<text lang="it">Non si utilizza nessun sistema fisso per la descrizione</text>
 		<additional_input>False</additional_input>
@@ -3181,6 +3405,7 @@
 		<order>4</order>
 		<text lang="en">Other</text>
 		<text lang="de">Sonstiges</text>
+		<text lang="es">Otro</text>
 		<text lang="fr">Autre</text>
 		<text lang="it">Altro</text>
 		<additional_input>True</additional_input>
@@ -3194,6 +3419,7 @@
 		<order>5</order>
 		<text lang="en">It has not yet been decided, with which system the metadata and contextual information will be described</text>
 		<text lang="de">Es wurde noch nicht entschieden, mit welchem System die Metadaten und Kontextinformationen beschrieben werden</text>
+		<text lang="es">Todavía no se ha decidido con qué sistema se describirán los metadatos y la información contextual</text>
 		<text lang="fr">Il n'a pas encore été décidé avec quel système les métadonnées et les informations contextuelles seront décrites</text>
 		<text lang="it">Non è ancora stato stabilito con quale sistema descrivere i metadati e le informazioni contestuali</text>
 		<additional_input>False</additional_input>
@@ -3214,6 +3440,7 @@
 		<order>0</order>
 		<text lang="en">Yes</text>
 		<text lang="de">Ja</text>
+		<text lang="es">Sí</text>
 		<text lang="fr">Oui</text>
 		<text lang="it">Sì</text>
 		<additional_input>True</additional_input>
@@ -3227,6 +3454,7 @@
 		<order>1</order>
 		<text lang="en">No</text>
 		<text lang="de">Nein</text>
+		<text lang="es">No</text>
 		<text lang="fr">Non</text>
 		<text lang="it">No</text>
 		<additional_input>False</additional_input>
@@ -3240,6 +3468,7 @@
 		<order>2</order>
 		<text lang="en">To be clarified</text>
 		<text lang="de">Noch zu klären</text>
+		<text lang="es">Por aclarar</text>
 		<text lang="fr">À déterminer</text>
 		<text lang="it">Da chiarire</text>
 		<additional_input>False</additional_input>
@@ -3260,6 +3489,7 @@
 		<order>1</order>
 		<text lang="en">Handle / DOI</text>
 		<text lang="de">Handle / DOI</text>
+		<text lang="es">Handle / DOI</text>
 		<text lang="fr">Handle / DOI</text>
 		<text lang="it">Handle / DOI</text>
 		<additional_input>False</additional_input>
@@ -3273,6 +3503,7 @@
 		<order>2</order>
 		<text lang="en">PURL</text>
 		<text lang="de">PURL</text>
+		<text lang="es">PURL</text>
 		<text lang="fr">PURL</text>
 		<text lang="it">PURL</text>
 		<additional_input>False</additional_input>
@@ -3286,6 +3517,7 @@
 		<order>3</order>
 		<text lang="en">ARK</text>
 		<text lang="de">ARK</text>
+		<text lang="es">ARK</text>
 		<text lang="fr">ARK</text>
 		<text lang="it">ARK</text>
 		<additional_input>False</additional_input>
@@ -3299,6 +3531,7 @@
 		<order>4</order>
 		<text lang="en">URN</text>
 		<text lang="de">URN</text>
+		<text lang="es">URN</text>
 		<text lang="fr">URN</text>
 		<text lang="it">URN</text>
 		<additional_input>False</additional_input>
@@ -3312,6 +3545,7 @@
 		<order>5</order>
 		<text lang="en">ISLRN</text>
 		<text lang="de">ISLRN</text>
+		<text lang="es">ISLRN</text>
 		<text lang="fr">ISLRN</text>
 		<text lang="it">ISLRN</text>
 		<additional_input>False</additional_input>
@@ -3325,6 +3559,7 @@
 		<order>6</order>
 		<text lang="en">Other</text>
 		<text lang="de">Anderes</text>
+		<text lang="es">Otro</text>
 		<text lang="fr">Autre</text>
 		<text lang="it">Altro</text>
 		<additional_input>True</additional_input>
@@ -3338,6 +3573,7 @@
 		<order>6</order>
 		<text lang="en">Commit tag on a code repository</text>
 		<text lang="de">Commit-Nummer auf einem Code-Repositorium</text>
+		<text lang="es">Etiqueta de confirmación en un repositorio de código</text>
 		<text lang="fr">Nombre de commit dans un dépôt de développement</text>
 		<text lang="it">Numero di commit in un repositorio di codice</text>
 		<additional_input>True</additional_input>
@@ -3351,6 +3587,7 @@
 		<order>7</order>
 		<text lang="en">None</text>
 		<text lang="de">Keins</text>
+		<text lang="es">Ninguno</text>
 		<text lang="fr">Aucun</text>
 		<text lang="it">Nessuno</text>
 		<additional_input>False</additional_input>
@@ -3371,6 +3608,7 @@
 		<order>1</order>
 		<text lang="en">Basis of a publication / proof of good scientific practice</text>
 		<text lang="de">Grundlage einer Publikation / Nachweis guter wissenschaftlicher Praxis</text>
+		<text lang="es">Base de una publicación / prueba de buena práctica científica</text>
 		<text lang="fr">Fondement d'une publication / preuve de bonnes pratiques scientifiques</text>
 		<text lang="it">Fondamento di una pubblicazione / Prova di una buona pratica scientifica</text>
 		<additional_input>False</additional_input>
@@ -3384,6 +3622,7 @@
 		<order>2</order>
 		<text lang="en">Re-use in subsequent projects or by others</text>
 		<text lang="de">Nachnutzung in Folgeprojekten oder durch andere</text>
+		<text lang="es">Reutilización en proyectos posteriores o por otros</text>
 		<text lang="fr">Réutilisation dans des projets ultérieurs ou par d'autres</text>
 		<text lang="it">Riutilizzo in progetti successivi o da parte di terzi</text>
 		<additional_input>False</additional_input>
@@ -3397,6 +3636,7 @@
 		<order>3</order>
 		<text lang="en">Legal obligations</text>
 		<text lang="de">Aufgrund gesetzlicher Bestimmungen</text>
+		<text lang="es">Obligaciones legales</text>
 		<text lang="fr">Obligations légales</text>
 		<text lang="it">Obbligazioni legali</text>
 		<additional_input>False</additional_input>
@@ -3410,6 +3650,7 @@
 		<order>4</order>
 		<text lang="en">Documentation, because of their societal relevance</text>
 		<text lang="de">Dokumentation aufgrund gesellschaftlicher Relevanz</text>
+		<text lang="es">La documentación, por su relevancia social</text>
 		<text lang="fr">La documentation, à cause de sa rélévance pour la société</text>
 		<text lang="it">Documentazione per via della rilevanza per la società</text>
 		<additional_input>False</additional_input>
@@ -3423,6 +3664,7 @@
 		<order>5</order>
 		<text lang="en">Self-commitment</text>
 		<text lang="de">Selbstverpflichtung</text>
+		<text lang="es">Obligación personal</text>
 		<text lang="fr">Engagement personnel</text>
 		<text lang="it">Obbligazione personale</text>
 		<additional_input>False</additional_input>
@@ -3436,6 +3678,7 @@
 		<order>6</order>
 		<text lang="en">Other</text>
 		<text lang="de">Andere</text>
+		<text lang="es">Otros</text>
 		<text lang="fr">Autres</text>
 		<text lang="it">Altri</text>
 		<additional_input>True</additional_input>
@@ -3456,6 +3699,7 @@
 		<order>0</order>
 		<text lang="en">Own institution</text>
 		<text lang="de">Eigene Institution</text>
+		<text lang="es">Institución propia</text>
 		<text lang="fr">Sa propre institution</text>
 		<text lang="it">Proprio istituto</text>
 		<additional_input>False</additional_input>
@@ -3469,6 +3713,7 @@
 		<order>1</order>
 		<text lang="en">Another partner institution</text>
 		<text lang="de">Eine andere Partner-Institution</text>
+		<text lang="es">Otra institución asociada</text>
 		<text lang="fr">Une autre institution partenaire</text>
 		<text lang="it">Un altro istituto partner</text>
 		<additional_input>True</additional_input>
@@ -3482,6 +3727,7 @@
 		<order>2</order>
 		<text lang="en">Discipline specific data center</text>
 		<text lang="de">Disziplinspezifisches Datenzentrum</text>
+		<text lang="es">Centro de datos específico para cada disciplina</text>
 		<text lang="fr">Centre de données spécifique à la discipline</text>
 		<text lang="it">Un centro dati specifico per la disciplina</text>
 		<additional_input>True</additional_input>
@@ -3495,6 +3741,7 @@
 		<order>3</order>
 		<text lang="en">Generic data center</text>
 		<text lang="de">Generisches Datenzentrum</text>
+		<text lang="es">Centro de datos genérico</text>
 		<text lang="fr">Centre générique de données</text>
 		<text lang="it">Un centro dati generico</text>
 		<additional_input>True</additional_input>
@@ -3508,6 +3755,7 @@
 		<order>4</order>
 		<text lang="en">To be decided</text>
 		<text lang="de">Wird noch entschieden</text>
+		<text lang="es">Por decidir</text>
 		<text lang="fr">À décider</text>
 		<text lang="it">Da stabilire</text>
 		<additional_input>False</additional_input>
@@ -3521,6 +3769,7 @@
 		<order>5</order>
 		<text lang="en">Other</text>
 		<text lang="de">Sonstiges</text>
+		<text lang="es">Otro</text>
 		<text lang="fr">Autre</text>
 		<text lang="it">Altro</text>
 		<additional_input>True</additional_input>
@@ -3541,6 +3790,7 @@
 		<order>101</order>
 		<text lang="en">Humanities and Social Sciences / Ancient Cultures</text>
 		<text lang="de">Geistes- und Sozialwissenschaften / Alte Kulturen</text>
+		<text lang="es">Humanidades y Ciencias Sociales / Culturas antiguas</text>
 		<text lang="fr">Sciences humaines et société / Cultures anciennes</text>
 		<text lang="it">Scienze umane e sociali / Culture antiche</text>
 		<additional_input>False</additional_input>
@@ -3554,6 +3804,7 @@
 		<order>102</order>
 		<text lang="en">Humanities and Social Sciences / History</text>
 		<text lang="de">Geistes- und Sozialwissenschaften / Geschichtswissenschaften</text>
+		<text lang="es">Humanidades y Ciencias Sociales / Historia</text>
 		<text lang="fr">Sciences humaines et société / Histoire</text>
 		<text lang="it">Scienze umane e sociali / Storia</text>
 		<additional_input>False</additional_input>
@@ -3567,6 +3818,7 @@
 		<order>103</order>
 		<text lang="en">Humanities and Social Sciences / Fine Arts, Music, Theatre and Media Studies</text>
 		<text lang="de">Geistes- und Sozialwissenschaften / Kunst-, Musik-, Theater- und Medienwissenschaften</text>
+		<text lang="es">Humanidades y Ciencias Sociales / Bellas Artes, Música, Teatro y Medios de Comunicación</text>
 		<text lang="fr">Sciences humaines et société / Beaux-arts, musique, théâtre et études médiatiques</text>
 		<text lang="it">Scienze umane e sociali / Arti figurative, musica, teatro e mezzi di comunicazione</text>
 		<additional_input>False</additional_input>
@@ -3580,6 +3832,7 @@
 		<order>104</order>
 		<text lang="en">Humanities and Social Sciences / Linguistics</text>
 		<text lang="de">Geistes- und Sozialwissenschaften / Sprachwissenschaften</text>
+		<text lang="es">Humanidades y Ciencias Sociales / Lingüística</text>
 		<text lang="fr">Sciences humaines et société / Linguistique</text>
 		<text lang="it">Scienze umane e sociali / Linguistica</text>
 		<additional_input>False</additional_input>
@@ -3593,6 +3846,7 @@
 		<order>105</order>
 		<text lang="en">Humanities and Social Sciences / Literary Studies</text>
 		<text lang="de">Geistes- und Sozialwissenschaften / Literaturwissenschaft</text>
+		<text lang="es">Humanidades y Ciencias Sociales / Estudios literarios</text>
 		<text lang="fr">Sciences humaines et société / Études littéraires</text>
 		<text lang="it">Scienze umane e sociali / Letteratura</text>
 		<additional_input>False</additional_input>
@@ -3606,6 +3860,7 @@
 		<order>106</order>
 		<text lang="en">Humanities and Social Sciences / Non-European Languages and Cultures, Social and Cultural Anthropology, Jewish Studies and Religious Studies</text>
 		<text lang="de">Geistes- und Sozialwissenschaften / Außereuropäische Sprachen und Kulturen, Sozial- und Kulturanthropologie, Judaistik und Religionswissenschaft</text>
+		<text lang="es">Humanidades y Ciencias Sociales / Lenguas y Culturas no Europeas, Antropología Social y Cultural, Estudios Judíos y Estudios Religiosos</text>
 		<text lang="fr">Sciences humaines et société / Langues et cultures non européennes, anthropologie sociale et culturelle, études juives et études religieuses</text>
 		<text lang="it">Scienze umane e sociali / Lingue e culture non europee, antropologia socioculturale, studi ebraici e studi religiosi</text>
 		<additional_input>False</additional_input>
@@ -3619,6 +3874,7 @@
 		<order>107</order>
 		<text lang="en">Humanities and Social Sciences / Theology</text>
 		<text lang="de">Geistes- und Sozialwissenschaften / Theologie</text>
+		<text lang="es">Humanidades y Ciencias Sociales / Teología</text>
 		<text lang="fr">Sciences humaines et société / Théologie</text>
 		<text lang="it">Scienze umane e sociali / Teologia</text>
 		<additional_input>False</additional_input>
@@ -3632,6 +3888,7 @@
 		<order>108</order>
 		<text lang="en">Humanities and Social Sciences / Philosophy</text>
 		<text lang="de">Geistes- und Sozialwissenschaften / Philosophie</text>
+		<text lang="es">Humanidades y Ciencias Sociales / Filosofía</text>
 		<text lang="fr">Sciences humaines et société / Philosophie</text>
 		<text lang="it">Scienze umane e sociali / Filosofia</text>
 		<additional_input>False</additional_input>
@@ -3645,6 +3902,7 @@
 		<order>109</order>
 		<text lang="en">Humanities and Social Sciences / Education Sciences</text>
 		<text lang="de">Geistes- und Sozialwissenschaften / Erziehungswissenschaft</text>
+		<text lang="es">Humanidades y Ciencias Sociales / Ciencias de la Educación</text>
 		<text lang="fr">Sciences humaines et société / Sciences de l'éducation</text>
 		<text lang="it">Scienze umane e sociali / Scienze dell'educazione</text>
 		<additional_input>False</additional_input>
@@ -3658,6 +3916,7 @@
 		<order>110</order>
 		<text lang="en">Humanities and Social Sciences / Psychology</text>
 		<text lang="de">Geistes- und Sozialwissenschaften / Psychologie</text>
+		<text lang="es">Humanidades y Ciencias Sociales / Psicología</text>
 		<text lang="fr">Sciences humaines et société / Psychologie</text>
 		<text lang="it">Scienze umane e sociali / Psicologia</text>
 		<additional_input>False</additional_input>
@@ -3671,6 +3930,7 @@
 		<order>111</order>
 		<text lang="en">Humanities and Social Sciences / Social Sciences</text>
 		<text lang="de">Geistes- und Sozialwissenschaften / Sozialwissenschaften</text>
+		<text lang="es">Humanidades y Ciencias Sociales / Ciencias Sociales</text>
 		<text lang="fr">Sciences humaines et société / Sciences sociales</text>
 		<text lang="it">Scienze umane e sociali / Scienze sociali</text>
 		<additional_input>False</additional_input>
@@ -3684,6 +3944,7 @@
 		<order>112</order>
 		<text lang="en">Humanities and Social Sciences / Economics</text>
 		<text lang="de">Geistes- und Sozialwissenschaften / Wirtschaftswissenschaften</text>
+		<text lang="es">Humanidades y Ciencias Sociales / Economía</text>
 		<text lang="fr">Sciences humaines et société / Économie</text>
 		<text lang="it">Scienze umane e sociali / Economia</text>
 		<additional_input>False</additional_input>
@@ -3697,6 +3958,7 @@
 		<order>113</order>
 		<text lang="en">Humanities and Social Sciences / Jurisprudence</text>
 		<text lang="de">Geistes- und Sozialwissenschaften / Rechtswissenschaften</text>
+		<text lang="es">Humanidades y Ciencias Sociales / Jurisprudencia</text>
 		<text lang="fr">Sciences humaines et société / Jurisprudence</text>
 		<text lang="it">Scienze umane e sociali / Giurisprudenza</text>
 		<additional_input>False</additional_input>
@@ -3710,6 +3972,7 @@
 		<order>201</order>
 		<text lang="en">Life Sciences / Basic Biological and Medical Research</text>
 		<text lang="de">Lebenswissenschaften / Grundlagen der Biologie und Medizin</text>
+		<text lang="es">Ciencias de la vida / Investigación biológica y médica básica</text>
 		<text lang="fr">Sciences de la vie / Recherche biologique et médicale fondamentale</text>
 		<text lang="it">Scienze della vita / Fondamenti della biologia e della medicina</text>
 		<additional_input>False</additional_input>
@@ -3723,6 +3986,7 @@
 		<order>202</order>
 		<text lang="en">Life Sciences / Plant Sciences</text>
 		<text lang="de">Lebenswissenschaften / Pflanzenwissenschaften</text>
+		<text lang="es">Ciencias de la vida / Ciencias vegetales</text>
 		<text lang="fr">Sciences de la vie / Sciences végétales</text>
 		<text lang="it">Scienze della vita / Botanica</text>
 		<additional_input>False</additional_input>
@@ -3736,6 +4000,7 @@
 		<order>203</order>
 		<text lang="en">Life Sciences / Zoology</text>
 		<text lang="de">Lebenswissenschaften / Zoologie</text>
+		<text lang="es">Ciencias de la vida / Zoología</text>
 		<text lang="fr">Sciences de la vie / Zoologie</text>
 		<text lang="it">Scienze della vita / Zoologia</text>
 		<additional_input>False</additional_input>
@@ -3749,6 +4014,7 @@
 		<order>204</order>
 		<text lang="en">Life Sciences / Microbiology, Virology and Immunology</text>
 		<text lang="de">Lebenswissenschaften / Mikrobiologie, Virologie und Immunologie</text>
+		<text lang="es">Ciencias de la Vida / Microbiología, Virología e Inmunología</text>
 		<text lang="fr">Sciences de la vie / Microbiologie, virologie et immunologie</text>
 		<text lang="it">Scienze della vita / Microbiologia, virologia e immunologia</text>
 		<additional_input>False</additional_input>
@@ -3762,6 +4028,7 @@
 		<order>205</order>
 		<text lang="en">Life Sciences / Medicine</text>
 		<text lang="de">Lebenswissenschaften / Medizin</text>
+		<text lang="es">Ciencias de la vida / Medicina</text>
 		<text lang="fr">Sciences de la vie / Médecine</text>
 		<text lang="it">Scienze della vita / Medicina</text>
 		<additional_input>False</additional_input>
@@ -3775,6 +4042,7 @@
 		<order>206</order>
 		<text lang="en">Life Sciences / Neurosciences</text>
 		<text lang="de">Lebenswissenschaften / Neurowissenschaft</text>
+		<text lang="es">Ciencias de la vida / Neurociencias</text>
 		<text lang="fr">Sciences de la vie / Neurosciences</text>
 		<text lang="it">Scienze della vita / Neuroscienze</text>
 		<additional_input>False</additional_input>
@@ -3788,6 +4056,7 @@
 		<order>207</order>
 		<text lang="en">Life Sciences / Agriculture, Forestry, Horticulture and Veterinary Medicine</text>
 		<text lang="de">Lebenswissenschaften / Agrar-, Forstwissenschaften, Gartenbau und Tiermedizin</text>
+		<text lang="es">Ciencias de la vida / Agricultura, silvicultura, horticultura y veterinaria</text>
 		<text lang="fr">Sciences de la vie / Agriculture, foresterie, horticulture et médecine vétérinaire</text>
 		<text lang="it">Scienze della vita / Agronomia, foresteria, orticoltura e medicina veterinaria</text>
 		<additional_input>False</additional_input>
@@ -3801,6 +4070,7 @@
 		<order>301</order>
 		<text lang="en">Natural Sciences / Molecular Chemistry</text>
 		<text lang="de">Naturwissenschaften / Molekülchemie</text>
+		<text lang="es">Ciencias naturales / Química molecular</text>
 		<text lang="fr">Sciences naturelles / Chimie moléculaire</text>
 		<text lang="it">Scienze naturali / chimica molecolare</text>
 		<additional_input>False</additional_input>
@@ -3814,6 +4084,7 @@
 		<order>302</order>
 		<text lang="en">Natural Sciences / Chemical Solid State and Surface Research</text>
 		<text lang="de">Naturwissenschaften / Chemische Festkörper- und Oberflächenforschung</text>
+		<text lang="es">Ciencias naturales / Investigación del estado sólido y de las superficies químicas</text>
 		<text lang="fr">Sciences naturelles / Chimie de l'état solide et des surfaces</text>
 		<text lang="it">Scienze naturali / Chimica dello stato solido e delle superfici</text>
 		<additional_input>False</additional_input>
@@ -3827,6 +4098,7 @@
 		<order>303</order>
 		<text lang="en">Natural Sciences / Physical and Theoretical Chemistry</text>
 		<text lang="de">Naturwissenschaften / Physikalische und Theoretische Chemie</text>
+		<text lang="es">Ciencias naturales / Química física y teórica</text>
 		<text lang="fr">Sciences naturelles / Chimie physique et théorique</text>
 		<text lang="it">Scienze naturali / Chimica fisica e teorica</text>
 		<additional_input>False</additional_input>
@@ -3840,6 +4112,7 @@
 		<order>304</order>
 		<text lang="en">Natural Sciences / Analytical Chemistry, Method Development (Chemistry)</text>
 		<text lang="de">Naturwissenschaften / Analytik, Methodenentwicklung (Chemie)</text>
+		<text lang="es">Ciencias naturales / Química analítica, Desarrollo de métodos (Química)</text>
 		<text lang="fr">Sciences naturelles / Chimie analytique, développement de méthodes (chemie)</text>
 		<text lang="it">Scienze naturali / Chimica analitica, sviluppo metodologico</text>
 		<additional_input>False</additional_input>
@@ -3853,6 +4126,7 @@
 		<order>305</order>
 		<text lang="en">Natural Sciences / Biological Chemistry and Food Chemistry</text>
 		<text lang="de">Naturwissenschaften / Biologische Chemie und Lebensmittelchemie</text>
+		<text lang="es">Ciencias naturales / Química biológica y química de los alimentos</text>
 		<text lang="fr">Sciences naturelles / Chimie biologique et chimie alimentaire</text>
 		<text lang="it">Scienze naturali / Chimica biologica e chimica alimentare</text>
 		<additional_input>False</additional_input>
@@ -3866,6 +4140,7 @@
 		<order>306</order>
 		<text lang="en">Natural Sciences / Polymer Research</text>
 		<text lang="de">Naturwissenschaften / Polymerforschung</text>
+		<text lang="es">Ciencias naturales / Investigación sobre polímeros</text>
 		<text lang="fr">Sciences naturelles / Recherche sur les polymères</text>
 		<text lang="it">Scienze naturali / Chimica dei polimeri</text>
 		<additional_input>False</additional_input>
@@ -3879,6 +4154,7 @@
 		<order>307</order>
 		<text lang="en">Natural Sciences / Condensed Matter Physics</text>
 		<text lang="de">Naturwissenschaften / Physik der kondensierten Materie</text>
+		<text lang="es">Ciencias naturales / Física de la materia condensada</text>
 		<text lang="fr">Sciences naturelles / Physique de la matière condensée</text>
 		<text lang="it">Scienze naturali / Fisica della materia condensata</text>
 		<additional_input>False</additional_input>
@@ -3892,6 +4168,7 @@
 		<order>308</order>
 		<text lang="en">Natural Sciences / Optics, Quantum Optics and Physics of Atoms, Molecules and Plasmas</text>
 		<text lang="de">Naturwissenschaften / Optik, Quantenoptik und Physik der Atome, Moleküle und Plasmen</text>
+		<text lang="es">Ciencias naturales / Óptica, óptica cuántica y física de átomos, de moléculas y de plasmas</text>
 		<text lang="fr">Sciences naturelles / Optique, optique quantique et physique des atomes, des molécules et des plasmas</text>
 		<text lang="it">Scienze naturali / Ottica, ottica quantistica, fisica degli atomi, delle molecole e dei plasmi</text>
 		<additional_input>False</additional_input>
@@ -3905,6 +4182,7 @@
 		<order>309</order>
 		<text lang="en">Natural Sciences / Particles, Nuclei and Fields</text>
 		<text lang="de">Naturwissenschaften / Teilchen, Kerne und Felder</text>
+		<text lang="es">Ciencias naturales / Partículas, núcleos y campos</text>
 		<text lang="fr">Sciences naturelles / Particules, noyaux et champs</text>
 		<text lang="it">Scienze naturali / Particelle, nuclei e campi</text>
 		<additional_input>False</additional_input>
@@ -3918,6 +4196,7 @@
 		<order>310</order>
 		<text lang="en">Natural Sciences / Statistical Physics, Soft Matter, Biological Physics, Nonlinear Dynamics</text>
 		<text lang="de">Naturwissenschaften / Statistische Physik, Weiche Materie, Biologische Physik, Nichtlineare Dynamik</text>
+		<text lang="es">Ciencias naturales / Física estadística, materia blanda, física biológica, dinámica no lineal</text>
 		<text lang="fr">Sciences naturelles / Physique statistique, matière molle, physique biologique, dynamique non-linéaire</text>
 		<text lang="it">Scienze naturali / Fisica statistica, materia molle, fisica biologica, dinamica nonlineare</text>
 		<additional_input>False</additional_input>
@@ -3931,6 +4210,7 @@
 		<order>311</order>
 		<text lang="en">Natural Sciences / Astrophysics and Astronomy</text>
 		<text lang="de">Naturwissenschaften / Astrophysik und Astronomie</text>
+		<text lang="es">Ciencias naturales / Astrofísica y astronomía</text>
 		<text lang="fr">Sciences naturelles / Astrophysique et astronomie</text>
 		<text lang="it">Scienze naturali / Astronomia e astrofisica</text>
 		<additional_input>False</additional_input>
@@ -3944,6 +4224,7 @@
 		<order>312</order>
 		<text lang="en">Natural Sciences / Mathematics</text>
 		<text lang="de">Naturwissenschaften / Mathematik</text>
+		<text lang="es">Ciencias naturales / Matemáticas</text>
 		<text lang="fr">Sciences naturelles / Mathématiques</text>
 		<text lang="it">Scienze naturali / Matematica</text>
 		<additional_input>False</additional_input>
@@ -3957,6 +4238,7 @@
 		<order>313</order>
 		<text lang="en">Natural Sciences / Atmospheric Science and Oceanography</text>
 		<text lang="de">Naturwissenschaften / Atmosphären- und Meeresforschung</text>
+		<text lang="es">Ciencias naturales / Ciencias de la atmósfera y oceanografía</text>
 		<text lang="fr">Sciences naturelles / Science atmosphérique et océanographie</text>
 		<text lang="it">Scienze naturali / Scienze dell'atmosfera e oceanografia</text>
 		<additional_input>False</additional_input>
@@ -3970,6 +4252,7 @@
 		<order>314</order>
 		<text lang="en">Natural Sciences / Geology and Palaeontology</text>
 		<text lang="de">Naturwissenschaften / Geologie und Paläontologie</text>
+		<text lang="es">Ciencias naturales / Geología y paleontología</text>
 		<text lang="fr">Sciences naturelles / Géologie et paléontologie</text>
 		<text lang="it">Scienze naturali / Geologia e paleontologia</text>
 		<additional_input>False</additional_input>
@@ -3983,6 +4266,7 @@
 		<order>315</order>
 		<text lang="en">Natural Sciences / Geophysics and Geodesy</text>
 		<text lang="de">Naturwissenschaften / Geophysik und Geodäsie</text>
+		<text lang="es">Ciencias naturales / Geofísica y geodesia</text>
 		<text lang="fr">Sciences naturelles / Géophysique et géodésie</text>
 		<text lang="it">Scienze naturali / Geofisica e geodesia</text>
 		<additional_input>False</additional_input>
@@ -3996,6 +4280,7 @@
 		<order>316</order>
 		<text lang="en">Natural Sciences / Geochemistry, Mineralogy and Crystallography</text>
 		<text lang="de">Naturwissenschaften / Geochemie, Mineralogie und Kristallographie</text>
+		<text lang="es">Ciencias naturales / Geoquímica, mineralogía y cristalografía</text>
 		<text lang="fr">Sciences naturelles / Géochimie, minéralogie et cristallographie</text>
 		<text lang="it">Scienze naturali / Geochimica, mineralogia e cristallografia</text>
 		<additional_input>False</additional_input>
@@ -4009,6 +4294,7 @@
 		<order>317</order>
 		<text lang="en">Natural Sciences / Geography</text>
 		<text lang="de">Naturwissenschaften / Geographie</text>
+		<text lang="es">Ciencias naturales / geografía</text>
 		<text lang="fr">Sciences naturelles / Géographie</text>
 		<text lang="it">Scienze naturali / Geografia</text>
 		<additional_input>False</additional_input>
@@ -4022,6 +4308,7 @@
 		<order>318</order>
 		<text lang="en">Natural Sciences / Water Research</text>
 		<text lang="de">Naturwissenschaften / Wasserforschung</text>
+		<text lang="es">Ciencias naturales / Investigación sobre el agua</text>
 		<text lang="fr">Sciences naturelles / Recherche sur l'eau</text>
 		<text lang="it">Scienze naturali / Idrologia</text>
 		<additional_input>False</additional_input>
@@ -4035,6 +4322,7 @@
 		<order>401</order>
 		<text lang="en">Engineering Sciences / Production Technology</text>
 		<text lang="de">Ingenieurwissenschaften / Produktionstechnik</text>
+		<text lang="es">Ciencias de la ingeniería / Tecnología de la producción</text>
 		<text lang="fr">Sciences de l'ingénierie / Technologie de production</text>
 		<text lang="it">Scienze ingegneristiche / Tecnologia della produzione</text>
 		<additional_input>False</additional_input>
@@ -4048,8 +4336,9 @@
 		<order>402</order>
 		<text lang="en">Engineering Sciences / Mechanics and Constructive Mechanical Engineering</text>
 		<text lang="de">Ingenieurwissenschaften / Mechanik und Konstruktiver Maschinenbau</text>
+		<text lang="es">Ciencias de la ingeniería / Mecánica e Ingeniería mecánica constructiva</text>
 		<text lang="fr">Sciences de l'ingénierie / Génie mécanique et mécanique des structures</text>
-		<text lang="it">Scienze ingegneristiche / Ingegneria Meccanica e ?</text>
+		<text lang="it">Scienze ingegneristiche / Ingegneria Meccanica e meccanica costruttiva</text>
 		<additional_input>False</additional_input>
 	</option>
 	<option dc:uri="https://rdmorganiser.github.io/terms/options/research_fields/209">
@@ -4061,6 +4350,7 @@
 		<order>403</order>
 		<text lang="en">Engineering Sciences / Process Engineering, Technical Chemistry</text>
 		<text lang="de">Ingenieurwissenschaften / Verfahrenstechnik, Technische Chemie</text>
+		<text lang="es">Ciencias de la ingeniería / Ingeniería de procesos, química técnica</text>
 		<text lang="fr">Sciences de l'ingénierie / Génie des procédés, chimie technique</text>
 		<text lang="it">Scienze ingegneristiche / Ingegneria dei processi, Chimica tecnica</text>
 		<additional_input>False</additional_input>
@@ -4074,6 +4364,7 @@
 		<order>404</order>
 		<text lang="en">Engineering Sciences / Heat Energy Technology, Thermal Machines, Fluid Mechanics</text>
 		<text lang="de">Ingenieurwissenschaften / Wärmeenergietechnik, Thermische Maschinen, Strömungsmechanik</text>
+		<text lang="es">Ciencias de la ingeniería / Tecnología de la energía térmica, máquinas térmicas, mecánica de fluidos</text>
 		<text lang="fr">Sciences de l'ingénierie / Technologie de l'énergie calorifique, machines thermiques, mécanique des fluides</text>
 		<text lang="it">Scienze ingegneristiche / Tecnologia del calore, macchine termiche, meccanica dei fluidi</text>
 		<additional_input>False</additional_input>
@@ -4087,6 +4378,7 @@
 		<order>405</order>
 		<text lang="en">Engineering Sciences / Materials Engineering</text>
 		<text lang="de">Ingenieurwissenschaften / Werkstofftechnik</text>
+		<text lang="es">Ciencias de la ingeniería / Ingeniería de materiales</text>
 		<text lang="fr">Sciences de l'ingénierie / Génie des matériaux</text>
 		<text lang="it">Scienze ingegneristiche / Ingegneria dei materiali</text>
 		<additional_input>False</additional_input>
@@ -4100,6 +4392,7 @@
 		<order>406</order>
 		<text lang="en">Engineering Sciences / Materials Science</text>
 		<text lang="de">Ingenieurwissenschaften / Materialwissenschaft</text>
+		<text lang="es">Ciencias de la ingeniería / Ciencia de los materiales</text>
 		<text lang="fr">Sciences de l'ingénierie / Science des matériaux</text>
 		<text lang="it">Scienze ingegneristiche / Scienza dei materiali</text>
 		<additional_input>False</additional_input>
@@ -4113,6 +4406,7 @@
 		<order>407</order>
 		<text lang="en">Engineering Sciences / Systems Engineering</text>
 		<text lang="de">Ingenieurwissenschaften / Systemtechnik</text>
+		<text lang="es">Ciencias de la ingeniería / Ingeniería de sistemas</text>
 		<text lang="fr">Sciences de l'ingénierie / Ingénierie des systèmes</text>
 		<text lang="it">Scienze ingegneristiche / Ingegneria dei sistemi</text>
 		<additional_input>False</additional_input>
@@ -4126,6 +4420,7 @@
 		<order>408</order>
 		<text lang="en">Engineering Sciences / Electrical Engineering</text>
 		<text lang="de">Ingenieurwissenschaften / Elektrotechnik</text>
+		<text lang="es">Ciencias de la ingeniería / Ingeniería eléctrica</text>
 		<text lang="fr">Sciences de l'ingénierie / Ingénierie électrique</text>
 		<text lang="it">Scienze ingegneristiche / Ingegneria elettrica</text>
 		<additional_input>False</additional_input>
@@ -4139,6 +4434,7 @@
 		<order>409</order>
 		<text lang="en">Engineering Sciences / Computer Science</text>
 		<text lang="de">Ingenieurwissenschaften / Informatik</text>
+		<text lang="es">Ciencias de la Ingeniería / Informática</text>
 		<text lang="fr">Sciences de l'ingénierie / Informatique</text>
 		<text lang="it">Scienze ingegneristiche / Informatica</text>
 		<additional_input>False</additional_input>
@@ -4152,6 +4448,7 @@
 		<order>410</order>
 		<text lang="en">Engineering Sciences / Construction Engineering and Architecture</text>
 		<text lang="de">Ingenieurwissenschaften / Bauwesen und Architektur</text>
+		<text lang="es">Ciencias de la ingeniería / Ingeniería de la construcción y arquitectura</text>
 		<text lang="fr">Sciences de l'ingénierie / Génie de la construction et architecture</text>
 		<text lang="it">Scienze ingegneristiche / Ingegneria civile</text>
 		<additional_input>False</additional_input>
@@ -4172,6 +4469,7 @@
 		<order>1</order>
 		<text lang="en">Law on the rights of audio support producers</text>
 		<text lang="de">Recht des Herstellers eines Tonträgers</text>
+		<text lang="es">Ley sobre los derechos de los productores de soportes de audio</text>
 		<text lang="fr">Loi sur les droits du fabricant de supports audio</text>
 		<text lang="it">Legge sui diritti del produttore di supporti audio</text>
 		<additional_input>False</additional_input>
@@ -4185,6 +4483,7 @@
 		<order>2</order>
 		<text lang="en">Law on the consulting rights of scientific reviewers</text>
 		<text lang="de">Recht des Verfassers sichtender wissenschaftlicher Ausgaben</text>
+		<text lang="es">Ley sobre los derechos de consulta de los revisores científicos</text>
 		<text lang="fr">Loi sur les droits de consultation scientifique de l'auteur</text>
 		<text lang="it">Legge sui diritti della revisione di pubblicazioni scientifiche</text>
 		<additional_input>False</additional_input>
@@ -4198,6 +4497,7 @@
 		<order>3</order>
 		<text lang="en">Law on rights radio senders</text>
 		<text lang="de">Recht des Sendeunternehmers</text>
+		<text lang="es">Ley de derechos de los emisores de radio</text>
 		<text lang="fr">Loi sur les droits d'un entrepreneur d'envoi</text>
 		<text lang="it">Legge sui diritti di un gestore radio</text>
 		<additional_input>False</additional_input>
@@ -4211,6 +4511,7 @@
 		<order>4</order>
 		<text lang="en">Law on database providers rights</text>
 		<text lang="de">Recht des Datenbankherstellers</text>
+		<text lang="es">Ley de derechos de los proveedores de bases de datos</text>
 		<text lang="fr">Loi sur les droits d'un fabricant de la base de données</text>
 		<text lang="it">Legge sui diritti di gestore di banche dati</text>
 		<additional_input>False</additional_input>
@@ -4224,6 +4525,7 @@
 		<order>6</order>
 		<text lang="en">Other copyright laws</text>
 		<text lang="de">Andere Urheberrechte</text>
+		<text lang="es">Otras leyes de derechos de autor</text>
 		<text lang="fr">Autres lois sur le droit d'auteur</text>
 		<text lang="it">Altre leggi sul diritto d'autore</text>
 		<additional_input>True</additional_input>
@@ -4237,6 +4539,7 @@
 		<order>7</order>
 		<text lang="en">No</text>
 		<text lang="de">Nein</text>
+		<text lang="es">No</text>
 		<text lang="fr">Non</text>
 		<text lang="it">No</text>
 		<additional_input>False</additional_input>
@@ -4257,6 +4560,7 @@
 		<order>0</order>
 		<text lang="en">The code will be published under the following license</text>
 		<text lang="de">Der Code wird unter folgender Lizenz veröffentlicht</text>
+		<text lang="es">El código se publicará bajo la siguiente licencia</text>
 		<text lang="fr">Le code sera publié sous la licence suivante</text>
 		<text lang="it">Il codice verrà pubblicato con la seguente licenza</text>
 		<additional_input>True</additional_input>
@@ -4270,6 +4574,7 @@
 		<order>1</order>
 		<text lang="en">Yet to be decided</text>
 		<text lang="de">Noch zu klären</text>
+		<text lang="es">Aún no se ha decidido</text>
 		<text lang="fr">À déterminer</text>
 		<text lang="it">Non ancora deciso</text>
 		<additional_input>False</additional_input>
@@ -4288,10 +4593,11 @@
 		<dc:comment/>
 		<optionset dc:uri="https://rdmorganiser.github.io/terms/options/software_license_types"/>
 		<order>1</order>
-		<text lang="en">Attribution</text>
-		<text lang="de">Namensnennung</text>
-		<text lang="fr">Attribution</text>
-		<text lang="it">Attribuzione</text>
+		<text lang="en">Attribution (BY)</text>
+		<text lang="de">Namensnennung (BY)</text>
+		<text lang="es">Atribución (BY)</text>
+		<text lang="fr">Attribution (BY)</text>
+		<text lang="it">Attribuzione (BY)</text>
 		<additional_input>False</additional_input>
 	</option>
 	<option dc:uri="https://rdmorganiser.github.io/terms/options/software_license_types/82">
@@ -4301,10 +4607,11 @@
 		<dc:comment/>
 		<optionset dc:uri="https://rdmorganiser.github.io/terms/options/software_license_types"/>
 		<order>2</order>
-		<text lang="en">Non-commercial</text>
-		<text lang="de">keine kommerzielle Nutzung</text>
-		<text lang="fr">Pas d'utilisation commerciale</text>
-		<text lang="it">NonCommerciale</text>
+		<text lang="en">Non-commercial (NC)</text>
+		<text lang="de">keine kommerzielle Nutzung (NC)</text>
+		<text lang="es">No comercial (NC)</text>
+		<text lang="fr">Pas d'utilisation commerciale (NC)</text>
+		<text lang="it">NonCommerciale (NC)</text>
 		<additional_input>False</additional_input>
 	</option>
 	<option dc:uri="https://rdmorganiser.github.io/terms/options/software_license_types/80">
@@ -4314,10 +4621,11 @@
 		<dc:comment/>
 		<optionset dc:uri="https://rdmorganiser.github.io/terms/options/software_license_types"/>
 		<order>3</order>
-		<text lang="en">No derivative work</text>
-		<text lang="de">keine Bearbeitung</text>
-		<text lang="fr">Pas de modification</text>
-		<text lang="it">NonOpereDerivate</text>
+		<text lang="en">No derivative work (ND)</text>
+		<text lang="de">keine Bearbeitung (ND)</text>
+		<text lang="es">Ninguna obra derivada (ND)</text>
+		<text lang="fr">Pas de modification (ND)</text>
+		<text lang="it">NonOpereDerivate (ND)</text>
 		<additional_input>False</additional_input>
 	</option>
 	<option dc:uri="https://rdmorganiser.github.io/terms/options/software_license_types/83">
@@ -4327,10 +4635,11 @@
 		<dc:comment/>
 		<optionset dc:uri="https://rdmorganiser.github.io/terms/options/software_license_types"/>
 		<order>4</order>
-		<text lang="en">Share-alike</text>
-		<text lang="de">Weitergabe unter gleichen Bedingungen</text>
-		<text lang="fr">Partage dans les mêmes conditions</text>
-		<text lang="it">CondividiAlloStessoModo</text>
+		<text lang="en">Share-alike (SA)</text>
+		<text lang="de">Weitergabe unter gleichen Bedingungen (SA)</text>
+		<text lang="es">Acciones similares (SA)</text>
+		<text lang="fr">Partage dans les mêmes conditions (SA)</text>
+		<text lang="it">CondividiAlloStessoModo (SA)</text>
 		<additional_input>False</additional_input>
 	</option>
 	<option dc:uri="https://rdmorganiser.github.io/terms/options/software_license_types/234">
@@ -4342,6 +4651,7 @@
 		<order>5</order>
 		<text lang="en">Other</text>
 		<text lang="de">Andere</text>
+		<text lang="es">Otros</text>
 		<text lang="fr">Autres</text>
 		<text lang="it">Altri</text>
 		<additional_input>True</additional_input>
@@ -4362,6 +4672,7 @@
 		<order>0</order>
 		<text lang="en">Created</text>
 		<text lang="de">Erzeugt</text>
+		<text lang="es">Creado</text>
 		<text lang="fr">Créé</text>
 		<text lang="it">Creato</text>
 		<additional_input>False</additional_input>
@@ -4375,6 +4686,7 @@
 		<order>1</order>
 		<text lang="en">Re-used</text>
 		<text lang="de">Nachgenutzt</text>
+		<text lang="es">Reutilizado</text>
 		<text lang="fr">Réutilisé</text>
 		<text lang="it">Riutilizzato</text>
 		<additional_input>False</additional_input>
@@ -4395,6 +4707,7 @@
 		<order>1</order>
 		<text lang="en">Business names (company names and work titles)</text>
 		<text lang="de">geschäftliche Bezeichnungen (Unternehmenskennzeichen und Werktitel)</text>
+		<text lang="es">Nombres de empresas (nombres de empresas y títulos de trabajo)</text>
 		<text lang="fr">Noms commerciaux (noms d'entreprises et titre de fonction)</text>
 		<text lang="it">Nomi commerciali (nomi di imprese e titoli di lavoro)</text>
 		<additional_input>False</additional_input>
@@ -4408,6 +4721,7 @@
 		<order>3</order>
 		<text lang="en">Geographical indications</text>
 		<text lang="de">geografische Herkunftsangaben</text>
+		<text lang="es">Indicaciones geográficas</text>
 		<text lang="fr">Indications géographiques</text>
 		<text lang="it">Indicazioni geografiche di origine</text>
 		<additional_input>False</additional_input>
@@ -4421,6 +4735,7 @@
 		<order>4</order>
 		<text lang="en">Plant Variety Protection (Plant Varieties)</text>
 		<text lang="de">Sortenschutz (Pflanzenzüchtungen)</text>
+		<text lang="es">Protección de las obtenciones vegetales (variedades de plantas)</text>
 		<text lang="fr">Protection des obtentions végétales (variétés végétales)</text>
 		<text lang="it">Protezione delle varietà vegetali</text>
 		<additional_input>False</additional_input>
@@ -4434,6 +4749,7 @@
 		<order>5</order>
 		<text lang="en">Patents</text>
 		<text lang="de">Patente</text>
+		<text lang="es">Patentes</text>
 		<text lang="fr">Brevets</text>
 		<text lang="it">Brevetti</text>
 		<additional_input>False</additional_input>
@@ -4447,6 +4763,7 @@
 		<order>6</order>
 		<text lang="en">Semiconductor protection or protection of topographies</text>
 		<text lang="de">Halbleiterschutz bzw. Schutz von Topografien</text>
+		<text lang="es">Protección de semiconductores o protección de topografías</text>
 		<text lang="fr">Protection des sémiconducteurs ou protection des topographies</text>
 		<text lang="it">Protezione dei semiconduttori o protezione delle topografie</text>
 		<additional_input>False</additional_input>
@@ -4460,6 +4777,7 @@
 		<order>7</order>
 		<text lang="en">Supplementary Protection Certificates</text>
 		<text lang="de">Ergänzende Schutzzertifikate</text>
+		<text lang="es">Certificados de protección complementaria</text>
 		<text lang="fr">Certificats de Protection Supplémentaires</text>
 		<text lang="it">Certificati di protezione supplementari</text>
 		<additional_input>False</additional_input>
@@ -4473,6 +4791,7 @@
 		<order>8</order>
 		<text lang="en">Utility models</text>
 		<text lang="de">Gebrauchsmuster</text>
+		<text lang="es">Modelos de utilidad</text>
 		<text lang="fr">Modèles d'utilité</text>
 		<text lang="it">Modelli di utilizzo</text>
 		<additional_input>False</additional_input>
@@ -4486,6 +4805,7 @@
 		<order>9</order>
 		<text lang="en">Trademark</text>
 		<text lang="de">Markenrecht</text>
+		<text lang="es">Marca comercial</text>
 		<text lang="fr">Marque déposée</text>
 		<text lang="it">Marchio depositato</text>
 		<additional_input>False</additional_input>
@@ -4499,6 +4819,7 @@
 		<order>10</order>
 		<text lang="en">Other</text>
 		<text lang="de">Andere</text>
+		<text lang="es">Otros</text>
 		<text lang="fr">Autres</text>
 		<text lang="it">Altri</text>
 		<additional_input>True</additional_input>
@@ -4512,6 +4833,7 @@
 		<order>10</order>
 		<text lang="en">No</text>
 		<text lang="de">Nein</text>
+		<text lang="es">No</text>
 		<text lang="fr">Non</text>
 		<text lang="it">No</text>
 		<additional_input>False</additional_input>
@@ -4532,6 +4854,7 @@
 		<order>1</order>
 		<text lang="en">Yes, internally with everyone, as long as they don't pass on the code externally</text>
 		<text lang="de">Ja, intern mit allen, solange sie den Code nicht veröffentlichen oder nach außen weitergeben</text>
+		<text lang="es">Sí, internamente con todos, siempre que no pasen el código externamente</text>
 		<text lang="fr">Oui, en interne avec tout le monde, tant qu'ils ne transmettent pas le code en externe</text>
 		<text lang="it">Sì, internamente con tutti, purché non rendano pubblico il codice</text>
 		<additional_input>False</additional_input>
@@ -4545,6 +4868,7 @@
 		<order>2</order>
 		<text lang="en">Yes, externally limited with individual approval</text>
 		<text lang="de">Ja, extern in begrenztem Umfang mit individueller Freigabe</text>
+		<text lang="es">Sí, limitado externamente con aprobación individual</text>
 		<text lang="fr">Oui, limité en externe avec approbation individuelle</text>
 		<text lang="it">Sì, esternamente in una cerchia ristretta con approvazione individuale</text>
 		<additional_input>False</additional_input>
@@ -4558,6 +4882,7 @@
 		<order>3</order>
 		<text lang="en">Yes, externally for everyone</text>
 		<text lang="de">Ja, extern für alle</text>
+		<text lang="es">Sí, externamente para todos</text>
 		<text lang="fr">Oui, en externe pour tout le monde</text>
 		<text lang="it">Sì, esternamente per tutti</text>
 		<additional_input>False</additional_input>
@@ -4571,6 +4896,7 @@
 		<order>4</order>
 		<text lang="en">No</text>
 		<text lang="de">Nein</text>
+		<text lang="es">No</text>
 		<text lang="fr">Non</text>
 		<text lang="it">No</text>
 		<additional_input>False</additional_input>
@@ -4591,6 +4917,7 @@
 		<order>1</order>
 		<text lang="en">Simple copying</text>
 		<text lang="de">Einfaches Kopieren</text>
+		<text lang="es">Copia simple</text>
 		<text lang="fr">Copie simple</text>
 		<text lang="it">Copia semplice</text>
 		<additional_input>False</additional_input>
@@ -4604,6 +4931,7 @@
 		<order>2</order>
 		<text lang="en">Version control system</text>
 		<text lang="de">Versionskontrollsystem</text>
+		<text lang="es">Sistema de control de versiones</text>
 		<text lang="fr">Système de contrôle de version</text>
 		<text lang="it">Sistema di controllo di versione</text>
 		<additional_input>True</additional_input>
@@ -4617,6 +4945,7 @@
 		<order>3</order>
 		<text lang="en">Other</text>
 		<text lang="de">Sonstiges</text>
+		<text lang="es">Otro</text>
 		<text lang="fr">Autre</text>
 		<text lang="it">Altro</text>
 		<additional_input>True</additional_input>
@@ -4630,6 +4959,7 @@
 		<order>4</order>
 		<text lang="en">Not yet decided</text>
 		<text lang="de">Noch nicht entschieden</text>
+		<text lang="es">Aún no se ha decidido</text>
 		<text lang="fr">Pas encore décidé</text>
 		<text lang="it">Non ancora deciso</text>
 		<additional_input>False</additional_input>
@@ -4650,6 +4980,7 @@
 		<order>1</order>
 		<text lang="en">Yes</text>
 		<text lang="de">Ja</text>
+		<text lang="es">Sí</text>
 		<text lang="fr">Oui</text>
 		<text lang="it">Sì</text>
 		<additional_input>True</additional_input>
@@ -4663,6 +4994,7 @@
 		<order>2</order>
 		<text lang="en">No</text>
 		<text lang="de">Nein</text>
+		<text lang="es">No</text>
 		<text lang="fr">Non</text>
 		<text lang="it">No</text>
 		<additional_input>False</additional_input>
@@ -4676,6 +5008,7 @@
 		<order>3</order>
 		<text lang="en">Not yet</text>
 		<text lang="de">Noch nicht</text>
+		<text lang="es">No todavía</text>
 		<text lang="fr">Pas encore</text>
 		<text lang="it">Non ancora</text>
 		<additional_input>False</additional_input>
@@ -4696,6 +5029,7 @@
 		<order>1</order>
 		<text lang="en">Yes</text>
 		<text lang="de">Ja</text>
+		<text lang="es">Sí</text>
 		<text lang="fr">Oui</text>
 		<text lang="it">Sì</text>
 		<additional_input>True</additional_input>
@@ -4709,6 +5043,7 @@
 		<order>2</order>
 		<text lang="en">No</text>
 		<text lang="de">Nein</text>
+		<text lang="es">No</text>
 		<text lang="fr">Non</text>
 		<text lang="it">No</text>
 		<additional_input>False</additional_input>

--- a/rdmorganiser/options/rdmo.xml
+++ b/rdmorganiser/options/rdmo.xml
@@ -16,7 +16,6 @@
 		<order>1</order>
 		<text lang="en">Users are required to register in order to use the repository</text>
 		<text lang="de">Nutzende müssen sich registrieren, um das Repositorium nutzen zu können.</text>
-		<text lang="es">Los usuarios deben registrarse para acceder al repositorio</text>
 		<text lang="fr">Les utilisateurs doivent s'inscrire pour accéder au dépôt</text>
 		<text lang="it">Gli utenti devono registrarsi per poter accedere al repositorio</text>
 		<additional_input>False</additional_input>
@@ -30,7 +29,6 @@
 		<order>2</order>
 		<text lang="en">If necessary, an authentication system or a data on demand function will be provided</text>
 		<text lang="de">Wenn notwendig, ein System für die Authentifizierung oder eine Datenabfragefunktion wird etabliert</text>
-		<text lang="es">Si es necesario, se proporcionará un sistema de identificación o una función de consulta de datos</text>
 		<text lang="fr">Si nécessaire, un système d'identification ou une fonction de requête sur demande seront fournis</text>
 		<text lang="it">Se necessario, sarà allestito un sistema di autenticazione o una funzione di accesso su richiesta</text>
 		<additional_input>False</additional_input>
@@ -44,7 +42,6 @@
 		<order>3</order>
 		<text lang="en">Other</text>
 		<text lang="de">Sonstiges</text>
-		<text lang="es">Otro</text>
 		<text lang="fr">Autre</text>
 		<text lang="it">Altro</text>
 		<additional_input>True</additional_input>
@@ -58,7 +55,6 @@
 		<order>4</order>
 		<text lang="en">There is no need to ascertain the identity of persons accessing the data</text>
 		<text lang="de">Es besteht keine Notwendigkeit, die Identität von Personen zu prüfen, die auf die Daten zugreifen wollen</text>
-		<text lang="es">No es necesario verificar la identidad de las personas que acceden a los datos</text>
 		<text lang="fr">La vérification de l'identité des personnes accédant aux données n'est pas nécessaire</text>
 		<text lang="it">Non è necessaria un'identificazione di persone che ottengono l'accesso ai dati</text>
 		<additional_input>False</additional_input>
@@ -79,7 +75,6 @@
 		<order>1</order>
 		<text lang="en">Other scientists (from the own or another field)</text>
 		<text lang="de">Andere Wissenschaftlerinnen und Wissenschaftler (aus dem eigenen oder anderen Forschungsfeldern)</text>
-		<text lang="es">Otros científicos (del mismo campo o de otro)</text>
 		<text lang="fr">Scientifiques autres (du même domaine ou non)</text>
 		<text lang="it">Altri ricercatori (nello stesso o in un altro campo)</text>
 		<additional_input>True</additional_input>
@@ -93,7 +88,6 @@
 		<order>2</order>
 		<text lang="en">Stakeholders from industry / economy</text>
 		<text lang="de">Entscheidungsträger aus Industrie / Wirtschaft</text>
-		<text lang="es">Actores de la industria o de la economía</text>
 		<text lang="fr">Acteurs industriels ou de l'économie</text>
 		<text lang="it">Attori dal mondo dell'industria o dell'economia</text>
 		<additional_input>True</additional_input>
@@ -107,7 +101,6 @@
 		<order>3</order>
 		<text lang="en">Standardisation bodies</text>
 		<text lang="de">Normungsgremien</text>
-		<text lang="es">Organismos normativos</text>
 		<text lang="fr">Organismes de normalisation</text>
 		<text lang="it">Enti normativi</text>
 		<additional_input>True</additional_input>
@@ -121,7 +114,6 @@
 		<order>4</order>
 		<text lang="en">Politics / Decision makers</text>
 		<text lang="de">Politik / Entscheidungsträger</text>
-		<text lang="es">Responsables políticos o de la toma de decisiones</text>
 		<text lang="fr">Représentants politiques ou décideurs</text>
 		<text lang="it">Politici o decisori</text>
 		<additional_input>True</additional_input>
@@ -135,7 +127,6 @@
 		<order>5</order>
 		<text lang="en">Citizens</text>
 		<text lang="de">Öffentlichkeit</text>
-		<text lang="es">Ciudadanos</text>
 		<text lang="fr">Citoyens</text>
 		<text lang="it">Cittadini</text>
 		<additional_input>True</additional_input>
@@ -156,8 +147,7 @@
 		<order>1</order>
 		<text lang="en">Existing data: project own data</text>
 		<text lang="de">Bereits existierende Daten: projekteigene Daten</text>
-		<text lang="es">Datos existentes: datos específicos del proyecto</text>
-		<text lang="fr">Données existantes&#8239;: elles appartiennent au projet</text>
+		<text lang="fr">Données existantes : elles appartiennent au projet</text>
 		<text lang="it">Dati esistenti: disponibili internamente al progetto</text>
 		<additional_input>True</additional_input>
 	</option>
@@ -170,8 +160,7 @@
 		<order>2</order>
 		<text lang="en">Existing data: internal data of the project partners</text>
 		<text lang="de">Bereits existierende Daten: von Projektpartner geliefert</text>
-		<text lang="es">Datos existentes: datos internos de los socios del proyecto</text>
-		<text lang="fr">Données existantes&#8239;: elles appartiennent à certains partenaires du projet</text>
+		<text lang="fr">Données existantes : elles appartiennent à certains partenaires du projet</text>
 		<text lang="it">Dati esistenti: forniti da membri del progetto</text>
 		<additional_input>True</additional_input>
 	</option>
@@ -184,8 +173,7 @@
 		<order>3</order>
 		<text lang="en">Existing data: publicly available data</text>
 		<text lang="de">Bereits existierende Daten: öffentlich zugängliche Daten</text>
-		<text lang="es">Datos existentes: datos disponibles públicamente</text>
-		<text lang="fr">Données existantes&#8239;: elles sont déjà ouvertes au publique</text>
+		<text lang="fr">Données existantes : elles sont déjà ouvertes au publique</text>
 		<text lang="it">Dati esistenti: già pubblicati</text>
 		<additional_input>True</additional_input>
 	</option>
@@ -198,8 +186,7 @@
 		<order>5</order>
 		<text lang="en">Generated data: from experiments</text>
 		<text lang="de">Selbst erzeugte Daten: aus Experimenten</text>
-		<text lang="es">Datos generados: a partir de experimentos</text>
-		<text lang="fr">Données produites&#8239;: à partir d'expériences</text>
+		<text lang="fr">Données produites : à partir d'expériences</text>
 		<text lang="it">Dati generati: da esperimenti</text>
 		<additional_input>True</additional_input>
 	</option>
@@ -212,8 +199,7 @@
 		<order>6</order>
 		<text lang="en">Generated data: from simulations</text>
 		<text lang="de">Selbst erzeugte Daten: aus Simulationen</text>
-		<text lang="es">Datos generados: a partir de simulaciones</text>
-		<text lang="fr">Données produites&#8239;: à partir de simulations</text>
+		<text lang="fr">Données produites : à partir de simulations</text>
 		<text lang="it">Dati generati: da simulazioni</text>
 		<additional_input>True</additional_input>
 	</option>
@@ -226,8 +212,7 @@
 		<order>7</order>
 		<text lang="en">Generated data: from observations</text>
 		<text lang="de">Selbst erzeugte Daten: aus Beobachtungen</text>
-		<text lang="es">Datos generados: a partir de observaciones</text>
-		<text lang="fr">Données produites&#8239;: à partir d'observations</text>
+		<text lang="fr">Données produites : à partir d'observations</text>
 		<text lang="it">Dati generati: da studi osservativi</text>
 		<additional_input>True</additional_input>
 	</option>
@@ -240,8 +225,7 @@
 		<order>8</order>
 		<text lang="en">Generated data: from surveys</text>
 		<text lang="de">Selbst erzeugte Daten: aus Umfragen</text>
-		<text lang="es">Datos generados: a partir de encuestas</text>
-		<text lang="fr">Données produites&#8239;: à partir de questionnaires ou sondages</text>
+		<text lang="fr">Données produites : à partir de questionnaires ou sondages</text>
 		<text lang="it">Dati generati: da questionari o sondaggi</text>
 		<additional_input>True</additional_input>
 	</option>
@@ -254,8 +238,7 @@
 		<order>9</order>
 		<text lang="en">Generated data: from transformation/analysis of other data</text>
 		<text lang="de">Selbst erzeugte Daten: durch Transformation / Analyse anderer Daten</text>
-		<text lang="es">Datos generados: a partir de transformación o análisis de otros datos</text>
-		<text lang="fr">Données produites&#8239;: à partir de l'analyse ou du raffinement de données existantes</text>
+		<text lang="fr">Données produites : à partir de l'analyse ou du raffinement de données existantes</text>
 		<text lang="it">Dati generati: dalla trasformazione o analisi di dati esistenti</text>
 		<additional_input>True</additional_input>
 	</option>
@@ -268,7 +251,6 @@
 		<order>10</order>
 		<text lang="en">Other</text>
 		<text lang="de">Sonstiges</text>
-		<text lang="es">Otro</text>
 		<text lang="fr">Autre</text>
 		<text lang="it">Altro</text>
 		<additional_input>True</additional_input>
@@ -287,38 +269,35 @@
 		<dc:comment/>
 		<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_sharing_restrictions"/>
 		<order>1</order>
-		<text lang="en">Legal restrictions: Data obtained with the permission of third parties, which did not agree to make the data publicly available</text>
-		<text lang="de">Rechtliche Hinderungsgründe: Daten erhalten mit der Genehmigung Dritter, die mit einer Veröffentlichung der Daten nicht einverstanden sind</text>
-		<text lang="es">Restricciones legales: Datos obtenidos con el permiso de terceros, que no aceptaron poner los datos a disposición del público</text>
-		<text lang="fr">Restrictions juridiques&#8239;: les données sont soumises au consentement d'un tiers, qui n'a pas accordé leur ouverture au publique</text>
+		<text lang="en">Legal restrictions: Permission is required to access the data or the researched object, and the grantors do not consent to the data being disseminated</text>
+		<text lang="de">Rechtliche Hinderungsgründe: Für den Zugang zu den Daten oder zum beforschten Objekt ist eine Genehmigung erforderlich und die Erteiler der Genehmigung sind mit einer Weitergabe der Daten nicht einverstanden</text>
+		<text lang="fr">Restrictions juridiques : les données sont soumises au consentement d'un tiers, qui n'a pas accordé leur ouverture au publique</text>
 		<text lang="it">Restrizioni legali: dati ottenuti con l'autorizzazione di un soggetto terzo, che non ha acconsentito alla loro diffusione pubblica</text>
 		<additional_input>True</additional_input>
 	</option>
-	<option dc:uri="https://rdmorganiser.github.io/terms/options/dataset_sharing_restrictions/confidentiality">
+	<option dc:uri="https://rdmorganiser.github.io/terms/options/dataset_sharing_restrictions/privacy">
 		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
-		<key>confidentiality</key>
-		<path>dataset_sharing_restrictions/confidentiality</path>
+		<key>privacy</key>
+		<path>dataset_sharing_restrictions/privacy</path>
 		<dc:comment/>
 		<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_sharing_restrictions"/>
 		<order>2</order>
-		<text lang="en">Legal restrictions: Data sharing might disclose the identity of a manufacturer or other confidential information</text>
-		<text lang="de">Rechtliche Hinderungsgründe: durch Öffnung der Daten könnten die Identität der Erzeugenden oder andere vertrauliche Informationen preisgegeben</text>
-		<text lang="es">Restricciones legales: El intercambio de datos podría revelar la identidad de un fabricante u otra información confidencial</text>
-		<text lang="fr">Restrictions juridiques&#8239;: le partage des données peut révéler l'identité d'un fabricant ou d'autres informations confidentiels</text>
+		<text lang="en">Legal restrictions: sharing the data could reveal personal data for whose dissemination there is no consent</text>
+		<text lang="de">Rechtliche Hinderungsgründe: durch das Teilen der Daten könnten personenbezogene Daten preisgegeben werden, für deren Weitergabe es keine Einwilligung gibt</text>
+		<text lang="fr">Restrictions juridiques : le partage des données peut révéler l'identité d'un fabricant ou d'autres informations confidentiels</text>
 		<text lang="it">Restrizioni legali: la condivisione dei dati potrebbe rivelare l'identità di un fornitore o altre informazioni confidenziali</text>
 		<additional_input>True</additional_input>
 	</option>
-	<option dc:uri="https://rdmorganiser.github.io/terms/options/dataset_sharing_restrictions/sensitive">
+	<option dc:uri="https://rdmorganiser.github.io/terms/options/dataset_sharing_restrictions/ipr">
 		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
-		<key>sensitive</key>
-		<path>dataset_sharing_restrictions/sensitive</path>
+		<key>ipr</key>
+		<path>dataset_sharing_restrictions/ipr</path>
 		<dc:comment/>
 		<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_sharing_restrictions"/>
 		<order>3</order>
-		<text lang="en">Legal restrictions: Data contain commercially sensitive information, and their sharing might compromise the protection of a partner(s) intellectual property</text>
-		<text lang="de">Rechtliche Hinderungsgründe: Daten enthalten wirtschaftlich sensible Informationen und ihre Weitergabe könnte den Schutz des geistigen Eigentums eines Partners gefährden</text>
-		<text lang="es">Restricciones legales: Los datos contienen información comercialmente sensible, y el compartirlos podría comprometer la protección de la propiedad intelectual de un socio(s)</text>
-		<text lang="fr">Restrictions juridiques&#8239;: les données contiennent des informations relevant du secret des affaires et leur partage peut fragiliser la propriété intellectuelle de certains partenaires</text>
+		<text lang="en">Legal restrictions: Parts of the data are intellectual property of third parties or a partner and the project does not own the right to disseminate the data</text>
+		<text lang="de">Rechtliche Hinderungsgründe: Teile der Daten sind geistiges Eigentum Dritter oder eines Partners und das Projekt besitzt nicht das Recht zur Weitergabe der Daten</text>
+		<text lang="fr">Restrictions juridiques : les données contiennent des informations relevant du secret des affaires et leur partage peut fragiliser la propriété intellectuelle de certains partenaires</text>
 		<text lang="it">Restrizioni legali: i dati contengono informazioni coperte dal segreto commerciale e la loro condivisione potrebbe indebolire la proprietà intellettuale di un partner</text>
 		<additional_input>True</additional_input>
 	</option>
@@ -331,8 +310,7 @@
 		<order>4</order>
 		<text lang="en">Legal restrictions: Risk of possible violation of (inter)national law or any constraints from the Grant Agreement</text>
 		<text lang="de">Rechtliche Hinderungsgründe: Risiko einer möglichen Verletzung (inter)nationalen Rechts oder von Bedingungen im Fördervertrag</text>
-		<text lang="es">Restricciones legales: Riesgo de posible violación de la legislación (inter)nacional o de cualquier restricción del acuerdo de subvención</text>
-		<text lang="fr">Restrictions juridiques&#8239;: il existe un risque de violation d'une loi (y compris à l'étranger) ou d'une régle de l'accord de subvention</text>
+		<text lang="fr">Restrictions juridiques : il existe un risque de violation d'une loi (y compris à l'étranger) ou d'une régle de l'accord de subvention</text>
 		<text lang="it">Restrizioni legali: rischio di possibile violazione di una legge (anche estera) o di una regola dell'accordo di finanziamento</text>
 		<additional_input>True</additional_input>
 	</option>
@@ -345,7 +323,6 @@
 		<order>5</order>
 		<text lang="en">Ethical restrictions, e.g. prevention of dual use, protection of vulnerable groups or endangered species, exclusion of stolen cultural assets</text>
 		<text lang="de">Ethische Hinderungsgründe, z.B. Beschränkung militärischer Nachnutzung, Schutz vulnerabler Gruppe oder gefährdeter Spezies, Ausschluss geraubter Kulturgüter</text>
-		<text lang="es">Restricciones éticas, por ejemplo, prevención del doble uso, protección de grupos vulnerables o especies en peligro, exclusión de bienes culturales robados</text>
 		<text lang="fr">Restrictions éthiques concernant par exemple des applications militaires, des groupes vulnérables, des espèces protégées ou l'exclusion de biens culturels volés</text>
 		<text lang="it">Restrizioni etiche: es. impedimento di riutilizzi militari, protezione di gruppi vulnerabili o specie protette, esclusione di beni culturali rubati</text>
 		<additional_input>True</additional_input>
@@ -359,8 +336,7 @@
 		<order>6</order>
 		<text lang="en">Voluntary restrictions: Data economy and better comprehensibility (no publication of pre-processed data without a clear reason for doing so)</text>
 		<text lang="de">Freiwillige Beschränkungen: Datensparsamkeit und bessere Verständlichkeit (keine Veröffentlichung von Zwischenergebnissen ohnen einen triftigen Grund)</text>
-		<text lang="es">Restricciones voluntarias: Economía de datos y mayor comprensibilidad (no se publican datos preprocesados sin una razón clara para hacerlo)</text>
-		<text lang="fr">Restrictions propres&#8239;: économie de données et cohérence (aucune publication de données intermédiaires sans raison clairement valable)</text>
+		<text lang="fr">Restrictions propres : économie de données et cohérence (aucune publication de données intermédiaires sans raison clairement valable)</text>
 		<text lang="it">Restrizioni volontarie: economia e comprensibilità (non pubblicazione di risultati intermedi senza una ragione specifica)</text>
 		<additional_input>True</additional_input>
 	</option>
@@ -373,8 +349,7 @@
 		<order>7</order>
 		<text lang="en">Voluntary restrictions: Use of results taken from past publications for confirmatory reasons only</text>
 		<text lang="de">Freiwillige Beschränkungen: Verwendung von Ergebnissen früherer Veröffentlichungen nur zu Bestätigungszwecken</text>
-		<text lang="es">Restricciones voluntarias: Utilización de resultados tomados de publicaciones anteriores sólo por razones de confirmación</text>
-		<text lang="fr">Restrictions propres&#8239;: les résultats publiés existants ne sont utilisés que pour comparaison</text>
+		<text lang="fr">Restrictions propres : les résultats publiés existants ne sont utilisés que pour comparaison</text>
 		<text lang="it">Restrizioni volontarie: utilizzo di risultati da pubblicazioni precedenti unicamente per confronto o conferma dei risultati</text>
 		<additional_input>True</additional_input>
 	</option>
@@ -387,23 +362,8 @@
 		<order>8</order>
 		<text lang="en">Voluntary restrictions: No direct relevance of the data for the main topic of the publication</text>
 		<text lang="de">Freiwillige Beschränkungen: keine direkte Relevanz der Daten für das Hauptthema der Textpublikation</text>
-		<text lang="es">Restricciones voluntarias: No hay relevancia directa de los datos para el tema principal de la publicación</text>
-		<text lang="fr">Restrictions propres&#8239;: aucune pertinence des données pour le sujet principal de la publication</text>
+		<text lang="fr">Restrictions propres : aucune pertinence des données pour le sujet principal de la publication</text>
 		<text lang="it">Restrizioni volontarie: mancata pertinenza dei dati rispetto al soggetto principale della pubblicazione</text>
-		<additional_input>True</additional_input>
-	</option>
-	<option dc:uri="https://rdmorganiser.github.io/terms/options/dataset_sharing_restrictions/future">
-		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
-		<key>future</key>
-		<path>dataset_sharing_restrictions/future</path>
-		<dc:comment/>
-		<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_sharing_restrictions"/>
-		<order>9</order>
-		<text lang="en">Voluntary restrictions: Intention to use underlying information in (near) future textual publications</text>
-		<text lang="de">Freiwillige Beschränkungen: Absicht, zugrunde liegende Informationen in (nahen) zukünftigen Textveröffentlichungen zu verwenden</text>
-		<text lang="es">Restricciones voluntarias: Intención de utilizar la información subyacente en futuras publicaciones textuales (cercanas)</text>
-		<text lang="fr">Restrictions propres&#8239;: intention d'utiliser dans un future proche l'information sous-jacente pour une publication écrite</text>
-		<text lang="it">Restrizioni volontarie: intenzione di utilizzare l'informazione contenuta nei dati in future pubblicazioni testuali</text>
 		<additional_input>True</additional_input>
 	</option>
 	<option dc:uri="https://rdmorganiser.github.io/terms/options/dataset_sharing_restrictions/redundancy">
@@ -415,8 +375,7 @@
 		<order>10</order>
 		<text lang="en">Voluntary restrictions: Redundancy of the data with the information already made available within a textual publication</text>
 		<text lang="de">Freiwillige Beschränkungen: Redundanz der Daten, wobei die Daten bereits in einer Textpublikation mit zur Verfügung gestellt worden sind</text>
-		<text lang="es">Restricciones voluntarias: Redundancia de los datos con la información ya disponible dentro de una publicación textual</text>
-		<text lang="fr">Restrictions propres&#8239;: redondance des données avec l'information rendue disponible dans une publication écrite</text>
+		<text lang="fr">Restrictions propres : redondance des données avec l'information rendue disponible dans une publication écrite</text>
 		<text lang="it">Restrizioni volontarie: ridondanza dei dati con l'informazione già contenuta in una pubblicazione testuale</text>
 		<additional_input>True</additional_input>
 	</option>
@@ -429,7 +388,6 @@
 		<order>11</order>
 		<text lang="en">Other restrictions</text>
 		<text lang="de">Andere Hinderungsgründe</text>
-		<text lang="es">Otras restricciones</text>
 		<text lang="fr">Autres restrictions</text>
 		<text lang="it">Altre restrizioni</text>
 		<additional_input>True</additional_input>
@@ -450,7 +408,6 @@
 		<order>1</order>
 		<text lang="en">Information on methodology used for data generation (creation or re-use) and transformation</text>
 		<text lang="de">Information zu Verfahren der Datenerzeugung und Weiterverarbeitung der Daten (auch bei Nachnutzung)</text>
-		<text lang="es">Información sobre la metodología utilizada para la generación (creación o reutilización) y transformación de datos</text>
 		<text lang="fr">Information sur la méthodologie employée pour la génération des données (création ou réutilisation) et leur transformation</text>
 		<text lang="it">Informazioni sui metodi usati per la creazione e la trasformazione dei dati</text>
 		<additional_input>True</additional_input>
@@ -464,7 +421,6 @@
 		<order>2</order>
 		<text lang="en">Information on methodology used for data cleaning and analysis</text>
 		<text lang="de">Information zu Verfahren der Datenbereinigung und -analyse</text>
-		<text lang="es">Información sobre la metodología utilizada para la selección y el análisis de los datos</text>
 		<text lang="fr">Information sur la méthodologie employée pour la filtration et l'analyse des données</text>
 		<text lang="it">Informazioni sui metodi usati per la selezione e l'analisi dei dati</text>
 		<additional_input>True</additional_input>
@@ -478,7 +434,6 @@
 		<order>3</order>
 		<text lang="en">Description of variables used and respective units of measurement</text>
 		<text lang="de">Beschreibung der verwendeten Variablen und zugehörigen Maßeinheiten</text>
-		<text lang="es">Descripción de las variables utilizadas y sus respectivas unidades de medida</text>
 		<text lang="fr">Description des variables en jeu et leurs unités de mesure respectives</text>
 		<text lang="it">Descrizione delle variabili in gioco e delle rispettive unità di misura</text>
 		<additional_input>True</additional_input>
@@ -492,7 +447,6 @@
 		<order>4</order>
 		<text lang="en">Quality control report</text>
 		<text lang="de">Qualitätskontrollbericht</text>
-		<text lang="es">Reporte de control de calidad</text>
 		<text lang="fr">Rapport de contrôle qualité</text>
 		<text lang="it">Rapporto del controllo qualità</text>
 		<additional_input>True</additional_input>
@@ -506,7 +460,6 @@
 		<order>5</order>
 		<text lang="en">Version information</text>
 		<text lang="de">Versionsinformation</text>
-		<text lang="es">Información sobre la versión</text>
 		<text lang="fr">Information de version</text>
 		<text lang="it">Informazione di versione</text>
 		<additional_input>True</additional_input>
@@ -520,8 +473,7 @@
 		<order>6</order>
 		<text lang="en">For survey data: survey instruments (questionnaires, ...), interviewer instructions, codebooks, scale manuals, technical reports</text>
 		<text lang="de">Für Umfragedaten: Erhebungsinstrumente (Fragebögen, ...), Intervieweranweisungen, Codebücher, Skalenhandbücher, technische Berichte</text>
-		<text lang="es">Para los datos de las encuestas: instrumentos de encuesta (cuestionarios, ...), instrucciones para el entrevistador, libros de códigos, manuales de escalas, informes técnicos</text>
-		<text lang="fr">En cas d'entrevues&#8239;: questionnaires, instructions pour les sondeurs, livres de code, manuelles d'échelle, rapports techniques</text>
+		<text lang="fr">En cas d'entrevues : questionnaires, instructions pour les sondeurs, livres de code, manuelles d'échelle, rapports techniques</text>
 		<text lang="it">In caso di sondaggi: questionari, istruzioni per gli intervistatori, libri di codice, manuali di scala, rapporti tecnici</text>
 		<additional_input>True</additional_input>
 	</option>
@@ -534,7 +486,6 @@
 		<order>10</order>
 		<text lang="en">Other</text>
 		<text lang="de">Sonstiges</text>
-		<text lang="es">Otro</text>
 		<text lang="fr">Autre</text>
 		<text lang="it">Altro</text>
 		<additional_input>True</additional_input>
@@ -555,7 +506,6 @@
 		<order>1</order>
 		<text lang="en">Publication of the results in a peer-reviewed journal</text>
 		<text lang="de">Veröffentlichung der Ergebnisse in einer fachreferierten Zeitschrift</text>
-		<text lang="es">Publicación de los resultados en una revista revisada por expertos</text>
 		<text lang="fr">Publication des résultats dans une revue à comité de lecture</text>
 		<text lang="it">Pubblicazione dei risultati in una rivista con peer review</text>
 		<additional_input>False</additional_input>
@@ -569,7 +519,6 @@
 		<order>2</order>
 		<text lang="en">Achievement of intellectual property rights such as</text>
 		<text lang="de">Erlangung intellektueller Rechte wie</text>
-		<text lang="es">Consecución de derechos de propiedad intelectual como</text>
 		<text lang="fr">Obtention de droits de propriété intellectuelle tels que</text>
 		<text lang="it">Conseguimento di diritti di proprietà intellettuale come</text>
 		<additional_input>True</additional_input>
@@ -583,7 +532,6 @@
 		<order>3</order>
 		<text lang="en">Finishing of a bachelor/master/doctor thesis</text>
 		<text lang="de">Anfertigung einer Abschlussarbeit (Bachelor-, Master- oder Doktor-)</text>
-		<text lang="es">Finalización de una tesis de pregrado/máster/doctorado</text>
 		<text lang="fr">Réalisation d'une thèse (de licence, de master ou de doctorat)</text>
 		<text lang="it">Completamento di una tesi (triennale, specialistica o di dottorato)</text>
 		<additional_input>False</additional_input>
@@ -597,7 +545,6 @@
 		<order>10</order>
 		<text lang="en">Other</text>
 		<text lang="de">Sonstiges</text>
-		<text lang="es">Otro</text>
 		<text lang="fr">Autre</text>
 		<text lang="it">Altro</text>
 		<additional_input>True</additional_input>
@@ -618,7 +565,6 @@
 		<order>1</order>
 		<text lang="en">table</text>
 		<text lang="de">Tabelle</text>
-		<text lang="es">tabla</text>
 		<text lang="fr">tableau</text>
 		<text lang="it">tabella</text>
 		<additional_input>True</additional_input>
@@ -632,7 +578,6 @@
 		<order>2</order>
 		<text lang="en">graphics</text>
 		<text lang="de">Grafik</text>
-		<text lang="es">gráfico</text>
 		<text lang="fr">graphique</text>
 		<text lang="it">grafico</text>
 		<additional_input>True</additional_input>
@@ -646,7 +591,6 @@
 		<order>3</order>
 		<text lang="en">video</text>
 		<text lang="de">Video</text>
-		<text lang="es">video</text>
 		<text lang="fr">vidéo</text>
 		<text lang="it">video</text>
 		<additional_input>True</additional_input>
@@ -660,7 +604,6 @@
 		<order>4</order>
 		<text lang="en">audio</text>
 		<text lang="de">Audio</text>
-		<text lang="es">audio</text>
 		<text lang="fr">audio</text>
 		<text lang="it">audio</text>
 		<additional_input>True</additional_input>
@@ -674,7 +617,6 @@
 		<order>5</order>
 		<text lang="en">text</text>
 		<text lang="de">Text</text>
-		<text lang="es">texto</text>
 		<text lang="fr">texte</text>
 		<text lang="it">testo</text>
 		<additional_input>True</additional_input>
@@ -688,7 +630,6 @@
 		<order>6</order>
 		<text lang="en">database</text>
 		<text lang="de">Datenbank</text>
-		<text lang="es">base de datos</text>
 		<text lang="fr">base de données</text>
 		<text lang="it">banca dati</text>
 		<additional_input>True</additional_input>
@@ -702,7 +643,6 @@
 		<order>7</order>
 		<text lang="en">geospatial data</text>
 		<text lang="de">Geografische Information</text>
-		<text lang="es">datos geoespaciales</text>
 		<text lang="fr">données géospatiales</text>
 		<text lang="it">Dati geospaziali</text>
 		<additional_input>True</additional_input>
@@ -716,7 +656,6 @@
 		<order>8</order>
 		<text lang="en">computer-aided design</text>
 		<text lang="de">Computer Aided Design</text>
-		<text lang="es">diseño asistido por ordenador</text>
 		<text lang="fr">conception assistée par ordinateur</text>
 		<text lang="it">computer-aided design</text>
 		<additional_input>True</additional_input>
@@ -730,7 +669,6 @@
 		<order>9</order>
 		<text lang="en">statistical analysis</text>
 		<text lang="de">Statistische Auswertung</text>
-		<text lang="es">análisis estadístico</text>
 		<text lang="fr">analyse statistique</text>
 		<text lang="it">analisi statistica</text>
 		<additional_input>True</additional_input>
@@ -744,7 +682,6 @@
 		<order>10</order>
 		<text lang="en">Other</text>
 		<text lang="de">Sonstiges</text>
-		<text lang="es">Otro</text>
 		<text lang="fr">Autre</text>
 		<text lang="it">Altro</text>
 		<additional_input>True</additional_input>
@@ -764,8 +701,7 @@
 		<optionset dc:uri="https://rdmorganiser.github.io/terms/options/mappings"/>
 		<order>1</order>
 		<text lang="en">The generated ontologies and vocabularies for the published data are provided, together with appropriate mappings in an informal, lightweight form (glossaries, alignment tables, …) to more commonly used ontologies</text>
-		<text lang="de">Die generierte Ontologien und Vokabularien für die veröffentlichten Daten werden mitgeliefert, zusammen mit passenden Konkordanzen zu gängigen Terminologie, in einer leichten und informellen Weise (Glossar, Korrespondenztabelle, ...)</text>
-		<text lang="es">Se adjuntan las ontologías y vocabularios generados para los datos publicados. La correspondencia con terminologías de uso común se expresa de forma ligera e informal (glosario, tabla de alineación, ...).</text>
+		<text lang="de">Die generierten Ontologien und Vokabularien für die veröffentlichten Daten werden mitgeliefert, zusammen mit passenden Konkordanzen zu gängiger Terminologie, in einer leichten und informellen Weise (Glossar, Korrespondenztabelle, ...)</text>
 		<text lang="fr">Les ontologies et vocabulaires générés pour les données publiées sont fournis. Les correspondances appropriées sont disposées de manière informelle et claire (glossaires, tableaux de correspondance, ...)</text>
 		<text lang="it">Le ontologie e i vocabolari generati per i dati pubblicati sono allegati. La corrispondenza a terminologie di uso comune è espressa in modo leggero e informale (glossario, tabella di allineamento, ...)</text>
 		<additional_input>True</additional_input>
@@ -778,8 +714,7 @@
 		<optionset dc:uri="https://rdmorganiser.github.io/terms/options/mappings"/>
 		<order>2</order>
 		<text lang="en">The generated ontologies and vocabularies for the published data are provided, together with appropriate mappings in a formal, heavyweight form (OWL, RDF, …) to more commonly used ontologies</text>
-		<text lang="de">Die generierte Ontologien und Vokabularien für die veröffentlichten Daten werden mitgeliefert, zusammen mit passenden Konkordanzen zu gängigen Terminologie, in einer vertieften und formellen Weise (OWL-Sprache, RDF-Modell, ...)</text>
-		<text lang="es">Se adjuntan las ontologías y vocabularios generados para los datos publicados. La correspondencia con las terminologías de uso común se expresa de manera formal y detallada (lenguaje OWL, modelo RDF, ...).</text>
+		<text lang="de">Die generierten Ontologien und Vokabularien für die veröffentlichten Daten werden mitgeliefert, zusammen mit passenden Konkordanzen zu gängiger Terminologie, in einer vertieften und formellen Weise (OWL-Sprache, RDF-Modell, ...)</text>
 		<text lang="fr">Les ontologies et vocabulaires générés pour les données publiées sont fournis. Les correspondances appropriées sont disposées de manière formelle et détaillée (langage OWL, modèle RDF, ...)</text>
 		<text lang="it">Le ontologie e i vocabolari generati per i dati pubblicati sono allegati. La corrispondenza a terminologie di uso comune è espressa in modo formale e dettagliato (linguaggio OWL, modello RDF, ...)</text>
 		<additional_input>True</additional_input>
@@ -793,7 +728,6 @@
 		<order>3</order>
 		<text lang="en">No mappings are necessary, as the datasets are described using standard terminologies / There is no need for a mapping, since the used terminology is chosen to be compatible with the existing literature</text>
 		<text lang="de">Das Mitliefern von Konkordanzen is nicht notwendig aufgrund der Kompatibilität der verwendeten Terminologie mit der bestehenden Literatur</text>
-		<text lang="es">No es necesario realizar mapeos, ya que los conjuntos de datos se describen utilizando terminologías estándar / No es necesario realizar mapeos, ya que la terminología utilizada se elige para que sea compatible con la literatura existente</text>
 		<text lang="fr">Comme le jeu de données utilise des terminologies de référence ou compatibles avec la littérature existante, aucune correspondance est nécessaire</text>
 		<text lang="it">Non c'è bisogno di riportare corrispondenze, dato cha la terminologia usata è compatibile con la letteratura esistente</text>
 		<additional_input>True</additional_input>
@@ -814,7 +748,6 @@
 		<order>1</order>
 		<text lang="en">Software</text>
 		<text lang="de">Programme</text>
-		<text lang="es">Programas</text>
 		<text lang="fr">Logiciels</text>
 		<text lang="it">Programmi</text>
 		<additional_input>False</additional_input>
@@ -828,7 +761,6 @@
 		<order>2</order>
 		<text lang="en">Workflows</text>
 		<text lang="de">Workflows</text>
-		<text lang="es">Workflows</text>
 		<text lang="fr">Workflows</text>
 		<text lang="it">Workflows</text>
 		<additional_input>False</additional_input>
@@ -842,7 +774,6 @@
 		<order>3</order>
 		<text lang="en">Protocols</text>
 		<text lang="de">Protokolle</text>
-		<text lang="es">Protocolos</text>
 		<text lang="fr">Protocoles</text>
 		<text lang="it">Protocolli</text>
 		<additional_input>False</additional_input>
@@ -856,7 +787,6 @@
 		<order>4</order>
 		<text lang="en">Models</text>
 		<text lang="de">Modelle</text>
-		<text lang="es">Modelos</text>
 		<text lang="fr">Modèles</text>
 		<text lang="it">Modelli</text>
 		<additional_input>False</additional_input>
@@ -870,7 +800,6 @@
 		<order>5</order>
 		<text lang="en">Samples</text>
 		<text lang="de">Proben</text>
-		<text lang="es">Muestras</text>
 		<text lang="fr">Échantillons</text>
 		<text lang="it">Campioni</text>
 		<additional_input>False</additional_input>
@@ -884,7 +813,6 @@
 		<order>6</order>
 		<text lang="en">New materials</text>
 		<text lang="de">Neue Werkstoffe</text>
-		<text lang="es">Nuevos materiales</text>
 		<text lang="fr">Nouveaux matériaux</text>
 		<text lang="it">Nuovi materiali</text>
 		<additional_input>False</additional_input>
@@ -898,7 +826,6 @@
 		<order>7</order>
 		<text lang="en">New chemical substances (reagents, ...)</text>
 		<text lang="de">Neue chemische Substanzen (Reagenzien, ...)</text>
-		<text lang="es">Nuevas sustancias químicas (reactivos, ...)</text>
 		<text lang="fr">Nouvelles substances chimiques (réactants, ...)</text>
 		<text lang="it">Nuove sostanze chimiche (reagenti, ...)</text>
 		<additional_input>False</additional_input>
@@ -912,7 +839,6 @@
 		<order>8</order>
 		<text lang="en">New biological substances (antibodies, ...)</text>
 		<text lang="de">Neue biologische Substanzen (Antikörper, ...)</text>
-		<text lang="es">Nuevas sustancias biológicas (anticuerpos, ...)</text>
 		<text lang="fr">Nouvelles substances biologiques (anticorps, ...)</text>
 		<text lang="it">Nuove sostanze biologiche (anticorpi, ...)</text>
 		<additional_input>False</additional_input>
@@ -926,7 +852,6 @@
 		<order>10</order>
 		<text lang="en">Other</text>
 		<text lang="de">Sonstiges</text>
-		<text lang="es">Otro</text>
 		<text lang="fr">Autre</text>
 		<text lang="it">Altro</text>
 		<additional_input>True</additional_input>
@@ -947,7 +872,6 @@
 		<order>1</order>
 		<text lang="en">The repository</text>
 		<text lang="de">Das Repositorium</text>
-		<text lang="es">El repositorio</text>
 		<text lang="fr">Le dépôt</text>
 		<text lang="it">Il repositorio</text>
 		<additional_input>False</additional_input>
@@ -961,7 +885,6 @@
 		<order>2</order>
 		<text lang="en">The institutional library</text>
 		<text lang="de">Die Bibliothek des Instituts</text>
-		<text lang="es">La biblioteca institucional</text>
 		<text lang="fr">Le centre de documentation de l'institution</text>
 		<text lang="it">La biblioteca dell’istituto</text>
 		<additional_input>False</additional_input>
@@ -975,7 +898,6 @@
 		<order>3</order>
 		<text lang="en">The IT department of the institute</text>
 		<text lang="de">Das Rechenzentrum des Instituts</text>
-		<text lang="es">El departamento de informática del instituto</text>
 		<text lang="fr">Le service informatique de l'institution</text>
 		<text lang="it">Il centro di calcolo dell’istituto</text>
 		<additional_input>False</additional_input>
@@ -989,7 +911,6 @@
 		<order>4</order>
 		<text lang="en">The project coordinator</text>
 		<text lang="de">Der Projektkoordinator</text>
-		<text lang="es">El coordinador del proyecto</text>
 		<text lang="fr">Le coordinateur du projet</text>
 		<text lang="it">Il coordinatore del progetto</text>
 		<additional_input>False</additional_input>
@@ -1003,7 +924,6 @@
 		<order>5</order>
 		<text lang="en">The data coordinator</text>
 		<text lang="de">Der Datenkoordinator</text>
-		<text lang="es">El responsable de los datos</text>
 		<text lang="fr">Le responsable des données</text>
 		<text lang="it">Il responsabile dei dati</text>
 		<additional_input>False</additional_input>
@@ -1017,7 +937,6 @@
 		<order>10</order>
 		<text lang="en">Other</text>
 		<text lang="de">Sonstiges</text>
-		<text lang="es">Otro</text>
 		<text lang="fr">Autre</text>
 		<text lang="it">Altro</text>
 		<additional_input>True</additional_input>
@@ -1038,7 +957,6 @@
 		<order>1</order>
 		<text lang="en">Yes, the data include qualified references to other datasets from the same project</text>
 		<text lang="de">Ja, die Daten enthalten qualifizierte Referenzen zu anderen Datensätzen desselben Projekts</text>
-		<text lang="es">Sí, los datos incluyen referencias cualificadas a otros conjuntos de datos del mismo proyecto</text>
 		<text lang="fr">Oui, les données se réfèrent à d'autres jeux de données du même projet</text>
 		<text lang="it">Sì, i dati contengono riferimenti qualificati ad altre raccolte di dati dello stesso progetto</text>
 		<additional_input>True</additional_input>
@@ -1052,7 +970,6 @@
 		<order>2</order>
 		<text lang="en">Yes, the data include qualified references to other datasets from previous research</text>
 		<text lang="de">Ja, die Daten enthalten qualifizierte Referenzen zu anderen Datensätzen aus vorherigen Forschungsaktivitäten</text>
-		<text lang="es">Sí, los datos incluyen referencias cualificadas a otros conjuntos de datos de investigaciones anteriores</text>
 		<text lang="fr">Oui, les données se réfèrent à d'autres jeux de données de recherches antérieurs</text>
 		<text lang="it">Sì, i dati contengono riferimenti qualificati ad altre raccolte di dati da ricerche precedenti</text>
 		<additional_input>True</additional_input>
@@ -1066,7 +983,6 @@
 		<order>3</order>
 		<text lang="en">No, the data do not include any references to other data</text>
 		<text lang="de">Nein, die Daten enthalten keine Referenzen anderer Daten</text>
-		<text lang="es">No, los datos no incluyen ninguna referencia a otros datos</text>
 		<text lang="fr">Non, les données ne font pas référence à d'autres données</text>
 		<text lang="it">No, i dati non fanno riferimenti ad altri dati</text>
 		<additional_input>True</additional_input>
@@ -1087,7 +1003,6 @@
 		<order>1</order>
 		<text lang="en">Completeness check</text>
 		<text lang="de">Prüfung auf Vollständigkeit</text>
-		<text lang="es">Control de integridad de los datos</text>
 		<text lang="fr">Contrôle d'intégralité des données</text>
 		<text lang="it">Controllo di integrità dei dati</text>
 		<additional_input>True</additional_input>
@@ -1101,7 +1016,6 @@
 		<order>2</order>
 		<text lang="en">Data reconciliation</text>
 		<text lang="de">Datenabgleich</text>
-		<text lang="es">Reconciliación de datos</text>
 		<text lang="fr">Réconciliation des données</text>
 		<text lang="it">Riconciliazione dei dati</text>
 		<additional_input>True</additional_input>
@@ -1115,7 +1029,6 @@
 		<order>3</order>
 		<text lang="en">Sampling procedures</text>
 		<text lang="de">Vorgehen bei der Probennahme</text>
-		<text lang="es">Procedimientos de muestreo</text>
 		<text lang="fr">Procédures d'échantillonnage</text>
 		<text lang="it">Procedure di campionamento</text>
 		<additional_input>True</additional_input>
@@ -1129,7 +1042,6 @@
 		<order>4</order>
 		<text lang="en">Repeated or comparative measurements</text>
 		<text lang="de">Wiederholte und vergleichbare Messungen</text>
-		<text lang="es">Mediciones repetidas o comparativas</text>
 		<text lang="fr">Mesures répétées ou comparées</text>
 		<text lang="it">Misure ripetute o comparative</text>
 		<additional_input>True</additional_input>
@@ -1143,7 +1055,6 @@
 		<order>5</order>
 		<text lang="en">Adherence to standard procedures for data recording</text>
 		<text lang="de">Konformität zu Standardprozeduren zur Datenaufnahme</text>
-		<text lang="es">Cumplimiento de los procedimientos estándar de registro de datos</text>
 		<text lang="fr">Acquisition des données en cohérence avec des procédures de référence</text>
 		<text lang="it">Acquisizione dei dati conforme a procedure standard</text>
 		<additional_input>True</additional_input>
@@ -1157,7 +1068,6 @@
 		<order>6</order>
 		<text lang="en">Use of controlled vocabularies and standard terminology</text>
 		<text lang="de">Verwendung kontrollierter Vokabulare und von Standard-Ausdrucksweise</text>
-		<text lang="es">Uso de vocabularios controlados y terminología estándar</text>
 		<text lang="fr">Utilisation de vocabulaires réglementés et d'une terminologie de référence</text>
 		<text lang="it">Uso di vocabolari controllati e terminologia standard</text>
 		<additional_input>True</additional_input>
@@ -1171,7 +1081,6 @@
 		<order>7</order>
 		<text lang="en">Metrological characterisation of the measurement set-up</text>
 		<text lang="de">Metrologische Charakterisierung des Messaufbaus</text>
-		<text lang="es">Caracterización metrológica del equipo de medición</text>
 		<text lang="fr">Charactérisation métrologique du procédé de mesure</text>
 		<text lang="it">Caratterizzazione metrologica dei procedimenti di misura</text>
 		<additional_input>True</additional_input>
@@ -1185,7 +1094,6 @@
 		<order>8</order>
 		<text lang="en">Data validation</text>
 		<text lang="de">Datenvalidierung</text>
-		<text lang="es">Validación de datos</text>
 		<text lang="fr">Validation des données</text>
 		<text lang="it">Validazione dei dati</text>
 		<additional_input>True</additional_input>
@@ -1199,7 +1107,6 @@
 		<order>9</order>
 		<text lang="en">Provision of test results along with the data</text>
 		<text lang="de">Verfügbarmachung von Testergebnissen zusammen mit den Daten</text>
-		<text lang="es">Suministro de los resultados de las pruebas junto con los datos</text>
 		<text lang="fr">Fourniture avec les données de résultats de tests</text>
 		<text lang="it">Disponibilità dei risultati di tests insieme con i dati</text>
 		<additional_input>True</additional_input>
@@ -1213,7 +1120,6 @@
 		<order>10</order>
 		<text lang="en">Peer review of textual publications based on the data</text>
 		<text lang="de">Peer-Review von Textpublikationen basierend auf den Daten</text>
-		<text lang="es">Revisión de las publicaciones textuales basadas en los datos</text>
 		<text lang="fr">Relecture par des paires de publication (textuel) se basant sur les données</text>
 		<text lang="it">Revisione di pubblicazioni testuali basate sui dati</text>
 		<additional_input>True</additional_input>
@@ -1227,7 +1133,6 @@
 		<order>20</order>
 		<text lang="en">Other</text>
 		<text lang="de">Sonstiges</text>
-		<text lang="es">Otro</text>
 		<text lang="fr">Autre</text>
 		<text lang="it">Altro</text>
 		<additional_input>True</additional_input>
@@ -1248,7 +1153,6 @@
 		<order>1</order>
 		<text lang="en">Yes, because of the big size of the data</text>
 		<text lang="de">Ja, wegen des großen Datenvolumens</text>
-		<text lang="es">Sí, debido al gran tamaño de los datos</text>
 		<text lang="fr">Oui, en raison de la quantité élevée de données</text>
 		<text lang="it">Sì, a causa della grande quantità dei dati</text>
 		<additional_input>True</additional_input>
@@ -1262,7 +1166,6 @@
 		<order>2</order>
 		<text lang="en">Yes, because of the particular format of the data</text>
 		<text lang="de">Ja, wegen des speziellen Datenformats</text>
-		<text lang="es">Sí, debido al formato particular de los datos</text>
 		<text lang="fr">Oui, en raison du format particulier des données</text>
 		<text lang="it">Sì, a causa della grande quantità dei dati</text>
 		<additional_input>True</additional_input>
@@ -1276,7 +1179,6 @@
 		<order>3</order>
 		<text lang="en">Yes, because the data are confidential</text>
 		<text lang="de">Ja, weil die Daten vertraulich sind</text>
-		<text lang="es">Sí, porque los datos son confidenciales</text>
 		<text lang="fr">Oui, parce que les données sont confidencielles</text>
 		<text lang="it">Sì, perché i dati sono confidenziali</text>
 		<additional_input>True</additional_input>
@@ -1290,7 +1192,6 @@
 		<order>4</order>
 		<text lang="en">Yes, because of legal issues related to the data</text>
 		<text lang="de">Ja, wegen rechtlicher Probleme mit den Daten</text>
-		<text lang="es">Sí, por cuestiones legales relacionadas con los datos</text>
 		<text lang="fr">Oui, pour des raisons juridiques en lien avec les données</text>
 		<text lang="it">Sì, a causa di problemi legali collegati ai dati</text>
 		<additional_input>True</additional_input>
@@ -1304,7 +1205,6 @@
 		<order>5</order>
 		<text lang="en">Yes, for other reasons</text>
 		<text lang="de">Ja, aus anderen Gründen</text>
-		<text lang="es">Sí, por otras razones</text>
 		<text lang="fr">Oui, pour d'autres raisons</text>
 		<text lang="it">Sì, per altri motivi</text>
 		<additional_input>True</additional_input>
@@ -1318,7 +1218,6 @@
 		<order>6</order>
 		<text lang="en">No, the data will be uploaded via a standard procedure and require no special arrangements</text>
 		<text lang="de">Nein, die Daten werden mit Hilfe einer Standardprozedur hochgeladen und erfordern keine speziellen Vorbereitungen</text>
-		<text lang="es">No, los datos se cargarán a través de un procedimiento estándar y no requieren ningún acuerdo especial</text>
 		<text lang="fr">Non, les données seront téléversées en suivant une procédure et non pas besoin d'ajustement particulier</text>
 		<text lang="it">No, i dati si possono caricare con una procedura standard e non necessitano accordi particolari</text>
 		<additional_input>True</additional_input>
@@ -1339,8 +1238,7 @@
 		<order>1</order>
 		<text lang="en">The repository meets the basic expectations of a research data repository: easy and free access while observing legal and ethical barriers, detailed metadata, protection against unauthorized access</text>
 		<text lang="de">Das Repositorium erfüllt die grundsätzlichen Erwartungen an ein Forschungsdatenrepositorium: leichter und kostenfreier Zugang bei Beachtung rechtlicher und ethischer Schranken, detaillierte Metadaten, Schutz gegen unautorisierten Zugriff</text>
-		<text lang="es">El repositorio cumple con las expectativas básicas de un repositorio de datos de investigación: acceso fácil y gratuito respetando las barreras legales y éticas, metadatos detallados, protección contra el acceso no autorizado</text>
-		<text lang="fr">Le dépôt remplit les attentes minimales en terme de stockage de données de recherche&#8239;: accès simple et gratuit, tout en proposant des barrières juridiques et ethiques, des métadonnées détaillées, et une protection contre les accès prohibés.</text>
+		<text lang="fr">Le dépôt remplit les attentes minimales en terme de stockage de données de recherche : accès simple et gratuit, tout en proposant des barrières juridiques et ethiques, des métadonnées détaillées, et une protection contre les accès prohibés.</text>
 		<text lang="it">Il repositorio soddisfa le richieste minime per la conservazione dei dati della ricerca: accesso agevole e gratuito pur nel rispetto delle barriere legali ed etiche, metadati dettagliati, protezione contro l'accesso non autorizzati</text>
 		<additional_input>True</additional_input>
 	</option>
@@ -1353,7 +1251,6 @@
 		<order>1</order>
 		<text lang="en">Machine-actionable and standardised metadata are used, e.g. Dublin Core</text>
 		<text lang="de">Maschinenlesbare und standardisierte Metadaten werden verwendet, z.B. Dublin Core</text>
-		<text lang="es">Se utilizan metadatos estandarizados y procesables por máquina, por ejemplo, Dublin Core</text>
 		<text lang="fr">Sont utilisées des métadonnées lisibles et exploitables par les machines (« machine-actionable ») et standardisées telles que « Dublin Core »</text>
 		<text lang="it">Sono utilizzati metadati leggibili e riutilizzabili da una macchina  («machine-actionable») e conformi a uno standard, es. Dublin Core</text>
 		<additional_input>True</additional_input>
@@ -1367,7 +1264,6 @@
 		<order>1</order>
 		<text lang="en">The repository can provide persistent identifiers, e.g. a DOI</text>
 		<text lang="de">Das Repositorium kann persistente Identifikatoren vergeben (z.B. einen DOI)</text>
-		<text lang="es">El repositorio puede proporcionar identificadores persistentes, por ejemplo, un DOI</text>
 		<text lang="fr">Le dépôt fournit des identificateurs persistents, par ex. des DOI</text>
 		<text lang="it">Il repositorio fornisce identificatori persistenti, es. DOI</text>
 		<additional_input>True</additional_input>
@@ -1381,7 +1277,6 @@
 		<order>1</order>
 		<text lang="en">The repository checks the quality of the data</text>
 		<text lang="de">Das Repositorium prüft die Qualität der Daten</text>
-		<text lang="es">El depósito comprueba la calidad de los datos</text>
 		<text lang="fr">Le dépôt contrôle la qualité des données</text>
 		<text lang="it">Il repositorio controlla la qualità dei dati</text>
 		<additional_input>True</additional_input>
@@ -1395,7 +1290,6 @@
 		<order>1</order>
 		<text lang="en">The repository offers expert curation for the long-term archivation</text>
 		<text lang="de">Das Repositorium bietet eine Datenpflege für die Langzeitarchivierung durch Experten an</text>
-		<text lang="es">El repositorio ofrece la curación de expertos para el archivo a largo plazo</text>
 		<text lang="fr">Le dépôt a une expertise en conservation et propose un archivage durable</text>
 		<text lang="it">Il repositorio offre un servizio professionale di cura dei dati per la conservazione a lungo termine</text>
 		<additional_input>True</additional_input>
@@ -1409,7 +1303,6 @@
 		<order>1</order>
 		<text lang="en">The repository offers services and mechanisms that go beyond the usual data download, which facilitate the subsequent use of the data, e.g. visualization, analysis tools.</text>
 		<text lang="de">Das Repositorium bietet über den üblichen Daten-Download hinausgehende Dienste und Mechanismen an, die die Nachnutzung der Daten erleichtern, z.B. Visualisierung, Analysetools</text>
-		<text lang="es">El repositorio ofrece servicios y mecanismos que van más allá de la habitual descarga de datos, que facilitan el uso posterior de los mismos, por ejemplo, visualización, herramientas de análisis.</text>
 		<text lang="fr">Au-delà du simple téléchargement, le dépôt propose des services ou des outils facilitant les manipulations ultérieures des données, permettant par exemple une visualisation ou une analyse</text>
 		<text lang="it">Oltre allo scaricamento dei dati, il repositorio offre servizi aggiuntivi che facilitano il riutilizzo dei dati, per esempio la visualizazione o l'analisi</text>
 		<additional_input>True</additional_input>
@@ -1423,7 +1316,6 @@
 		<order>1</order>
 		<text lang="en">The repository holds a certification</text>
 		<text lang="de">Das Repositorium ist zertifiziert</text>
-		<text lang="es">El depósito tiene una certificación</text>
 		<text lang="fr">Le dépôt a une certification à jour</text>
 		<text lang="it">Il repositorio possiede una certificazione ufficiale</text>
 		<additional_input>True</additional_input>
@@ -1437,7 +1329,6 @@
 		<order>2</order>
 		<text lang="en">The repository is internationally acknowledged for the a specific discipline/domain</text>
 		<text lang="de">Das Repositorium ist auf dem Fachgebiet international anerkannt</text>
-		<text lang="es">El repositorio está reconocido internacionalmente para una disciplina/dominio específico</text>
 		<text lang="fr">Le dépôt est reconnu internationallement pour un domaine particulier</text>
 		<text lang="it">Il repositorio gode di un riconoscimento internazionale per una disciplina o dominio specifico</text>
 		<additional_input>True</additional_input>
@@ -1451,7 +1342,6 @@
 		<order>3</order>
 		<text lang="en">The repository is managed by a trustworthy institution</text>
 		<text lang="de">Das Repositorium wird von einer vertrauenswürdigen Institution verwaltet</text>
-		<text lang="es">El depósito está gestionado por una institución de confianza</text>
 		<text lang="fr">Le dépôt est géré par un organisme de confiance</text>
 		<text lang="it">Il repositorio è gestito da un'istituzione considerata affidabile</text>
 		<additional_input>True</additional_input>
@@ -1465,7 +1355,6 @@
 		<order>4</order>
 		<text lang="en">The repository's policy is available online</text>
 		<text lang="de">Die Nutzungsbedingungen des Repositoriums sind online verfügbar</text>
-		<text lang="es">La política del depósito está disponible en línea</text>
 		<text lang="fr">La politique du dépôt est disponible en ligne</text>
 		<text lang="it">La regolamentazione del repositorio è disponibile in linea</text>
 		<additional_input>True</additional_input>
@@ -1486,7 +1375,6 @@
 		<order>1</order>
 		<text lang="en">Protection against unauthorized access</text>
 		<text lang="de">Schutz vor unerlaubtem Zugriff</text>
-		<text lang="es">Protección contra el acceso no autorizado</text>
 		<text lang="fr">Protection contre les accès indésirables</text>
 		<text lang="it">Protezione contro accessi indesiserati</text>
 		<additional_input>True</additional_input>
@@ -1500,8 +1388,7 @@
 		<order>2</order>
 		<text lang="en">Data robustness: checksum</text>
 		<text lang="de">Datenrobustheit: Checksumme</text>
-		<text lang="es">Solidez de los datos: suma de comprobación</text>
-		<text lang="fr">Robustesse de données&#8239;: somme de contrôle</text>
+		<text lang="fr">Robustesse de données : somme de contrôle</text>
 		<text lang="it">Robustezza dei dati: checksum</text>
 		<additional_input>True</additional_input>
 	</option>
@@ -1514,8 +1401,7 @@
 		<order>3</order>
 		<text lang="en">Data robustness: encryption</text>
 		<text lang="de">Datenrobustheit: Verschlüsselung</text>
-		<text lang="es">Solidez de los datos: cifrado</text>
-		<text lang="fr">Robustesse de données&#8239;: chiffrement</text>
+		<text lang="fr">Robustesse de données : chiffrement</text>
 		<text lang="it">Robustezza dei dati: cifratura</text>
 		<additional_input>True</additional_input>
 	</option>
@@ -1528,8 +1414,7 @@
 		<order>4</order>
 		<text lang="en">Data recovery: backups</text>
 		<text lang="de">Datenwiederherstellung: Backups</text>
-		<text lang="es">Recuperación de datos: copias de seguridad</text>
-		<text lang="fr">Récupération de données&#8239;: sauvegardes</text>
+		<text lang="fr">Récupération de données : sauvegardes</text>
 		<text lang="it">Recupero dei dati: backup</text>
 		<additional_input>True</additional_input>
 	</option>
@@ -1542,8 +1427,7 @@
 		<order>5</order>
 		<text lang="en">Data recovery: multiple replicas in a distributed file system</text>
 		<text lang="de">Datenwiederherstellung: redundante Kopien in einem verteilten Dateisystem</text>
-		<text lang="es">Recuperación de datos: múltiples réplicas en un sistema de archivos distribuido</text>
-		<text lang="fr">Récupération de données&#8239;: plusieures copies dans un système de fichier distribué</text>
+		<text lang="fr">Récupération de données : plusieures copies dans un système de fichier distribué</text>
 		<text lang="it">Recupero dei dati: copie multiple in un sistema distribuito di cartelle</text>
 		<additional_input>True</additional_input>
 	</option>
@@ -1556,8 +1440,7 @@
 		<order>6</order>
 		<text lang="en">Sensitive data: anonymisation or pseudonymisation</text>
 		<text lang="de">Sensible Daten: Anonymisierung oder Pseudonymisierung</text>
-		<text lang="es">Datos sensibles: anonimización o seudonimización</text>
-		<text lang="fr">Données sensibles&#8239;: anonymisation ou pseudonymisation</text>
+		<text lang="fr">Données sensibles : anonymisation ou pseudonymisation</text>
 		<text lang="it">Dati sensibili: anonimizzazione o pseudonimizzazione</text>
 		<additional_input>True</additional_input>
 	</option>
@@ -1570,7 +1453,6 @@
 		<order>10</order>
 		<text lang="en">Other</text>
 		<text lang="de">Sonstiges</text>
-		<text lang="es">Otro</text>
 		<text lang="fr">Autre</text>
 		<text lang="it">Altro</text>
 		<additional_input>True</additional_input>
@@ -1592,7 +1474,6 @@
 		<order>1</order>
 		<text lang="en">free software</text>
 		<text lang="de">Freie Software</text>
-		<text lang="es">software gratuito</text>
 		<text lang="fr">Logiciel libre</text>
 		<text lang="it">programma libero</text>
 		<additional_input>True</additional_input>
@@ -1606,7 +1487,6 @@
 		<order>2</order>
 		<text lang="en">common commercial software</text>
 		<text lang="de">Gängige kommerzielle Software</text>
-		<text lang="es">software comercial común</text>
 		<text lang="fr">Logiciel commercial propriétaire</text>
 		<text lang="it">programma commerciale</text>
 		<additional_input>True</additional_input>
@@ -1620,7 +1500,6 @@
 		<order>3</order>
 		<text lang="en">self-generated software or script</text>
 		<text lang="de">Selbsterzeugte Software oder Skript</text>
-		<text lang="es">software o script autogenerado</text>
 		<text lang="fr">Logiciel ou script auto-généré</text>
 		<text lang="it">programma o script autoprodotto</text>
 		<additional_input>True</additional_input>
@@ -1634,7 +1513,6 @@
 		<order>5</order>
 		<text lang="en">Other</text>
 		<text lang="de">Sonstiges</text>
-		<text lang="es">Otro</text>
 		<text lang="fr">Autre</text>
 		<text lang="it">Altro</text>
 		<additional_input>True</additional_input>
@@ -1655,7 +1533,6 @@
 		<order>0</order>
 		<text lang="en">Calibration procedure</text>
 		<text lang="de">Kalibrierverfahren</text>
-		<text lang="es">Procedimiento de calibración</text>
 		<text lang="fr">Procédure de calibrage</text>
 		<text lang="it">Procedura di calibrazione</text>
 		<additional_input>True</additional_input>
@@ -1669,7 +1546,6 @@
 		<order>1</order>
 		<text lang="en">Repeated measurements</text>
 		<text lang="de">Wiederholte Messungen</text>
-		<text lang="es">Mediciones repetidas</text>
 		<text lang="fr">Mesures répétées</text>
 		<text lang="it">Misure ripetute</text>
 		<additional_input>True</additional_input>
@@ -1683,7 +1559,6 @@
 		<order>2</order>
 		<text lang="en">Standards for data recording</text>
 		<text lang="de">Datenaufzeichnungsstandards</text>
-		<text lang="es">Normas para el registro de datos</text>
 		<text lang="fr">Normes d'enregistrement des données</text>
 		<text lang="it">Standard per il salvataggio dei dati</text>
 		<additional_input>True</additional_input>
@@ -1697,7 +1572,6 @@
 		<order>3</order>
 		<text lang="en">Controlled vocabularies or standard terminology</text>
 		<text lang="de">Kontrollierte Vokabulare oder standardisierte Terminologien</text>
-		<text lang="es">Vocabularios controlados o terminología estándar</text>
 		<text lang="fr">Vocabulaires contrôlés ou terminologie standard</text>
 		<text lang="it">Vocabolari controllati o terminologia standard</text>
 		<additional_input>True</additional_input>
@@ -1711,7 +1585,6 @@
 		<order>4</order>
 		<text lang="en">Validation of the data collection</text>
 		<text lang="de">Validierung der Datenerfassung</text>
-		<text lang="es">Validación de la recogida de datos</text>
 		<text lang="fr">Validation de la collecte des données</text>
 		<text lang="it">Validazione dell’acquisizione dati</text>
 		<additional_input>True</additional_input>
@@ -1725,7 +1598,6 @@
 		<order>5</order>
 		<text lang="en">Peer reviews of the data</text>
 		<text lang="de">Peer reviews der Daten</text>
-		<text lang="es">Control "peer review" de los datos</text>
 		<text lang="fr">Examen des données par des pairs</text>
 		<text lang="it">Controllo "peer review" dei dati</text>
 		<additional_input>True</additional_input>
@@ -1739,7 +1611,6 @@
 		<order>6</order>
 		<text lang="en">Others</text>
 		<text lang="de">Sonstiges</text>
-		<text lang="es">Otros</text>
 		<text lang="fr">Autres</text>
 		<text lang="it">Altro</text>
 		<additional_input>True</additional_input>
@@ -1760,7 +1631,6 @@
 		<order>1</order>
 		<text lang="en">Bundesdatenschutzgesetz (BDSG, Federal Data Protection Act)</text>
 		<text lang="de">Bundesdatenschutzgesetz (BDSG)</text>
-		<text lang="es">Bundesdatenschutzgesetz (BDSG, Ley Federal alemana de Protección de Datos)</text>
 		<text lang="fr">Loi allemande sur la protection des données (BDSG pour Bundesdatenschutzgesetz)</text>
 		<text lang="it">Bundesdatenschutzgesetz (BDSG, legge federale sulla protezione dei dati)</text>
 		<additional_input>False</additional_input>
@@ -1774,7 +1644,6 @@
 		<order>2</order>
 		<text lang="en">Landesdatenschutzgesetz Baden-Württemberg (State Data Protection Act of Baden-Württemberg)</text>
 		<text lang="de">Landesdatenschutzgesetz Baden-Württemberg</text>
-		<text lang="es">Ley estatal de protección de datos de Baden-Württemberg</text>
 		<text lang="fr">Loi sur la protection des données du Bade-Wurtemberg</text>
 		<text lang="it">Legge sulla protezione dei dati del Baden-Württenberg</text>
 		<additional_input>False</additional_input>
@@ -1788,7 +1657,6 @@
 		<order>3</order>
 		<text lang="en">Landesdatenschutzgesetz Bayern (State Data Protection Act of Bavaria)</text>
 		<text lang="de">Landesdatenschutzgesetz Bayern</text>
-		<text lang="es">Ley estatal de protección de datos de Baviera</text>
 		<text lang="fr">Loi sur la protection des données de la Bavière</text>
 		<text lang="it">Legge sulla protezione dei dati della Baviera</text>
 		<additional_input>False</additional_input>
@@ -1802,7 +1670,6 @@
 		<order>4</order>
 		<text lang="en">Landesdatenschutzgesetz Berlin (State Data Protection Act of Berlin)</text>
 		<text lang="de">Landesdatenschutzgesetz Berlin</text>
-		<text lang="es">Ley estatal de protección de datos de Berlín</text>
 		<text lang="fr">Loi sur la protection des données de Berlin</text>
 		<text lang="it">Legge sulla protezione dei dati di Berlino</text>
 		<additional_input>False</additional_input>
@@ -1816,7 +1683,6 @@
 		<order>5</order>
 		<text lang="en">Landesdatenschutzgesetz Bremen (State Data Protection Act of Bremen)</text>
 		<text lang="de">Landesdatenschutzgesetz Bremen</text>
-		<text lang="es">Ley estatal de protección de datos de Bremen</text>
 		<text lang="fr">Loi sur la protection des données de Brême</text>
 		<text lang="it">Legge sulla protezione dei dati di Brema</text>
 		<additional_input>False</additional_input>
@@ -1830,7 +1696,6 @@
 		<order>6</order>
 		<text lang="en">Landesdatenschutzgesetz Brandenburg (State Data Protection Act of Brandenburg)</text>
 		<text lang="de">Landesdatenschutzgesetz Brandenburg</text>
-		<text lang="es">Ley estatal de protección de datos de Brandemburgo</text>
 		<text lang="fr">Loi sur la protection des données du Brandebourg</text>
 		<text lang="it">Legge sulla protezione dei dati del Brandeburgo</text>
 		<additional_input>False</additional_input>
@@ -1844,7 +1709,6 @@
 		<order>7</order>
 		<text lang="en">Landesdatenschutzgesetz Hamburg (State Data Protection Act of Hamburg)</text>
 		<text lang="de">Landesdatenschutzgesetz Hamburg</text>
-		<text lang="es">Ley estatal de protección de datos de Hamburgo</text>
 		<text lang="fr">Loi sur la protection des données de Hambourg</text>
 		<text lang="it">Legge sulla protezione dei dati di Amburgo</text>
 		<additional_input>False</additional_input>
@@ -1858,7 +1722,6 @@
 		<order>8</order>
 		<text lang="en">Landesdatenschutzgesetz Mecklenburg-Vorpommern (State Data Protection Act of Mecklenburg-Vorpommern)</text>
 		<text lang="de">Landesdatenschutzgesetz Mecklenburg-Vorpommern</text>
-		<text lang="es">Ley estatal de protección de datos de Mecklemburgo-Pomerania Occidental</text>
 		<text lang="fr">Loi sur la protection des données du Mecklembourg-Poméranie-Occidentale</text>
 		<text lang="it">Legge sulla protezione dei dati del Meclemburgo-Pomerania Anteriore</text>
 		<additional_input>False</additional_input>
@@ -1872,7 +1735,6 @@
 		<order>9</order>
 		<text lang="en">Landesdatenschutzgesetz Hessen (State Data Protection Act of Hesse)</text>
 		<text lang="de">Landesdatenschutzgesetz Hessen</text>
-		<text lang="es">Ley estatal de protección de datos de Hesse</text>
 		<text lang="fr">Loi sur la protection des données de la Hesse</text>
 		<text lang="it">Legge sulla protezione dei dati dell'Assia</text>
 		<additional_input>False</additional_input>
@@ -1886,7 +1748,6 @@
 		<order>10</order>
 		<text lang="en">Landesdatenschutzgesetz Nordrhein-Westfalen (State Data Protection Act of North Rhine-Westphalia)</text>
 		<text lang="de">Landesdatenschutzgesetz Nordrhein-Westfalen</text>
-		<text lang="es">Ley estatal de protección de datos de Renania del Norte-Westfalia</text>
 		<text lang="fr">Loi sur la protection des données de la Rhénanie-du-Nord-Westphalie</text>
 		<text lang="it">Legge sulla protezione dei dati della Renania Settentrionale-Vestfalia</text>
 		<additional_input>False</additional_input>
@@ -1900,7 +1761,6 @@
 		<order>11</order>
 		<text lang="en">Landesdatenschutzgesetz Rheinland-Pfalz (State Data Protection Act of Rhineland-Palatinate)</text>
 		<text lang="de">Landesdatenschutzgesetz Rheinland-Pfalz</text>
-		<text lang="es">Ley estatal de protección de datos de Renania-Palatinado</text>
 		<text lang="fr">Loi sur la protection des données de la Rhénanie-Palatinat</text>
 		<text lang="it">Legge sulla protezione dei dati della Renania-Palatinato</text>
 		<additional_input>False</additional_input>
@@ -1914,7 +1774,6 @@
 		<order>12</order>
 		<text lang="en">Landesdatenschutzgesetz Niedersachsen (State Data Protection Act of Lower Saxony)</text>
 		<text lang="de">Landesdatenschutzgesetz Niedersachsen</text>
-		<text lang="es">Ley estatal de protección de datos de Baja Sajonia</text>
 		<text lang="fr">Loi sur la protection des données de la Basse-Saxe</text>
 		<text lang="it">Legge sulla protezione dei dati della Bassa-Sassonia</text>
 		<additional_input>False</additional_input>
@@ -1928,7 +1787,6 @@
 		<order>13</order>
 		<text lang="en">Landesdatenschutzgesetz Saarland (State Data Protection Act of Saarland)</text>
 		<text lang="de">Landesdatenschutzgesetz Saarland</text>
-		<text lang="es">Ley estatal de protección de datos del Sarre</text>
 		<text lang="fr">Loi sur la protection des données de la Sarre</text>
 		<text lang="it">Legge sulla protezione dei dati della Saarland</text>
 		<additional_input>False</additional_input>
@@ -1942,7 +1800,6 @@
 		<order>14</order>
 		<text lang="en">Landesdatenschutzgesetz Sachsen (State Data Protection Act of Saxony)</text>
 		<text lang="de">Landesdatenschutzgesetz Sachsen</text>
-		<text lang="es">Ley estatal de protección de datos de Sajonia</text>
 		<text lang="fr">Loi sur la protection des données de la Saxe</text>
 		<text lang="it">Legge sulla protezione dei dati della Sassonia</text>
 		<additional_input>False</additional_input>
@@ -1956,7 +1813,6 @@
 		<order>15</order>
 		<text lang="en">Landesdatenschutzgesetz Sachsen-Anhalt (State Data Protection Act of Saxony-Anhalt)</text>
 		<text lang="de">Landesdatenschutzgesetz Sachsen-Anhalt</text>
-		<text lang="es">Ley estatal de protección de datos de Sajonia-Anhalt</text>
 		<text lang="fr">Loi sur la protection des données de la Saxe-Anhalt</text>
 		<text lang="it">Legge sulla protezione dei dati della Sassonia-Anhalt</text>
 		<additional_input>False</additional_input>
@@ -1970,7 +1826,6 @@
 		<order>16</order>
 		<text lang="en">Landesdatenschutzgesetz Schleswig-Holstein (State Data Protection Act of Schleswig-Holstein)</text>
 		<text lang="de">Landesdatenschutzgesetz Schleswig-Holstein</text>
-		<text lang="es">Ley estatal de protección de datos de Schleswig-Holstein</text>
 		<text lang="fr">Loi sur la protection des données du Schleswig-Holstein</text>
 		<text lang="it">Legge sulla protezione dei dati dello Schleswig-Holstein</text>
 		<additional_input>False</additional_input>
@@ -1984,7 +1839,6 @@
 		<order>17</order>
 		<text lang="en">Landesdatenschutzgesetz Thüringen (State Data Protection Act of Thuringia)</text>
 		<text lang="de">Landesdatenschutzgesetz Thüringen</text>
-		<text lang="es">Ley estatal de protección de datos de Turingia</text>
 		<text lang="fr">Loi sur la protection des données de la Thuringe</text>
 		<text lang="it">Legge sulla protezione dei dati della Turingia</text>
 		<additional_input>False</additional_input>
@@ -1996,11 +1850,10 @@
 		<dc:comment/>
 		<optionset dc:uri="https://rdmorganiser.github.io/terms/options/data_protection_laws"/>
 		<order>18</order>
-		<text lang="en">Sozialgesetzbuch X (Volume X of the German Social Insurance Code), e.g. for medical data</text>
+		<text lang="en">Sozialgesetzbuch X (Social Security Act X), e.g. for medical data</text>
 		<text lang="de">Sozialgesetzbuch X (z.B. für medizinische Daten)</text>
-		<text lang="es">Sozialgesetzbuch X (libro X del Código alemán de Seguridad Social), por ejemplo, para los datos médicos</text>
-		<text lang="fr">Sozialgesetzbuch X (Livre X du Code allemand de la sécurité sociale), par ex. pour la protection des données médicales</text>
-		<text lang="it">Sozialgesetzbuch X (tomo X del codice tedesco di previdenza sociale), es. per i dati medici</text>
+		<text lang="fr">Loi allemande sur la sécurité sociale X (Sozialgesetzbuch X), par ex. pour la protection des données médicales</text>
+		<text lang="it">Sozialgesetzbuch X (legge X sulla sicurezza sociale), es. per i dati medici</text>
 		<additional_input>False</additional_input>
 	</option>
 	<option dc:uri="https://rdmorganiser.github.io/terms/options/data_protection_laws/39">
@@ -2010,11 +1863,10 @@
 		<dc:comment/>
 		<optionset dc:uri="https://rdmorganiser.github.io/terms/options/data_protection_laws"/>
 		<order>19</order>
-		<text lang="en">Bundesstatistikgesetz (German Federal Statistics Act), e.g. for census data</text>
+		<text lang="en">Bundesstatistikgesetz (Federal Statistics Act), e.g. for census data</text>
 		<text lang="de">Bundesstatistikgesetz (z.B. für Zensusdaten)</text>
-		<text lang="es">Bundesstatistikgesetz (Ley Federal alemana de Estadística), por ejemplo, para los datos del censo</text>
-		<text lang="fr">Bundesstatistikgesetz (Loi fédérale allemande sur la statistique), par ex. pour la protection des données de recensement</text>
-		<text lang="it">Bundesstatistikgesetz (legge federale tedesca sulla statistica), es. per i dati di censimento</text>
+		<text lang="fr">Loi allemande sur la statistique (Bundesstatistikgesetz), par ex. pour la protection des données de recensement</text>
+		<text lang="it">Bundesstatistikgesetz (legge federale sulla statistica), es. per i dati di censimento</text>
 		<additional_input>False</additional_input>
 	</option>
 	<option dc:uri="https://rdmorganiser.github.io/terms/options/data_protection_laws/155">
@@ -2026,7 +1878,6 @@
 		<order>100</order>
 		<text lang="en">Other</text>
 		<text lang="de">Sonstiges</text>
-		<text lang="es">Otro</text>
 		<text lang="fr">Autre</text>
 		<text lang="it">Altro</text>
 		<additional_input>True</additional_input>
@@ -2047,7 +1898,6 @@
 		<order>1</order>
 		<text lang="en">Yes, during the collection</text>
 		<text lang="de">Ja, während der Erhebung</text>
-		<text lang="es">Sí, durante la recogida</text>
 		<text lang="fr">Oui, lors de la collecte</text>
 		<text lang="it">Sì, durante la raccolta</text>
 		<additional_input>False</additional_input>
@@ -2061,7 +1911,6 @@
 		<order>2</order>
 		<text lang="en">Yes, before / at the beginning of the data analysis</text>
 		<text lang="de">Ja, vor / zu Beginn der Datenanalyse</text>
-		<text lang="es">Sí, antes / al comienzo del análisis de datos</text>
 		<text lang="fr">Oui, avant ou au début de l'analyse des données</text>
 		<text lang="it">Sì, prima / all'inizio dell'analisi dati</text>
 		<additional_input>False</additional_input>
@@ -2075,7 +1924,6 @@
 		<order>3</order>
 		<text lang="en">Yes, after the data analysis / before publication</text>
 		<text lang="de">Ja, nach der Datenanalyse / vor der Publikation</text>
-		<text lang="es">Sí, después del análisis de los datos / antes de la publicación</text>
 		<text lang="fr">Oui, après l'analyse des données ou avant la publication</text>
 		<text lang="it">Sì, dopo l'analisi dei dati / prima della pubblicazione</text>
 		<additional_input>False</additional_input>
@@ -2089,7 +1937,6 @@
 		<order>4</order>
 		<text lang="en">No</text>
 		<text lang="de">Nein</text>
-		<text lang="es">No</text>
 		<text lang="fr">Non</text>
 		<text lang="it">No</text>
 		<additional_input>False</additional_input>
@@ -2110,7 +1957,6 @@
 		<order>1</order>
 		<text lang="en">Yes, by several persons at various institutions</text>
 		<text lang="de">Ja, von mehreren Personen an verschiedenen Institutionen</text>
-		<text lang="es">Sí, por varias personas en varias instituciones</text>
 		<text lang="fr">Oui, par plusieurs personnes dans divers établissements</text>
 		<text lang="it">Sì, da parte di più persone in diverse istituzioni</text>
 		<additional_input>False</additional_input>
@@ -2124,7 +1970,6 @@
 		<order>2</order>
 		<text lang="en">Yes, by multiple persons of the same workgroup at the same institution</text>
 		<text lang="de">Ja, von mehreren Personen derselben Arbeitsgruppe an derselben Institution</text>
-		<text lang="es">Sí, por varias personas del mismo grupo de trabajo en la misma institución</text>
 		<text lang="fr">Oui, par plusieurs personnes du même groupe de travail dans la même institution</text>
 		<text lang="it">Sì, da parte di più persone dello stesso gruppo di lavoro nella stessa istituzione</text>
 		<additional_input>False</additional_input>
@@ -2138,7 +1983,6 @@
 		<order>3</order>
 		<text lang="en">No</text>
 		<text lang="de">Nein</text>
-		<text lang="es">No</text>
 		<text lang="fr">Non</text>
 		<text lang="it">No</text>
 		<additional_input>False</additional_input>
@@ -2159,7 +2003,6 @@
 		<order>1</order>
 		<text lang="en">work of literature, scholarship or the arts</text>
 		<text lang="de">Werk der Literatur, Wissenschaft oder Kunst</text>
-		<text lang="es">obra literaria, académica o artística</text>
 		<text lang="fr">œuvre littéraire, universitaire ou artistique</text>
 		<text lang="it">opera letteraria, accademica o artistica</text>
 		<additional_input>False</additional_input>
@@ -2173,7 +2016,6 @@
 		<order>2</order>
 		<text lang="en">translation or other edition of a work</text>
 		<text lang="de">Übersetzung oder andere Bearbeitung eines Werkes</text>
-		<text lang="es">traducción u otra edición de una obra</text>
 		<text lang="fr">traduction ou autre édition d'une œuvre</text>
 		<text lang="it">traduzione o riedizione di un'opera</text>
 		<additional_input>False</additional_input>
@@ -2187,7 +2029,6 @@
 		<order>3</order>
 		<text lang="en">collected edition or database work</text>
 		<text lang="de">Sammelwerk oder Datenbankwerk</text>
-		<text lang="es">edición recopilada o trabajo de base de datos</text>
 		<text lang="fr">édition collectée ou travail de base de données</text>
 		<text lang="it">raccolta o banca dati</text>
 		<additional_input>False</additional_input>
@@ -2201,7 +2042,6 @@
 		<order>6</order>
 		<text lang="en">Other</text>
 		<text lang="de">Andere</text>
-		<text lang="es">Otros</text>
 		<text lang="fr">Autres</text>
 		<text lang="it">Altri</text>
 		<additional_input>True</additional_input>
@@ -2215,7 +2055,6 @@
 		<order>7</order>
 		<text lang="en">No</text>
 		<text lang="de">Nein</text>
-		<text lang="es">No</text>
 		<text lang="fr">Non</text>
 		<text lang="it">No</text>
 		<additional_input>False</additional_input>
@@ -2236,7 +2075,6 @@
 		<order>1</order>
 		<text lang="en">The dataset adheres to standardised formats</text>
 		<text lang="de">Für den Datensatz werden standardisierte Formate genutzt</text>
-		<text lang="es">El conjunto de datos se adhiere a formatos estandarizados</text>
 		<text lang="fr">Le jeu de données adhère à des formats standardisés</text>
 		<text lang="it">La raccolta di dati aderisce a formati standard</text>
 		<additional_input>True</additional_input>
@@ -2250,7 +2088,6 @@
 		<order>2</order>
 		<text lang="en">The dataset is usable with available (open) software applications or software applications that are established and widely used in the respective community</text>
 		<text lang="de">Der Datensatz ist mit verfügbarer (offener) Software bzw. mit in der jeweiligen Community etablierter und vielgenutzter Software nutzbar</text>
-		<text lang="es">El conjunto de datos se puede utilizar con aplicaciones de software disponibles (abiertas) o con aplicaciones de software establecidas y ampliamente utilizadas en la comunidad respectiva</text>
 		<text lang="fr">Le jeu de données est utilisable avec des logiciels accessibles (de licence ouvertes) ou qui sont répendues dans la communauté en question</text>
 		<text lang="it">La raccolta di dati si lascia aprire con programmi liberamente disponibili o per lo meno di largo utilizzo nella comunità scientifica di diferimento</text>
 		<additional_input>True</additional_input>
@@ -2264,7 +2101,6 @@
 		<order>3</order>
 		<text lang="en">The dataset can easily be re-combined with different datasets from different origins</text>
 		<text lang="de">Der Datensatz kann ohne großen Aufwand mit verschiedenen anderen Datensätzen aus unterschiedlichen Quellen rekombiniert werden</text>
-		<text lang="es">El conjunto de datos puede recombinarse fácilmente con otros conjuntos de datos de diferentes orígenes</text>
 		<text lang="fr">Le jeu de données peut facilement être re-combiné avec différents ensembles de données d'origines différentes</text>
 		<text lang="it">La raccolta di dati si lascia ricombinare con una larga varietà di dati di diversa provenienza</text>
 		<additional_input>True</additional_input>
@@ -2278,7 +2114,6 @@
 		<order>4</order>
 		<text lang="en">Other aspects in terms of interoperability</text>
 		<text lang="de">Weitere für die Interoperabilität wichtige Aspekte</text>
-		<text lang="es">Otros aspectos en materia de interoperabilidad</text>
 		<text lang="fr">Autres aspects sur l'interopérabilité</text>
 		<text lang="it">Altri aspetti dell’interoperatività</text>
 		<additional_input>True</additional_input>
@@ -2299,7 +2134,6 @@
 		<order>0</order>
 		<text lang="en">The dataset will be published under the followig license:</text>
 		<text lang="de">Der Datensatz wird unter folgender Lizenz veröffentlicht:</text>
-		<text lang="es">El conjunto de datos se publicará bajo la siguiente licencia:</text>
 		<text lang="fr">Le jeu de données sera publié sous la licence suivante&#8239;:</text>
 		<text lang="it">La raccolta dati verrà pubblicata con la seguente licenza:</text>
 		<additional_input>True</additional_input>
@@ -2313,7 +2147,6 @@
 		<order>1</order>
 		<text lang="en">Yet to be determined</text>
 		<text lang="de">Noch zu klären</text>
-		<text lang="es">Aún por determinar</text>
 		<text lang="fr">À déterminer</text>
 		<text lang="it">Da chiarire</text>
 		<additional_input>False</additional_input>
@@ -2329,84 +2162,78 @@
 		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
 		<key>71</key>
 		<path>dataset_license_types/71</path>
-		<dc:comment>https://creativecommons.org/licenses/by/4.0/legalcode</dc:comment>
+		<dc:comment/>
 		<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_license_types"/>
 		<order>1</order>
-		<text lang="en">Creative Commons Attribution (CC-BY)</text>
-		<text lang="de">Creative Commons Namensnennung (CC-BY)</text>
-		<text lang="es">Creative Commons Atribución/Reconocimiento (CC-BY)</text>
-		<text lang="fr">Creative Commons Attribution (CC-BY)</text>
-		<text lang="it">Creative Commons Attribuzione (CC-BY)</text>
+		<text lang="en">&lt;a href=&quot;https://creativecommons.org/licenses/by/4.0/legalcode.en&quot; target=&quot;_blank&quot;&gt;Creative Commons Attribution (CC-BY)&lt;/a&gt;</text>
+		<text lang="de">&lt;a href=&quot;https://creativecommons.org/licenses/by/4.0/legalcode.de&quot; target=&quot;_blank&quot;&gt;Creative Commons Namensnennung (CC-BY)&lt;/a&gt;</text>
+		<text lang="fr">&lt;a href=&quot;https://creativecommons.org/licenses/by/4.0/legalcode.fr&quot; target=&quot;_blank&quot;&gt;Creative Commons Attribution (CC-BY)&lt;/a&gt;</text>
+		<text lang="it">&lt;a href=&quot;https://creativecommons.org/licenses/by/4.0/legalcode.it&quot; target=&quot;_blank&quot;&gt;Creative Commons Attribuzione (CC-BY)&lt;/a&gt;</text>
 		<additional_input>False</additional_input>
 	</option>
 	<option dc:uri="https://rdmorganiser.github.io/terms/options/dataset_license_types/73">
 		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
 		<key>73</key>
 		<path>dataset_license_types/73</path>
-		<dc:comment>https://creativecommons.org/licenses/by-nc/4.0/legalcode</dc:comment>
+		<dc:comment/>
 		<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_license_types"/>
 		<order>2</order>
-		<text lang="en">Creative Commons Attribution-NonCommercial (CC-BY-NC)</text>
-		<text lang="de">Creative Commons Namensnennung-Nicht kommerziell (CC-BY-NC)</text>
-		<text lang="es">Creative Commons Atribución/Reconocimiento-NoComercial (CC-BY-NC)</text>
-		<text lang="fr">Creative Commons Attribution - Utilisation non commerciale (CC-BY-NC)</text>
-		<text lang="it">Creative Commons Attribuzione-NonCommerciale (CC-BY-NC)</text>
+		<text lang="en">&lt;a href=&quot;https://creativecommons.org/licenses/by-nc/4.0/legalcode.en&quot; target=&quot;_blank&quot;&gt;Creative Commons Attribution-NonCommercial (CC-BY-NC)&lt;/a&gt;</text>
+		<text lang="de">&lt;a href=&quot;https://creativecommons.org/licenses/by-nc/4.0/legalcode.de&quot; target=&quot;_blank&quot;&gt;Creative Commons Namensnennung-Nicht kommerziell (CC-BY-NC)&lt;/a&gt;</text>
+		<text lang="fr">&lt;a href=&quot;https://creativecommons.org/licenses/by-nc/4.0/legalcode.fr&quot; target=&quot;_blank&quot;&gt;Creative Commons Attribution - Utilisation non commerciale (CC-BY-NC)&lt;/a&gt;</text>
+		<text lang="it">&lt;a href=&quot;https://creativecommons.org/licenses/by-nc/4.0/legalcode.it&quot; target=&quot;_blank&quot;&gt;Creative Commons Attribuzione-NonCommerciale (CC-BY-NC)&lt;/a&gt;</text>
 		<additional_input>False</additional_input>
 	</option>
 	<option dc:uri="https://rdmorganiser.github.io/terms/options/dataset_license_types/74">
 		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
 		<key>74</key>
 		<path>dataset_license_types/74</path>
-		<dc:comment>https://creativecommons.org/licenses/by-nd/4.0/legalcode</dc:comment>
+		<dc:comment/>
 		<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_license_types"/>
 		<order>3</order>
-		<text lang="en">Creative Commons Attribution-NoDerivatives (CC-BY-ND)</text>
-		<text lang="de">Creative Commons Namensnennung-Keine Bearbeitungen (CC-BY-ND)</text>
-		<text lang="es">Creative Commons Atribución/Reconocimiento-SinDerivados (CC-BY-ND)</text>
-		<text lang="fr">Creative Commons Attribution - Pas d'Œuvre dérivée (CC-BY-ND)</text>
-		<text lang="it">Creative Commons Attribuzione-NonOpereDerivate (CC-BY-ND)</text>
+		<text lang="en">&lt;a href=&quot;https://creativecommons.org/licenses/by-nd/4.0/legalcode.en&quot; target=&quot;_blank&quot;&gt;Creative Commons Attribution-NoDerivatives (CC-BY-ND)&lt;/a&gt;</text>
+		<text lang="de">&lt;a href=&quot;https://creativecommons.org/licenses/by-nd/4.0/legalcode.de&quot; target=&quot;_blank&quot;&gt;Creative Commons Namensnennung-Keine Bearbeitungen (CC-BY-ND)&lt;/a&gt;</text>
+		<text lang="fr">&lt;a href=&quot;https://creativecommons.org/licenses/by-nd/4.0/legalcode.fr&quot; target=&quot;_blank&quot;&gt;Creative Commons Attribution - Pas d'Œuvre dérivée (CC-BY-ND)&lt;/a&gt;</text>
+		<text lang="it">&lt;a href=&quot;https://creativecommons.org/licenses/by-nd/4.0/legalcode.it&quot; target=&quot;_blank&quot;&gt;Creative Commons Attribuzione-NonOpereDerivate (CC-BY-ND)&lt;/a&gt;</text>
 		<additional_input>False</additional_input>
 	</option>
 	<option dc:uri="https://rdmorganiser.github.io/terms/options/dataset_license_types/75">
 		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
 		<key>75</key>
 		<path>dataset_license_types/75</path>
-		<dc:comment>https://creativecommons.org/licenses/by-sa/4.0/legalcode</dc:comment>
+		<dc:comment/>
 		<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_license_types"/>
 		<order>4</order>
-		<text lang="en">Creative Commons Attribution-ShareAlike (CC-BY-SA)</text>
-		<text lang="de">Creative Commons Namensnennung-ShareAlike (CC-BY-SA)</text>
-		<text lang="es">Creative Commons Atribución/Reconocimiento-CompartirIgual (CC-BY-SA)</text>
-		<text lang="fr">Creative Commons Attribution - Partage dans les mêmes conditions (CC-BY-SA)</text>
-		<text lang="it">Creative Commons Attribuzione-CondividiAlloStessoModo (CC-BY-SA)</text>
+		<text lang="en">&lt;a href=&quot;https://creativecommons.org/licenses/by-sa/4.0/legalcode.en&quot; target=&quot;_blank&quot;&gt;Creative Commons Attribution-ShareAlike (CC-BY-SA)&lt;/a&gt;</text>
+		<text lang="de">&lt;a href=&quot;https://creativecommons.org/licenses/by-sa/4.0/legalcode.de&quot; target=&quot;_blank&quot;&gt;Creative Commons Namensnennung-ShareAlike (CC-BY-SA)&lt;/a&gt;</text>
+		<text lang="fr">&lt;a href=&quot;https://creativecommons.org/licenses/by-sa/4.0/legalcode.fr&quot; target=&quot;_blank&quot;&gt;Creative Commons Attribution - Partage dans les mêmes conditions (CC-BY-SA)&lt;/a&gt;</text>
+		<text lang="it">&lt;a href=&quot;https://creativecommons.org/licenses/by-sa/4.0/legalcode.it&quot; target=&quot;_blank&quot;&gt;Creative Commons Attribuzione-CondividiAlloStessoModo (CC-BY-SA)&lt;/a&gt;</text>
 		<additional_input>False</additional_input>
 	</option>
 	<option dc:uri="https://rdmorganiser.github.io/terms/options/dataset_license_types/ODC-By">
 		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
 		<key>ODC-By</key>
 		<path>dataset_license_types/ODC-By</path>
-		<dc:comment>https://opendatacommons.org/licenses/by/1-0/</dc:comment>
+		<dc:comment/>
 		<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_license_types"/>
 		<order>5</order>
-		<text lang="en">Open Data Commons Attribution</text>
-		<text lang="de">Open Data Commons Attribution</text>
-		<text lang="es">Open Data Commons Attribution</text>
-		<text lang="fr">Open Data Commons Attribution</text>
-		<text lang="it">Open Data Commons Attribution</text>
+		<text lang="en">&lt;a href=&quot;https://opendatacommons.org/licenses/by/1-0/&quot; target=&quot;_blank&quot;&gt;Open Data Commons Attribution&lt;/a&gt;</text>
+		<text lang="de">&lt;a href=&quot;https://opendatacommons.org/licenses/by/1-0/&quot; target=&quot;_blank&quot;&gt;Open Data Commons Attribution&lt;/a&gt;</text>
+		<text lang="fr">&lt;a href=&quot;https://opendatacommons.org/licenses/by/1-0/&quot; target=&quot;_blank&quot;&gt;Open Data Commons Attribution&lt;/a&gt;</text>
+		<text lang="it">&lt;a href=&quot;https://opendatacommons.org/licenses/by/1-0/&quot; target=&quot;_blank&quot;&gt;Open Data Commons Attribution&lt;/a&gt;</text>
 		<additional_input>True</additional_input>
 	</option>
-	<option dc:uri="https://rdmorganiser.github.io/terms/options/dataset_license_types/ODbl">
+		<option dc:uri="https://rdmorganiser.github.io/terms/options/dataset_license_types/ODbl">
 		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
 		<key>ODbl</key>
 		<path>dataset_license_types/ODbl</path>
-		<dc:comment>https://opendatacommons.org/licenses/odbl/1-0/</dc:comment>
+		<dc:comment/>
 		<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_license_types"/>
 		<order>6</order>
-		<text lang="en">Open Data Commons Open Database</text>
-		<text lang="de">Open Data Commons Open Database</text>
-		<text lang="es">Open Data Commons Open Database</text>
-		<text lang="fr">Open Data Commons Open Database</text>
-		<text lang="it">Open Data Commons Open Database</text>
+		<text lang="en">&lt;a href=&quot;https://opendatacommons.org/licenses/odbl/1-0/&quot; target=&quot;_blank&quot;&gt;Open Data Commons Open Database&lt;/a&gt;</text>
+		<text lang="de">&lt;a href=&quot;https://opendatacommons.org/licenses/odbl/1-0/&quot; target=&quot;_blank&quot;&gt;Open Data Commons Open Database&lt;/a&gt;</text>
+		<text lang="fr">&lt;a href=&quot;https://opendatacommons.org/licenses/odbl/1-0/&quot; target=&quot;_blank&quot;&gt;Open Data Commons Open Database&lt;/a&gt;</text>
+		<text lang="it">&lt;a href=&quot;https://opendatacommons.org/licenses/odbl/1-0/&quot; target=&quot;_blank&quot;&gt;Open Data Commons Open Database&lt;/a&gt;</text>
 		<additional_input>True</additional_input>
 	</option>
 	<option dc:uri="https://rdmorganiser.github.io/terms/options/dataset_license_types/cc0">
@@ -2416,11 +2243,10 @@
 		<dc:comment/>
 		<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_license_types"/>
 		<order>7</order>
-		<text lang="en">Public domain (CC0)</text>
-		<text lang="de">Gemeinfrei (CC0)</text>
-		<text lang="es">Dominio público (CC0)</text>
-		<text lang="fr">Domaine public (CC0)</text>
-		<text lang="it">Pubblico dominio (CC0)</text>
+		<text lang="en">&lt;a href=&quot;https://creativecommons.org/publicdomain/zero/1.0/deed.en&quot; target=&quot;_blank&quot;&gt;Public domain (CC0)&lt;/a&gt;</text>
+		<text lang="de">&lt;a href=&quot;https://creativecommons.org/publicdomain/zero/1.0/deed.de&quot; target=&quot;_blank&quot;&gt;Gemeinfrei (CC0)&lt;/a&gt;</text>
+		<text lang="fr">&lt;a href=&quot;https://creativecommons.org/publicdomain/zero/1.0/deed.fr&quot; target=&quot;_blank&quot;&gt;Domaine public (CC0)&lt;/a&gt;</text>
+		<text lang="it">&lt;a href=&quot;https://creativecommons.org/publicdomain/zero/1.0/deed.it&quot; target=&quot;_blank&quot;&gt;Pubblico dominio (CC0)&lt;/a&gt;</text>
 		<additional_input>False</additional_input>
 	</option>
 	<option dc:uri="https://rdmorganiser.github.io/terms/options/dataset_license_types/233">
@@ -2432,7 +2258,6 @@
 		<order>8</order>
 		<text lang="en">Other, or exact designation - if known</text>
 		<text lang="de">Andere, bzw. genaue Bezeichnung - falls bekannt</text>
-		<text lang="es">Otros</text>
 		<text lang="fr">Autre, ou dénomination exacte - si connue</text>
 		<text lang="it">Altra, o denominazione esatta - qualora nota</text>
 		<additional_input>True</additional_input>
@@ -2453,7 +2278,6 @@
 		<order>1</order>
 		<text lang="en">Created</text>
 		<text lang="de">Erzeugt</text>
-		<text lang="es">Creado</text>
 		<text lang="fr">Créé</text>
 		<text lang="it">Creato</text>
 		<additional_input>False</additional_input>
@@ -2467,7 +2291,6 @@
 		<order>2</order>
 		<text lang="en">Re-used</text>
 		<text lang="de">Nachgenutzt</text>
-		<text lang="es">Reutilizado</text>
 		<text lang="fr">Réutilisé</text>
 		<text lang="it">Riutilizzato</text>
 		<additional_input>False</additional_input>
@@ -2481,7 +2304,6 @@
 		<order>3</order>
 		<text lang="en">Both (combination of re-used and newly generated data)</text>
 		<text lang="de">Beides (Kombination aus nachgenutzten und neu erzeugten Daten)</text>
-		<text lang="es">Ambos (combinación de datos reutilizados y generados recientemente)</text>
 		<text lang="fr">Les deux (combination de données créées et réutilisées)</text>
 		<text lang="it">Tutti e due (combinazione di dati creati e riutilizzati)</text>
 		<additional_input>False</additional_input>
@@ -2502,7 +2324,6 @@
 		<order>1</order>
 		<text lang="en">patent</text>
 		<text lang="de">Patent</text>
-		<text lang="es">Patente</text>
 		<text lang="fr">brevet</text>
 		<text lang="it">Brevetto</text>
 		<additional_input>False</additional_input>
@@ -2516,7 +2337,6 @@
 		<order>2</order>
 		<text lang="en">utility model</text>
 		<text lang="de">Gebrauchsmuster</text>
-		<text lang="es">modelo de utilidad</text>
 		<text lang="fr">modèle d'utilité</text>
 		<text lang="it">modello di utilità</text>
 		<additional_input>False</additional_input>
@@ -2530,7 +2350,6 @@
 		<order>3</order>
 		<text lang="en">trademark</text>
 		<text lang="de">Marke</text>
-		<text lang="es">marca registrada</text>
 		<text lang="fr">marque déposée</text>
 		<text lang="it">Marchio depositato</text>
 		<additional_input>False</additional_input>
@@ -2544,7 +2363,6 @@
 		<order>4</order>
 		<text lang="en">plant variety rights protection</text>
 		<text lang="de">Sortenschutz</text>
-		<text lang="es">protección de las obtenciones vegetales</text>
 		<text lang="fr">protection des droits sur la variété végétale</text>
 		<text lang="it">protezione dei diritti su varietà vegetali</text>
 		<additional_input>False</additional_input>
@@ -2558,7 +2376,6 @@
 		<order>5</order>
 		<text lang="en">integrated circuit layout design protection</text>
 		<text lang="de">Halbleiterschutz</text>
-		<text lang="es">protección del diseño de circuitos integrados</text>
 		<text lang="fr">protection de la conception de la disposition des circuits intégrés</text>
 		<text lang="it">protezione del design di circuiti integrati</text>
 		<additional_input>False</additional_input>
@@ -2572,7 +2389,6 @@
 		<order>6</order>
 		<text lang="en">geographical indication</text>
 		<text lang="de">geographische Herkunftsangabe</text>
-		<text lang="es">indicación geográfica</text>
 		<text lang="fr">indication géographique</text>
 		<text lang="it">indicazione geografica di origine</text>
 		<additional_input>False</additional_input>
@@ -2586,7 +2402,6 @@
 		<order>7</order>
 		<text lang="en">registered design</text>
 		<text lang="de">eingetragenes Design</text>
-		<text lang="es">diseño registrado</text>
 		<text lang="fr">conception déposé</text>
 		<text lang="it">marchio depositato</text>
 		<additional_input>False</additional_input>
@@ -2600,7 +2415,6 @@
 		<order>10</order>
 		<text lang="en">Other</text>
 		<text lang="de">Andere</text>
-		<text lang="es">Otros</text>
 		<text lang="fr">Autres</text>
 		<text lang="it">Altri</text>
 		<additional_input>True</additional_input>
@@ -2614,7 +2428,6 @@
 		<order>11</order>
 		<text lang="en">No</text>
 		<text lang="de">Nein</text>
-		<text lang="es">No</text>
 		<text lang="fr">Non</text>
 		<text lang="it">No</text>
 		<additional_input>False</additional_input>
@@ -2635,7 +2448,6 @@
 		<order>0</order>
 		<text lang="en">yes, with little effort</text>
 		<text lang="de">ja, mit geringem Aufwand</text>
-		<text lang="es">sí, con poco esfuerzo</text>
 		<text lang="fr">oui, avec peu d'effort</text>
 		<text lang="it">sì, con poco sforzo</text>
 		<additional_input>False</additional_input>
@@ -2649,7 +2461,6 @@
 		<order>1</order>
 		<text lang="en">yes, with moderate, but reasonable effort</text>
 		<text lang="de">ja, mit mäßigem, aber vertretbarem Auswand</text>
-		<text lang="es">sí, con un esfuerzo moderado, pero razonable</text>
 		<text lang="fr">oui, avec un effort modéré mais raisonnable</text>
 		<text lang="it">sì, con uno sforzo moderato ma accettabile</text>
 		<additional_input>False</additional_input>
@@ -2663,7 +2474,6 @@
 		<order>2</order>
 		<text lang="en">no or only with disproportionate cost or effort</text>
 		<text lang="de">nein bzw. nur mit unverhältnismäßig großem Aufwand</text>
-		<text lang="es">no o sólo con un coste o esfuerzo desproporcionado</text>
 		<text lang="fr">non ou seulement avec un coût ou un effort disproportionné</text>
 		<text lang="it">no oppure con uno sforzo sproporzionato</text>
 		<additional_input>False</additional_input>
@@ -2677,7 +2487,6 @@
 		<order>3</order>
 		<text lang="en">no, the data is not reproducible per se</text>
 		<text lang="de">nein, die Daten sind per se nicht reproduzierbar</text>
-		<text lang="es">no, los datos no son reproducibles per se</text>
 		<text lang="fr">non, les données ne sont pas reproductibles en soi</text>
 		<text lang="it">no, i dati sono intrinsecamente non riproducibili</text>
 		<additional_input>False</additional_input>
@@ -2698,7 +2507,6 @@
 		<order>4</order>
 		<text lang="en">Yes, internally with everyone, as long as they don't pass on the data</text>
 		<text lang="de">Ja, intern mit allen, solange sie die Daten nicht veröffentlichen oder nach außen weitergeben</text>
-		<text lang="es">Sí, internamente con todos, siempre que no pasen los datos</text>
 		<text lang="fr">Oui, en interne avec tout le monde, tant qu'ils ne transmettent pas les données</text>
 		<text lang="it">Sì, internamente con tutti, a condizione che i dati non vengano diffusi al pubblico</text>
 		<additional_input>False</additional_input>
@@ -2712,7 +2520,6 @@
 		<order>3</order>
 		<text lang="en">Yes, externally limited with individual approval</text>
 		<text lang="de">Ja, extern in begrenztem Umfang mit individueller Freigabe</text>
-		<text lang="es">Sí, limitado externamente con aprobación individual</text>
 		<text lang="fr">Oui, limité en externe avec approbation individuelle</text>
 		<text lang="it">Sì, esternamente in una cerchia ristretta con approvazione individuale</text>
 		<additional_input>False</additional_input>
@@ -2726,7 +2533,6 @@
 		<order>1</order>
 		<text lang="en">Yes, externally for everyone</text>
 		<text lang="de">Ja, extern für alle</text>
-		<text lang="es">Sí, externamente para todos</text>
 		<text lang="fr">Oui, en externe pour tout le monde</text>
 		<text lang="it">Sì, esternamente per tutti</text>
 		<additional_input>False</additional_input>
@@ -2740,7 +2546,6 @@
 		<order>4</order>
 		<text lang="en">No</text>
 		<text lang="de">Nein</text>
-		<text lang="es">No</text>
 		<text lang="fr">Non</text>
 		<text lang="it">No</text>
 		<additional_input>False</additional_input>
@@ -2761,7 +2566,6 @@
 		<order>1</order>
 		<text lang="en">less than 1 GB</text>
 		<text lang="de">weniger als ein GB</text>
-		<text lang="es">menos de 1 GB</text>
 		<text lang="fr">moins de 1 Go</text>
 		<text lang="it">meno di 1 GB</text>
 		<additional_input>False</additional_input>
@@ -2775,7 +2579,6 @@
 		<order>1</order>
 		<text lang="en">between 1 GB and 1 TB</text>
 		<text lang="de">zwischen 1 GB und 1 TB</text>
-		<text lang="es">entre 1 GB y 1 TB</text>
 		<text lang="fr">entre 1 Go et 1 To</text>
 		<text lang="it">tra 1 GB e 1 TB</text>
 		<additional_input>False</additional_input>
@@ -2789,7 +2592,6 @@
 		<order>2</order>
 		<text lang="en">between 1 TB and 100 TB</text>
 		<text lang="de">zwischen 1 TB und 100 TB</text>
-		<text lang="es">entre 1 TB y 100 TB</text>
 		<text lang="fr">entre 1 To et 100 To</text>
 		<text lang="it">tra 1 TB e 100 TB</text>
 		<additional_input>False</additional_input>
@@ -2803,7 +2605,6 @@
 		<order>3</order>
 		<text lang="en">more than 100 TB</text>
 		<text lang="de">mehr als 100 TB</text>
-		<text lang="es">más de 100 TB</text>
 		<text lang="fr">plus que 100 To</text>
 		<text lang="it">più di 100 TB</text>
 		<additional_input>False</additional_input>
@@ -2817,7 +2618,6 @@
 		<order>4</order>
 		<text lang="en">exact size</text>
 		<text lang="de">genau</text>
-		<text lang="es">tamaño exacto</text>
 		<text lang="fr">taille exacte</text>
 		<text lang="it">dimensione esatta</text>
 		<additional_input>True</additional_input>
@@ -2838,7 +2638,6 @@
 		<order>1</order>
 		<text lang="en">Simple copying</text>
 		<text lang="de">Einfaches Kopieren</text>
-		<text lang="es">Copia simple</text>
 		<text lang="fr">Copie simple</text>
 		<text lang="it">Copia semplice</text>
 		<additional_input>False</additional_input>
@@ -2852,7 +2651,6 @@
 		<order>2</order>
 		<text lang="en">Version control system</text>
 		<text lang="de">Versionskontrollsystem</text>
-		<text lang="es">Sistema de control de versiones</text>
 		<text lang="fr">Système de contrôle de version</text>
 		<text lang="it">Sistema di controllo di versione</text>
 		<additional_input>True</additional_input>
@@ -2866,7 +2664,6 @@
 		<order>3</order>
 		<text lang="en">Other</text>
 		<text lang="de">Sonstiges</text>
-		<text lang="es">Otro</text>
 		<text lang="fr">Autre</text>
 		<text lang="it">Altro</text>
 		<additional_input>True</additional_input>
@@ -2880,7 +2677,6 @@
 		<order>4</order>
 		<text lang="en">Not yet decided</text>
 		<text lang="de">Noch nicht entschieden</text>
-		<text lang="es">Aún no se ha decidido</text>
 		<text lang="fr">Pas encore décidé</text>
 		<text lang="it">Non ancora deciso</text>
 		<additional_input>False</additional_input>
@@ -2901,7 +2697,6 @@
 		<order>0</order>
 		<text lang="en">Yes, reviewed and approved by the following committee</text>
 		<text lang="de">Ja, positiv begutachtet von folgender Kommission</text>
-		<text lang="es">Sí, revisado y aprobado por el siguiente comité</text>
 		<text lang="fr">Oui, examiné et approuvé par le comité suivant</text>
 		<text lang="it">Sì, esaminato e approvato dal seguente comitato</text>
 		<additional_input>True</additional_input>
@@ -2915,7 +2710,6 @@
 		<order>1</order>
 		<text lang="en">Yes, approved under obligations which will be complied in the following way</text>
 		<text lang="de">Ja, begutachtet mit Auflagen, die folgendermaßen erfüllt werden</text>
-		<text lang="es">Sí, aprobado bajo obligaciones que se cumplirán de la siguiente manera</text>
 		<text lang="fr">Oui, approuvé en vertu d'obligations qui seront respectées de la manière suivante</text>
 		<text lang="it">Sì, approvato con alcune restrizioni, che dovranno essere implementate come segue</text>
 		<additional_input>True</additional_input>
@@ -2929,7 +2723,6 @@
 		<order>2</order>
 		<text lang="en">Not yet, but it is already in the review process</text>
 		<text lang="de">Noch nicht, es befindet sich aber bereits in Begutachtung</text>
-		<text lang="es">Todavía no, pero ya está en proceso de revisión</text>
 		<text lang="fr">Pas encore, mais il est déjà en cours d'examen</text>
 		<text lang="it">Non ancora, ma attualmente in corso d'esame</text>
 		<additional_input>False</additional_input>
@@ -2943,7 +2736,6 @@
 		<order>3</order>
 		<text lang="en">Not yet, it will be handed in for review by</text>
 		<text lang="de">Noch nicht, es wird zur Begutachtung eingereicht bis spätestens</text>
-		<text lang="es">Todavía no, se entregará para su revisión por</text>
 		<text lang="fr">Pas encore, il sera remis pour examen par</text>
 		<text lang="it">Non ancora, ma sarà sottoposto a esame entro</text>
 		<additional_input>True</additional_input>
@@ -2957,7 +2749,6 @@
 		<order>4</order>
 		<text lang="en">No, a review is not necessary, because</text>
 		<text lang="de">Nein, eine Begutachtung ist nicht notwendig, weil</text>
-		<text lang="es">No, no es necesaria una revisión, porque</text>
 		<text lang="fr">Non, un examen n'est pas nécessaire, car</text>
 		<text lang="it">No, una valutazione non è necessaria, perché</text>
 		<additional_input>True</additional_input>
@@ -2978,7 +2769,6 @@
 		<order>0</order>
 		<text lang="en">No</text>
 		<text lang="de">Nein</text>
-		<text lang="es">No</text>
 		<text lang="fr">Non</text>
 		<text lang="it">No</text>
 		<additional_input>False</additional_input>
@@ -2992,7 +2782,6 @@
 		<order>1</order>
 		<text lang="en">Yes. The permit has been received.</text>
 		<text lang="de">Ja. Die Genehmigung liegt bereits vor.</text>
-		<text lang="es">Sí. Se ha recibido el permiso.</text>
 		<text lang="fr">Oui. Le permis a été reçu.</text>
 		<text lang="it">Sì. L'autorizzazione è stata già ricevuta.</text>
 		<additional_input>False</additional_input>
@@ -3006,7 +2795,6 @@
 		<order>2</order>
 		<text lang="en">Yes. The permit has been applied for on</text>
 		<text lang="de">Ja. Die Genehmigung wurde beantragt am/im</text>
-		<text lang="es">Sí. El permiso se ha solicitado el</text>
 		<text lang="fr">Oui. Le permis a été demandé le</text>
 		<text lang="it">Sì. L'autorizzazione è stata richiesta il</text>
 		<additional_input>True</additional_input>
@@ -3020,7 +2808,6 @@
 		<order>3</order>
 		<text lang="en">Yes. The permit will be applied for by</text>
 		<text lang="de">Ja. Die Genehmigung wird beantragt bis spätestens</text>
-		<text lang="es">Sí. El permiso será solicitado por</text>
 		<text lang="fr">Oui. Le permis sera demandé par</text>
 		<text lang="it">Sì. L'autorizzazione verrà richiesta il</text>
 		<additional_input>True</additional_input>
@@ -3041,7 +2828,6 @@
 		<order>1</order>
 		<text lang="en">For analysis / use of the data within the project as well as for re-use</text>
 		<text lang="de">Zur Analyse/Nutzung der Daten im Rahmen des Projektes sowie zur Nachnutzung</text>
-		<text lang="es">Para el análisis/uso de los datos dentro del proyecto, así como para su reutilización</text>
 		<text lang="fr">Pour l'analyse / l'utilisation des données dans le projet ainsi que pour la réutilisation</text>
 		<text lang="it">Per l'analisi/utilizzo dei dati all'interno del progetto, come pure per il loro riutilizzo</text>
 		<additional_input>False</additional_input>
@@ -3055,7 +2841,6 @@
 		<order>2</order>
 		<text lang="en">Only for analysis / use of the data within the project</text>
 		<text lang="de">Nur zur Analyse/Nutzung der Daten im Rahmen des Projektes</text>
-		<text lang="es">Sólo para el análisis/uso de los datos dentro del proyecto</text>
 		<text lang="fr">Uniquement pour l'analyse / l'utilisation des données dans le projet</text>
 		<text lang="it">Esclusivamente per l'analisi/riutilizzo dei dati all'interno del progetto</text>
 		<additional_input>False</additional_input>
@@ -3069,7 +2854,6 @@
 		<order>3</order>
 		<text lang="en">For analysis / use of the data within the project as well as for long-term storage</text>
 		<text lang="de">Zur Analyse/Nutzung der Daten im Rahmen des Projektes sowie zur langfristigen Aufbewahrung</text>
-		<text lang="es">Para el análisis/uso de los datos dentro del proyecto, así como para su almacenamiento a largo plazo</text>
 		<text lang="fr">Pour l'analyse / l'utilisation des données dans le projet ainsi que pour leur conservation dans le long terme</text>
 		<text lang="it">Per l'analisi/utilizzo dei dati all'interno del progetto, come pure per la loro conservazione a lungo termine</text>
 		<additional_input>False</additional_input>
@@ -3083,7 +2867,6 @@
 		<order>4</order>
 		<text lang="en">The "informed consent" is not obtained</text>
 		<text lang="de">Es wird keine "informierte Einwilligung" eingeholt</text>
-		<text lang="es">El "consentimiento informado" no se obtiene</text>
 		<text lang="fr">Le « consentement éclairé » n'est pas obtenu</text>
 		<text lang="it">Il "consenso informato" non è stato richiesto</text>
 		<additional_input>False</additional_input>
@@ -3104,7 +2887,6 @@
 		<order>1</order>
 		<text lang="en">Infrastructure resources of the usual workplace equipment are sufficient.</text>
 		<text lang="de">Die üblichen Infrastrukturressourcen des Arbeitsplatzes reichen aus.</text>
-		<text lang="es">Los recursos de infraestructura del equipo habitual del lugar de trabajo son suficientes.</text>
 		<text lang="fr">Les ressources en infrastructure de l'équipement habituel sur le lieu de travail sont suffisantes.</text>
 		<text lang="it">Le infrastrutture ordinarie presenti sul luogo di lavoro sono sufficienti.</text>
 		<additional_input>False</additional_input>
@@ -3118,7 +2900,6 @@
 		<order>2</order>
 		<text lang="en">Fast read and write of data is required (high performance storage)</text>
 		<text lang="de">Schnelles Lesen und Schreiben von Daten wird benötigt (High-Performance-Speicher)</text>
-		<text lang="es">Se requiere una lectura y escritura rápida de los datos (almacenamiento de alto rendimiento)</text>
 		<text lang="fr">Les données nécessitent une lecture et une écriture rapide (mémoire haute performance)</text>
 		<text lang="it">È necessaria una lettura e scrittura rapida dei dati (memoria ad alta prestazione)</text>
 		<additional_input>False</additional_input>
@@ -3132,7 +2913,6 @@
 		<order>3</order>
 		<text lang="en">The following infrastructure resources are needed</text>
 		<text lang="de">Es werden folgende Infrastrukturressourcen benötigt</text>
-		<text lang="es">Se necesitan los siguientes recursos de infraestructura</text>
 		<text lang="fr">Les ressources d'infrastructure suivantes sont nécessaires</text>
 		<text lang="it">Le seguenti infrastrutture sono necessarie</text>
 		<additional_input>True</additional_input>
@@ -3153,7 +2933,6 @@
 		<order>1</order>
 		<text lang="en">Location</text>
 		<text lang="de">Ort</text>
-		<text lang="es">Ubicación</text>
 		<text lang="fr">Emplacement</text>
 		<text lang="it">Collocazione</text>
 		<additional_input>False</additional_input>
@@ -3167,7 +2946,6 @@
 		<order>2</order>
 		<text lang="en">Content</text>
 		<text lang="de">Inhalt</text>
-		<text lang="es">Contenido</text>
 		<text lang="fr">Contenu</text>
 		<text lang="it">Contenuto</text>
 		<additional_input>False</additional_input>
@@ -3181,7 +2959,6 @@
 		<order>3</order>
 		<text lang="en">Methodology</text>
 		<text lang="de">Methodik</text>
-		<text lang="es">Metodología</text>
 		<text lang="fr">Méthodologie</text>
 		<text lang="it">Metodo</text>
 		<additional_input>False</additional_input>
@@ -3195,7 +2972,6 @@
 		<order>4</order>
 		<text lang="en">Creation process</text>
 		<text lang="de">Erzeugungsprozess</text>
-		<text lang="es">Proceso de creación</text>
 		<text lang="fr">Processus de création</text>
 		<text lang="it">Processo di creazione</text>
 		<additional_input>False</additional_input>
@@ -3209,7 +2985,6 @@
 		<order>5</order>
 		<text lang="en">Technology</text>
 		<text lang="de">Technologie</text>
-		<text lang="es">Tecnología</text>
 		<text lang="fr">Technologie</text>
 		<text lang="it">Tecnologia</text>
 		<additional_input>False</additional_input>
@@ -3223,7 +2998,6 @@
 		<order>6</order>
 		<text lang="en">Documentation of the software necessary to use the data</text>
 		<text lang="de">Dokumentation der zur Nutzung notwendigen Software</text>
-		<text lang="es">Documentación del software necesario para utilizar los datos</text>
 		<text lang="fr">Documentation du logiciel nécessaire à l'utilisation des données</text>
 		<text lang="it">Documentazione dei programmi necessari all'utilizzo dei dati</text>
 		<additional_input>False</additional_input>
@@ -3237,7 +3011,6 @@
 		<order>7</order>
 		<text lang="en">Time</text>
 		<text lang="de">Zeit</text>
-		<text lang="es">Tiempo</text>
 		<text lang="fr">Temps</text>
 		<text lang="it">Tempo</text>
 		<additional_input>False</additional_input>
@@ -3251,7 +3024,6 @@
 		<order>8</order>
 		<text lang="en">Sources</text>
 		<text lang="de">Quellen</text>
-		<text lang="es">Fuentes</text>
 		<text lang="fr">Sources</text>
 		<text lang="it">Fonti</text>
 		<additional_input>False</additional_input>
@@ -3265,7 +3037,6 @@
 		<order>9</order>
 		<text lang="en">Agents</text>
 		<text lang="de">Akteure</text>
-		<text lang="es">Agentes</text>
 		<text lang="fr">Agents</text>
 		<text lang="it">Soggetti coinvolti</text>
 		<additional_input>False</additional_input>
@@ -3279,7 +3050,6 @@
 		<order>10</order>
 		<text lang="en">Identifiers</text>
 		<text lang="de">Identifikatoren</text>
-		<text lang="es">Identificadores</text>
 		<text lang="fr">Identifiants</text>
 		<text lang="it">Identificatori</text>
 		<additional_input>False</additional_input>
@@ -3293,7 +3063,6 @@
 		<order>11</order>
 		<text lang="en">Other</text>
 		<text lang="de">Andere</text>
-		<text lang="es">Otros</text>
 		<text lang="fr">Autres</text>
 		<text lang="it">Altri</text>
 		<additional_input>True</additional_input>
@@ -3314,7 +3083,6 @@
 		<order>1</order>
 		<text lang="en">Automatic check for completeness</text>
 		<text lang="de">Automatische Prüfung auf Vollständigkeit</text>
-		<text lang="es">Comprobación automática de la integridad</text>
 		<text lang="fr">Vérification automatique d'intégralité</text>
 		<text lang="it">Controllo automatico della completezza</text>
 		<additional_input>False</additional_input>
@@ -3328,7 +3096,6 @@
 		<order>2</order>
 		<text lang="en">Manual check for correctness</text>
 		<text lang="de">Manuelle Prüfung auf Korrektheit</text>
-		<text lang="es">Comprobación manual de la corrección</text>
 		<text lang="fr">Vérification manuelle d'exactitude</text>
 		<text lang="it">Controllo manuale dell'esattezza</text>
 		<additional_input>False</additional_input>
@@ -3342,7 +3109,6 @@
 		<order>3</order>
 		<text lang="en">Manual check for completeness</text>
 		<text lang="de">Manuelle Prüfung auf Vollständigkeit</text>
-		<text lang="es">Comprobación manual de la integridad</text>
 		<text lang="fr">Vérification manuelle d'integralité</text>
 		<text lang="it">Controllo manuale della completezza</text>
 		<additional_input>False</additional_input>
@@ -3356,7 +3122,6 @@
 		<order>4</order>
 		<text lang="en">Other</text>
 		<text lang="de">Sonstiges</text>
-		<text lang="es">Otro</text>
 		<text lang="fr">Autre</text>
 		<text lang="it">Altro</text>
 		<additional_input>True</additional_input>
@@ -3377,7 +3142,6 @@
 		<order>1</order>
 		<text lang="en">Discipline-specific standards, classifications etc. are used</text>
 		<text lang="de">Es werden disziplinspezifische Standards, Klassifikationen etc. genutzt</text>
-		<text lang="es">Se utilizan normas, clasificaciones, etc. específicas de cada disciplina</text>
 		<text lang="fr">Des normes spécifiques à la discipline, des classifications ou autres sont utilisées</text>
 		<text lang="it">Si utilizzano standard disciplinari, sistemi di classificazione ecc.</text>
 		<additional_input>True</additional_input>
@@ -3391,7 +3155,6 @@
 		<order>2</order>
 		<text lang="en">A custom description system is used (please briefly outline and, if necessary, indicate where it is documented in more detail)</text>
 		<text lang="de">Es wird ein eigenes Beschreibungssystem genutzt (bitte beschreiben Sie dieses kurz und geben, wenn nötig, an, wo es ausführlicher dokumentiert ist)</text>
-		<text lang="es">Se utiliza un sistema de descripción personalizado (resuma brevemente y, si es necesario, indique dónde está documentado con más detalle)</text>
 		<text lang="fr">Un système de description personnalisé est utilisé (veuillez décrire brièvement et, si nécessaire, indiquer où il est documenté plus en détail)</text>
 		<text lang="it">Si utilizza un proprio sistema di descrizione (si prega di descriverlo brevemente, aggiungendo un riferimento alla documentazione estesa, se necessario)</text>
 		<additional_input>True</additional_input>
@@ -3405,7 +3168,6 @@
 		<order>3</order>
 		<text lang="en">No fixed system for the description is used</text>
 		<text lang="de">Es wird kein festgelegtes System zur Beschreibung genutzt</text>
-		<text lang="es">No se utiliza un sistema fijo para la descripción</text>
 		<text lang="fr">Aucun système fixe pour la description n'est utilisé</text>
 		<text lang="it">Non si utilizza nessun sistema fisso per la descrizione</text>
 		<additional_input>False</additional_input>
@@ -3419,7 +3181,6 @@
 		<order>4</order>
 		<text lang="en">Other</text>
 		<text lang="de">Sonstiges</text>
-		<text lang="es">Otro</text>
 		<text lang="fr">Autre</text>
 		<text lang="it">Altro</text>
 		<additional_input>True</additional_input>
@@ -3433,7 +3194,6 @@
 		<order>5</order>
 		<text lang="en">It has not yet been decided, with which system the metadata and contextual information will be described</text>
 		<text lang="de">Es wurde noch nicht entschieden, mit welchem System die Metadaten und Kontextinformationen beschrieben werden</text>
-		<text lang="es">Todavía no se ha decidido con qué sistema se describirán los metadatos y la información contextual</text>
 		<text lang="fr">Il n'a pas encore été décidé avec quel système les métadonnées et les informations contextuelles seront décrites</text>
 		<text lang="it">Non è ancora stato stabilito con quale sistema descrivere i metadati e le informazioni contestuali</text>
 		<additional_input>False</additional_input>
@@ -3454,7 +3214,6 @@
 		<order>0</order>
 		<text lang="en">Yes</text>
 		<text lang="de">Ja</text>
-		<text lang="es">Sí</text>
 		<text lang="fr">Oui</text>
 		<text lang="it">Sì</text>
 		<additional_input>True</additional_input>
@@ -3468,7 +3227,6 @@
 		<order>1</order>
 		<text lang="en">No</text>
 		<text lang="de">Nein</text>
-		<text lang="es">No</text>
 		<text lang="fr">Non</text>
 		<text lang="it">No</text>
 		<additional_input>False</additional_input>
@@ -3482,7 +3240,6 @@
 		<order>2</order>
 		<text lang="en">To be clarified</text>
 		<text lang="de">Noch zu klären</text>
-		<text lang="es">Por aclarar</text>
 		<text lang="fr">À déterminer</text>
 		<text lang="it">Da chiarire</text>
 		<additional_input>False</additional_input>
@@ -3503,7 +3260,6 @@
 		<order>1</order>
 		<text lang="en">Handle / DOI</text>
 		<text lang="de">Handle / DOI</text>
-		<text lang="es">Handle / DOI</text>
 		<text lang="fr">Handle / DOI</text>
 		<text lang="it">Handle / DOI</text>
 		<additional_input>False</additional_input>
@@ -3517,7 +3273,6 @@
 		<order>2</order>
 		<text lang="en">PURL</text>
 		<text lang="de">PURL</text>
-		<text lang="es">PURL</text>
 		<text lang="fr">PURL</text>
 		<text lang="it">PURL</text>
 		<additional_input>False</additional_input>
@@ -3531,7 +3286,6 @@
 		<order>3</order>
 		<text lang="en">ARK</text>
 		<text lang="de">ARK</text>
-		<text lang="es">ARK</text>
 		<text lang="fr">ARK</text>
 		<text lang="it">ARK</text>
 		<additional_input>False</additional_input>
@@ -3545,7 +3299,6 @@
 		<order>4</order>
 		<text lang="en">URN</text>
 		<text lang="de">URN</text>
-		<text lang="es">URN</text>
 		<text lang="fr">URN</text>
 		<text lang="it">URN</text>
 		<additional_input>False</additional_input>
@@ -3559,7 +3312,6 @@
 		<order>5</order>
 		<text lang="en">ISLRN</text>
 		<text lang="de">ISLRN</text>
-		<text lang="es">ISLRN</text>
 		<text lang="fr">ISLRN</text>
 		<text lang="it">ISLRN</text>
 		<additional_input>False</additional_input>
@@ -3573,7 +3325,6 @@
 		<order>6</order>
 		<text lang="en">Other</text>
 		<text lang="de">Anderes</text>
-		<text lang="es">Otro</text>
 		<text lang="fr">Autre</text>
 		<text lang="it">Altro</text>
 		<additional_input>True</additional_input>
@@ -3587,7 +3338,6 @@
 		<order>6</order>
 		<text lang="en">Commit tag on a code repository</text>
 		<text lang="de">Commit-Nummer auf einem Code-Repositorium</text>
-		<text lang="es">Etiqueta de confirmación en un repositorio de código</text>
 		<text lang="fr">Nombre de commit dans un dépôt de développement</text>
 		<text lang="it">Numero di commit in un repositorio di codice</text>
 		<additional_input>True</additional_input>
@@ -3601,7 +3351,6 @@
 		<order>7</order>
 		<text lang="en">None</text>
 		<text lang="de">Keins</text>
-		<text lang="es">Ninguno</text>
 		<text lang="fr">Aucun</text>
 		<text lang="it">Nessuno</text>
 		<additional_input>False</additional_input>
@@ -3622,7 +3371,6 @@
 		<order>1</order>
 		<text lang="en">Basis of a publication / proof of good scientific practice</text>
 		<text lang="de">Grundlage einer Publikation / Nachweis guter wissenschaftlicher Praxis</text>
-		<text lang="es">Base de una publicación / prueba de buena práctica científica</text>
 		<text lang="fr">Fondement d'une publication / preuve de bonnes pratiques scientifiques</text>
 		<text lang="it">Fondamento di una pubblicazione / Prova di una buona pratica scientifica</text>
 		<additional_input>False</additional_input>
@@ -3636,7 +3384,6 @@
 		<order>2</order>
 		<text lang="en">Re-use in subsequent projects or by others</text>
 		<text lang="de">Nachnutzung in Folgeprojekten oder durch andere</text>
-		<text lang="es">Reutilización en proyectos posteriores o por otros</text>
 		<text lang="fr">Réutilisation dans des projets ultérieurs ou par d'autres</text>
 		<text lang="it">Riutilizzo in progetti successivi o da parte di terzi</text>
 		<additional_input>False</additional_input>
@@ -3650,7 +3397,6 @@
 		<order>3</order>
 		<text lang="en">Legal obligations</text>
 		<text lang="de">Aufgrund gesetzlicher Bestimmungen</text>
-		<text lang="es">Obligaciones legales</text>
 		<text lang="fr">Obligations légales</text>
 		<text lang="it">Obbligazioni legali</text>
 		<additional_input>False</additional_input>
@@ -3664,7 +3410,6 @@
 		<order>4</order>
 		<text lang="en">Documentation, because of their societal relevance</text>
 		<text lang="de">Dokumentation aufgrund gesellschaftlicher Relevanz</text>
-		<text lang="es">La documentación, por su relevancia social</text>
 		<text lang="fr">La documentation, à cause de sa rélévance pour la société</text>
 		<text lang="it">Documentazione per via della rilevanza per la società</text>
 		<additional_input>False</additional_input>
@@ -3678,7 +3423,6 @@
 		<order>5</order>
 		<text lang="en">Self-commitment</text>
 		<text lang="de">Selbstverpflichtung</text>
-		<text lang="es">Obligación personal</text>
 		<text lang="fr">Engagement personnel</text>
 		<text lang="it">Obbligazione personale</text>
 		<additional_input>False</additional_input>
@@ -3692,7 +3436,6 @@
 		<order>6</order>
 		<text lang="en">Other</text>
 		<text lang="de">Andere</text>
-		<text lang="es">Otros</text>
 		<text lang="fr">Autres</text>
 		<text lang="it">Altri</text>
 		<additional_input>True</additional_input>
@@ -3713,7 +3456,6 @@
 		<order>0</order>
 		<text lang="en">Own institution</text>
 		<text lang="de">Eigene Institution</text>
-		<text lang="es">Institución propia</text>
 		<text lang="fr">Sa propre institution</text>
 		<text lang="it">Proprio istituto</text>
 		<additional_input>False</additional_input>
@@ -3727,7 +3469,6 @@
 		<order>1</order>
 		<text lang="en">Another partner institution</text>
 		<text lang="de">Eine andere Partner-Institution</text>
-		<text lang="es">Otra institución asociada</text>
 		<text lang="fr">Une autre institution partenaire</text>
 		<text lang="it">Un altro istituto partner</text>
 		<additional_input>True</additional_input>
@@ -3741,7 +3482,6 @@
 		<order>2</order>
 		<text lang="en">Discipline specific data center</text>
 		<text lang="de">Disziplinspezifisches Datenzentrum</text>
-		<text lang="es">Centro de datos específico para cada disciplina</text>
 		<text lang="fr">Centre de données spécifique à la discipline</text>
 		<text lang="it">Un centro dati specifico per la disciplina</text>
 		<additional_input>True</additional_input>
@@ -3755,7 +3495,6 @@
 		<order>3</order>
 		<text lang="en">Generic data center</text>
 		<text lang="de">Generisches Datenzentrum</text>
-		<text lang="es">Centro de datos genérico</text>
 		<text lang="fr">Centre générique de données</text>
 		<text lang="it">Un centro dati generico</text>
 		<additional_input>True</additional_input>
@@ -3769,7 +3508,6 @@
 		<order>4</order>
 		<text lang="en">To be decided</text>
 		<text lang="de">Wird noch entschieden</text>
-		<text lang="es">Por decidir</text>
 		<text lang="fr">À décider</text>
 		<text lang="it">Da stabilire</text>
 		<additional_input>False</additional_input>
@@ -3783,7 +3521,6 @@
 		<order>5</order>
 		<text lang="en">Other</text>
 		<text lang="de">Sonstiges</text>
-		<text lang="es">Otro</text>
 		<text lang="fr">Autre</text>
 		<text lang="it">Altro</text>
 		<additional_input>True</additional_input>
@@ -3804,7 +3541,6 @@
 		<order>101</order>
 		<text lang="en">Humanities and Social Sciences / Ancient Cultures</text>
 		<text lang="de">Geistes- und Sozialwissenschaften / Alte Kulturen</text>
-		<text lang="es">Humanidades y Ciencias Sociales / Culturas antiguas</text>
 		<text lang="fr">Sciences humaines et société / Cultures anciennes</text>
 		<text lang="it">Scienze umane e sociali / Culture antiche</text>
 		<additional_input>False</additional_input>
@@ -3818,7 +3554,6 @@
 		<order>102</order>
 		<text lang="en">Humanities and Social Sciences / History</text>
 		<text lang="de">Geistes- und Sozialwissenschaften / Geschichtswissenschaften</text>
-		<text lang="es">Humanidades y Ciencias Sociales / Historia</text>
 		<text lang="fr">Sciences humaines et société / Histoire</text>
 		<text lang="it">Scienze umane e sociali / Storia</text>
 		<additional_input>False</additional_input>
@@ -3832,7 +3567,6 @@
 		<order>103</order>
 		<text lang="en">Humanities and Social Sciences / Fine Arts, Music, Theatre and Media Studies</text>
 		<text lang="de">Geistes- und Sozialwissenschaften / Kunst-, Musik-, Theater- und Medienwissenschaften</text>
-		<text lang="es">Humanidades y Ciencias Sociales / Bellas Artes, Música, Teatro y Medios de Comunicación</text>
 		<text lang="fr">Sciences humaines et société / Beaux-arts, musique, théâtre et études médiatiques</text>
 		<text lang="it">Scienze umane e sociali / Arti figurative, musica, teatro e mezzi di comunicazione</text>
 		<additional_input>False</additional_input>
@@ -3846,7 +3580,6 @@
 		<order>104</order>
 		<text lang="en">Humanities and Social Sciences / Linguistics</text>
 		<text lang="de">Geistes- und Sozialwissenschaften / Sprachwissenschaften</text>
-		<text lang="es">Humanidades y Ciencias Sociales / Lingüística</text>
 		<text lang="fr">Sciences humaines et société / Linguistique</text>
 		<text lang="it">Scienze umane e sociali / Linguistica</text>
 		<additional_input>False</additional_input>
@@ -3860,7 +3593,6 @@
 		<order>105</order>
 		<text lang="en">Humanities and Social Sciences / Literary Studies</text>
 		<text lang="de">Geistes- und Sozialwissenschaften / Literaturwissenschaft</text>
-		<text lang="es">Humanidades y Ciencias Sociales / Estudios literarios</text>
 		<text lang="fr">Sciences humaines et société / Études littéraires</text>
 		<text lang="it">Scienze umane e sociali / Letteratura</text>
 		<additional_input>False</additional_input>
@@ -3874,7 +3606,6 @@
 		<order>106</order>
 		<text lang="en">Humanities and Social Sciences / Non-European Languages and Cultures, Social and Cultural Anthropology, Jewish Studies and Religious Studies</text>
 		<text lang="de">Geistes- und Sozialwissenschaften / Außereuropäische Sprachen und Kulturen, Sozial- und Kulturanthropologie, Judaistik und Religionswissenschaft</text>
-		<text lang="es">Humanidades y Ciencias Sociales / Lenguas y Culturas no Europeas, Antropología Social y Cultural, Estudios Judíos y Estudios Religiosos</text>
 		<text lang="fr">Sciences humaines et société / Langues et cultures non européennes, anthropologie sociale et culturelle, études juives et études religieuses</text>
 		<text lang="it">Scienze umane e sociali / Lingue e culture non europee, antropologia socioculturale, studi ebraici e studi religiosi</text>
 		<additional_input>False</additional_input>
@@ -3888,7 +3619,6 @@
 		<order>107</order>
 		<text lang="en">Humanities and Social Sciences / Theology</text>
 		<text lang="de">Geistes- und Sozialwissenschaften / Theologie</text>
-		<text lang="es">Humanidades y Ciencias Sociales / Teología</text>
 		<text lang="fr">Sciences humaines et société / Théologie</text>
 		<text lang="it">Scienze umane e sociali / Teologia</text>
 		<additional_input>False</additional_input>
@@ -3902,7 +3632,6 @@
 		<order>108</order>
 		<text lang="en">Humanities and Social Sciences / Philosophy</text>
 		<text lang="de">Geistes- und Sozialwissenschaften / Philosophie</text>
-		<text lang="es">Humanidades y Ciencias Sociales / Filosofía</text>
 		<text lang="fr">Sciences humaines et société / Philosophie</text>
 		<text lang="it">Scienze umane e sociali / Filosofia</text>
 		<additional_input>False</additional_input>
@@ -3916,7 +3645,6 @@
 		<order>109</order>
 		<text lang="en">Humanities and Social Sciences / Education Sciences</text>
 		<text lang="de">Geistes- und Sozialwissenschaften / Erziehungswissenschaft</text>
-		<text lang="es">Humanidades y Ciencias Sociales / Ciencias de la Educación</text>
 		<text lang="fr">Sciences humaines et société / Sciences de l'éducation</text>
 		<text lang="it">Scienze umane e sociali / Scienze dell'educazione</text>
 		<additional_input>False</additional_input>
@@ -3930,7 +3658,6 @@
 		<order>110</order>
 		<text lang="en">Humanities and Social Sciences / Psychology</text>
 		<text lang="de">Geistes- und Sozialwissenschaften / Psychologie</text>
-		<text lang="es">Humanidades y Ciencias Sociales / Psicología</text>
 		<text lang="fr">Sciences humaines et société / Psychologie</text>
 		<text lang="it">Scienze umane e sociali / Psicologia</text>
 		<additional_input>False</additional_input>
@@ -3944,7 +3671,6 @@
 		<order>111</order>
 		<text lang="en">Humanities and Social Sciences / Social Sciences</text>
 		<text lang="de">Geistes- und Sozialwissenschaften / Sozialwissenschaften</text>
-		<text lang="es">Humanidades y Ciencias Sociales / Ciencias Sociales</text>
 		<text lang="fr">Sciences humaines et société / Sciences sociales</text>
 		<text lang="it">Scienze umane e sociali / Scienze sociali</text>
 		<additional_input>False</additional_input>
@@ -3958,7 +3684,6 @@
 		<order>112</order>
 		<text lang="en">Humanities and Social Sciences / Economics</text>
 		<text lang="de">Geistes- und Sozialwissenschaften / Wirtschaftswissenschaften</text>
-		<text lang="es">Humanidades y Ciencias Sociales / Economía</text>
 		<text lang="fr">Sciences humaines et société / Économie</text>
 		<text lang="it">Scienze umane e sociali / Economia</text>
 		<additional_input>False</additional_input>
@@ -3972,7 +3697,6 @@
 		<order>113</order>
 		<text lang="en">Humanities and Social Sciences / Jurisprudence</text>
 		<text lang="de">Geistes- und Sozialwissenschaften / Rechtswissenschaften</text>
-		<text lang="es">Humanidades y Ciencias Sociales / Jurisprudencia</text>
 		<text lang="fr">Sciences humaines et société / Jurisprudence</text>
 		<text lang="it">Scienze umane e sociali / Giurisprudenza</text>
 		<additional_input>False</additional_input>
@@ -3986,7 +3710,6 @@
 		<order>201</order>
 		<text lang="en">Life Sciences / Basic Biological and Medical Research</text>
 		<text lang="de">Lebenswissenschaften / Grundlagen der Biologie und Medizin</text>
-		<text lang="es">Ciencias de la vida / Investigación biológica y médica básica</text>
 		<text lang="fr">Sciences de la vie / Recherche biologique et médicale fondamentale</text>
 		<text lang="it">Scienze della vita / Fondamenti della biologia e della medicina</text>
 		<additional_input>False</additional_input>
@@ -4000,7 +3723,6 @@
 		<order>202</order>
 		<text lang="en">Life Sciences / Plant Sciences</text>
 		<text lang="de">Lebenswissenschaften / Pflanzenwissenschaften</text>
-		<text lang="es">Ciencias de la vida / Ciencias vegetales</text>
 		<text lang="fr">Sciences de la vie / Sciences végétales</text>
 		<text lang="it">Scienze della vita / Botanica</text>
 		<additional_input>False</additional_input>
@@ -4014,7 +3736,6 @@
 		<order>203</order>
 		<text lang="en">Life Sciences / Zoology</text>
 		<text lang="de">Lebenswissenschaften / Zoologie</text>
-		<text lang="es">Ciencias de la vida / Zoología</text>
 		<text lang="fr">Sciences de la vie / Zoologie</text>
 		<text lang="it">Scienze della vita / Zoologia</text>
 		<additional_input>False</additional_input>
@@ -4028,7 +3749,6 @@
 		<order>204</order>
 		<text lang="en">Life Sciences / Microbiology, Virology and Immunology</text>
 		<text lang="de">Lebenswissenschaften / Mikrobiologie, Virologie und Immunologie</text>
-		<text lang="es">Ciencias de la Vida / Microbiología, Virología e Inmunología</text>
 		<text lang="fr">Sciences de la vie / Microbiologie, virologie et immunologie</text>
 		<text lang="it">Scienze della vita / Microbiologia, virologia e immunologia</text>
 		<additional_input>False</additional_input>
@@ -4042,7 +3762,6 @@
 		<order>205</order>
 		<text lang="en">Life Sciences / Medicine</text>
 		<text lang="de">Lebenswissenschaften / Medizin</text>
-		<text lang="es">Ciencias de la vida / Medicina</text>
 		<text lang="fr">Sciences de la vie / Médecine</text>
 		<text lang="it">Scienze della vita / Medicina</text>
 		<additional_input>False</additional_input>
@@ -4056,7 +3775,6 @@
 		<order>206</order>
 		<text lang="en">Life Sciences / Neurosciences</text>
 		<text lang="de">Lebenswissenschaften / Neurowissenschaft</text>
-		<text lang="es">Ciencias de la vida / Neurociencias</text>
 		<text lang="fr">Sciences de la vie / Neurosciences</text>
 		<text lang="it">Scienze della vita / Neuroscienze</text>
 		<additional_input>False</additional_input>
@@ -4070,7 +3788,6 @@
 		<order>207</order>
 		<text lang="en">Life Sciences / Agriculture, Forestry, Horticulture and Veterinary Medicine</text>
 		<text lang="de">Lebenswissenschaften / Agrar-, Forstwissenschaften, Gartenbau und Tiermedizin</text>
-		<text lang="es">Ciencias de la vida / Agricultura, silvicultura, horticultura y veterinaria</text>
 		<text lang="fr">Sciences de la vie / Agriculture, foresterie, horticulture et médecine vétérinaire</text>
 		<text lang="it">Scienze della vita / Agronomia, foresteria, orticoltura e medicina veterinaria</text>
 		<additional_input>False</additional_input>
@@ -4084,7 +3801,6 @@
 		<order>301</order>
 		<text lang="en">Natural Sciences / Molecular Chemistry</text>
 		<text lang="de">Naturwissenschaften / Molekülchemie</text>
-		<text lang="es">Ciencias naturales / Química molecular</text>
 		<text lang="fr">Sciences naturelles / Chimie moléculaire</text>
 		<text lang="it">Scienze naturali / chimica molecolare</text>
 		<additional_input>False</additional_input>
@@ -4098,7 +3814,6 @@
 		<order>302</order>
 		<text lang="en">Natural Sciences / Chemical Solid State and Surface Research</text>
 		<text lang="de">Naturwissenschaften / Chemische Festkörper- und Oberflächenforschung</text>
-		<text lang="es">Ciencias naturales / Investigación del estado sólido y de las superficies químicas</text>
 		<text lang="fr">Sciences naturelles / Chimie de l'état solide et des surfaces</text>
 		<text lang="it">Scienze naturali / Chimica dello stato solido e delle superfici</text>
 		<additional_input>False</additional_input>
@@ -4112,7 +3827,6 @@
 		<order>303</order>
 		<text lang="en">Natural Sciences / Physical and Theoretical Chemistry</text>
 		<text lang="de">Naturwissenschaften / Physikalische und Theoretische Chemie</text>
-		<text lang="es">Ciencias naturales / Química física y teórica</text>
 		<text lang="fr">Sciences naturelles / Chimie physique et théorique</text>
 		<text lang="it">Scienze naturali / Chimica fisica e teorica</text>
 		<additional_input>False</additional_input>
@@ -4126,7 +3840,6 @@
 		<order>304</order>
 		<text lang="en">Natural Sciences / Analytical Chemistry, Method Development (Chemistry)</text>
 		<text lang="de">Naturwissenschaften / Analytik, Methodenentwicklung (Chemie)</text>
-		<text lang="es">Ciencias naturales / Química analítica, Desarrollo de métodos (Química)</text>
 		<text lang="fr">Sciences naturelles / Chimie analytique, développement de méthodes (chemie)</text>
 		<text lang="it">Scienze naturali / Chimica analitica, sviluppo metodologico</text>
 		<additional_input>False</additional_input>
@@ -4140,7 +3853,6 @@
 		<order>305</order>
 		<text lang="en">Natural Sciences / Biological Chemistry and Food Chemistry</text>
 		<text lang="de">Naturwissenschaften / Biologische Chemie und Lebensmittelchemie</text>
-		<text lang="es">Ciencias naturales / Química biológica y química de los alimentos</text>
 		<text lang="fr">Sciences naturelles / Chimie biologique et chimie alimentaire</text>
 		<text lang="it">Scienze naturali / Chimica biologica e chimica alimentare</text>
 		<additional_input>False</additional_input>
@@ -4154,7 +3866,6 @@
 		<order>306</order>
 		<text lang="en">Natural Sciences / Polymer Research</text>
 		<text lang="de">Naturwissenschaften / Polymerforschung</text>
-		<text lang="es">Ciencias naturales / Investigación sobre polímeros</text>
 		<text lang="fr">Sciences naturelles / Recherche sur les polymères</text>
 		<text lang="it">Scienze naturali / Chimica dei polimeri</text>
 		<additional_input>False</additional_input>
@@ -4168,7 +3879,6 @@
 		<order>307</order>
 		<text lang="en">Natural Sciences / Condensed Matter Physics</text>
 		<text lang="de">Naturwissenschaften / Physik der kondensierten Materie</text>
-		<text lang="es">Ciencias naturales / Física de la materia condensada</text>
 		<text lang="fr">Sciences naturelles / Physique de la matière condensée</text>
 		<text lang="it">Scienze naturali / Fisica della materia condensata</text>
 		<additional_input>False</additional_input>
@@ -4182,7 +3892,6 @@
 		<order>308</order>
 		<text lang="en">Natural Sciences / Optics, Quantum Optics and Physics of Atoms, Molecules and Plasmas</text>
 		<text lang="de">Naturwissenschaften / Optik, Quantenoptik und Physik der Atome, Moleküle und Plasmen</text>
-		<text lang="es">Ciencias naturales / Óptica, óptica cuántica y física de átomos, de moléculas y de plasmas</text>
 		<text lang="fr">Sciences naturelles / Optique, optique quantique et physique des atomes, des molécules et des plasmas</text>
 		<text lang="it">Scienze naturali / Ottica, ottica quantistica, fisica degli atomi, delle molecole e dei plasmi</text>
 		<additional_input>False</additional_input>
@@ -4196,7 +3905,6 @@
 		<order>309</order>
 		<text lang="en">Natural Sciences / Particles, Nuclei and Fields</text>
 		<text lang="de">Naturwissenschaften / Teilchen, Kerne und Felder</text>
-		<text lang="es">Ciencias naturales / Partículas, núcleos y campos</text>
 		<text lang="fr">Sciences naturelles / Particules, noyaux et champs</text>
 		<text lang="it">Scienze naturali / Particelle, nuclei e campi</text>
 		<additional_input>False</additional_input>
@@ -4210,7 +3918,6 @@
 		<order>310</order>
 		<text lang="en">Natural Sciences / Statistical Physics, Soft Matter, Biological Physics, Nonlinear Dynamics</text>
 		<text lang="de">Naturwissenschaften / Statistische Physik, Weiche Materie, Biologische Physik, Nichtlineare Dynamik</text>
-		<text lang="es">Ciencias naturales / Física estadística, materia blanda, física biológica, dinámica no lineal</text>
 		<text lang="fr">Sciences naturelles / Physique statistique, matière molle, physique biologique, dynamique non-linéaire</text>
 		<text lang="it">Scienze naturali / Fisica statistica, materia molle, fisica biologica, dinamica nonlineare</text>
 		<additional_input>False</additional_input>
@@ -4224,7 +3931,6 @@
 		<order>311</order>
 		<text lang="en">Natural Sciences / Astrophysics and Astronomy</text>
 		<text lang="de">Naturwissenschaften / Astrophysik und Astronomie</text>
-		<text lang="es">Ciencias naturales / Astrofísica y astronomía</text>
 		<text lang="fr">Sciences naturelles / Astrophysique et astronomie</text>
 		<text lang="it">Scienze naturali / Astronomia e astrofisica</text>
 		<additional_input>False</additional_input>
@@ -4238,7 +3944,6 @@
 		<order>312</order>
 		<text lang="en">Natural Sciences / Mathematics</text>
 		<text lang="de">Naturwissenschaften / Mathematik</text>
-		<text lang="es">Ciencias naturales / Matemáticas</text>
 		<text lang="fr">Sciences naturelles / Mathématiques</text>
 		<text lang="it">Scienze naturali / Matematica</text>
 		<additional_input>False</additional_input>
@@ -4252,7 +3957,6 @@
 		<order>313</order>
 		<text lang="en">Natural Sciences / Atmospheric Science and Oceanography</text>
 		<text lang="de">Naturwissenschaften / Atmosphären- und Meeresforschung</text>
-		<text lang="es">Ciencias naturales / Ciencias de la atmósfera y oceanografía</text>
 		<text lang="fr">Sciences naturelles / Science atmosphérique et océanographie</text>
 		<text lang="it">Scienze naturali / Scienze dell'atmosfera e oceanografia</text>
 		<additional_input>False</additional_input>
@@ -4266,7 +3970,6 @@
 		<order>314</order>
 		<text lang="en">Natural Sciences / Geology and Palaeontology</text>
 		<text lang="de">Naturwissenschaften / Geologie und Paläontologie</text>
-		<text lang="es">Ciencias naturales / Geología y paleontología</text>
 		<text lang="fr">Sciences naturelles / Géologie et paléontologie</text>
 		<text lang="it">Scienze naturali / Geologia e paleontologia</text>
 		<additional_input>False</additional_input>
@@ -4280,7 +3983,6 @@
 		<order>315</order>
 		<text lang="en">Natural Sciences / Geophysics and Geodesy</text>
 		<text lang="de">Naturwissenschaften / Geophysik und Geodäsie</text>
-		<text lang="es">Ciencias naturales / Geofísica y geodesia</text>
 		<text lang="fr">Sciences naturelles / Géophysique et géodésie</text>
 		<text lang="it">Scienze naturali / Geofisica e geodesia</text>
 		<additional_input>False</additional_input>
@@ -4294,7 +3996,6 @@
 		<order>316</order>
 		<text lang="en">Natural Sciences / Geochemistry, Mineralogy and Crystallography</text>
 		<text lang="de">Naturwissenschaften / Geochemie, Mineralogie und Kristallographie</text>
-		<text lang="es">Ciencias naturales / Geoquímica, mineralogía y cristalografía</text>
 		<text lang="fr">Sciences naturelles / Géochimie, minéralogie et cristallographie</text>
 		<text lang="it">Scienze naturali / Geochimica, mineralogia e cristallografia</text>
 		<additional_input>False</additional_input>
@@ -4308,7 +4009,6 @@
 		<order>317</order>
 		<text lang="en">Natural Sciences / Geography</text>
 		<text lang="de">Naturwissenschaften / Geographie</text>
-		<text lang="es">Ciencias naturales / geografía</text>
 		<text lang="fr">Sciences naturelles / Géographie</text>
 		<text lang="it">Scienze naturali / Geografia</text>
 		<additional_input>False</additional_input>
@@ -4322,7 +4022,6 @@
 		<order>318</order>
 		<text lang="en">Natural Sciences / Water Research</text>
 		<text lang="de">Naturwissenschaften / Wasserforschung</text>
-		<text lang="es">Ciencias naturales / Investigación sobre el agua</text>
 		<text lang="fr">Sciences naturelles / Recherche sur l'eau</text>
 		<text lang="it">Scienze naturali / Idrologia</text>
 		<additional_input>False</additional_input>
@@ -4336,7 +4035,6 @@
 		<order>401</order>
 		<text lang="en">Engineering Sciences / Production Technology</text>
 		<text lang="de">Ingenieurwissenschaften / Produktionstechnik</text>
-		<text lang="es">Ciencias de la ingeniería / Tecnología de la producción</text>
 		<text lang="fr">Sciences de l'ingénierie / Technologie de production</text>
 		<text lang="it">Scienze ingegneristiche / Tecnologia della produzione</text>
 		<additional_input>False</additional_input>
@@ -4350,9 +4048,8 @@
 		<order>402</order>
 		<text lang="en">Engineering Sciences / Mechanics and Constructive Mechanical Engineering</text>
 		<text lang="de">Ingenieurwissenschaften / Mechanik und Konstruktiver Maschinenbau</text>
-		<text lang="es">Ciencias de la ingeniería / Mecánica e Ingeniería mecánica constructiva</text>
 		<text lang="fr">Sciences de l'ingénierie / Génie mécanique et mécanique des structures</text>
-		<text lang="it">Scienze ingegneristiche / Ingegneria Meccanica e meccanica costruttiva</text>
+		<text lang="it">Scienze ingegneristiche / Ingegneria Meccanica e ?</text>
 		<additional_input>False</additional_input>
 	</option>
 	<option dc:uri="https://rdmorganiser.github.io/terms/options/research_fields/209">
@@ -4364,7 +4061,6 @@
 		<order>403</order>
 		<text lang="en">Engineering Sciences / Process Engineering, Technical Chemistry</text>
 		<text lang="de">Ingenieurwissenschaften / Verfahrenstechnik, Technische Chemie</text>
-		<text lang="es">Ciencias de la ingeniería / Ingeniería de procesos, química técnica</text>
 		<text lang="fr">Sciences de l'ingénierie / Génie des procédés, chimie technique</text>
 		<text lang="it">Scienze ingegneristiche / Ingegneria dei processi, Chimica tecnica</text>
 		<additional_input>False</additional_input>
@@ -4378,7 +4074,6 @@
 		<order>404</order>
 		<text lang="en">Engineering Sciences / Heat Energy Technology, Thermal Machines, Fluid Mechanics</text>
 		<text lang="de">Ingenieurwissenschaften / Wärmeenergietechnik, Thermische Maschinen, Strömungsmechanik</text>
-		<text lang="es">Ciencias de la ingeniería / Tecnología de la energía térmica, máquinas térmicas, mecánica de fluidos</text>
 		<text lang="fr">Sciences de l'ingénierie / Technologie de l'énergie calorifique, machines thermiques, mécanique des fluides</text>
 		<text lang="it">Scienze ingegneristiche / Tecnologia del calore, macchine termiche, meccanica dei fluidi</text>
 		<additional_input>False</additional_input>
@@ -4392,7 +4087,6 @@
 		<order>405</order>
 		<text lang="en">Engineering Sciences / Materials Engineering</text>
 		<text lang="de">Ingenieurwissenschaften / Werkstofftechnik</text>
-		<text lang="es">Ciencias de la ingeniería / Ingeniería de materiales</text>
 		<text lang="fr">Sciences de l'ingénierie / Génie des matériaux</text>
 		<text lang="it">Scienze ingegneristiche / Ingegneria dei materiali</text>
 		<additional_input>False</additional_input>
@@ -4406,7 +4100,6 @@
 		<order>406</order>
 		<text lang="en">Engineering Sciences / Materials Science</text>
 		<text lang="de">Ingenieurwissenschaften / Materialwissenschaft</text>
-		<text lang="es">Ciencias de la ingeniería / Ciencia de los materiales</text>
 		<text lang="fr">Sciences de l'ingénierie / Science des matériaux</text>
 		<text lang="it">Scienze ingegneristiche / Scienza dei materiali</text>
 		<additional_input>False</additional_input>
@@ -4420,7 +4113,6 @@
 		<order>407</order>
 		<text lang="en">Engineering Sciences / Systems Engineering</text>
 		<text lang="de">Ingenieurwissenschaften / Systemtechnik</text>
-		<text lang="es">Ciencias de la ingeniería / Ingeniería de sistemas</text>
 		<text lang="fr">Sciences de l'ingénierie / Ingénierie des systèmes</text>
 		<text lang="it">Scienze ingegneristiche / Ingegneria dei sistemi</text>
 		<additional_input>False</additional_input>
@@ -4434,7 +4126,6 @@
 		<order>408</order>
 		<text lang="en">Engineering Sciences / Electrical Engineering</text>
 		<text lang="de">Ingenieurwissenschaften / Elektrotechnik</text>
-		<text lang="es">Ciencias de la ingeniería / Ingeniería eléctrica</text>
 		<text lang="fr">Sciences de l'ingénierie / Ingénierie électrique</text>
 		<text lang="it">Scienze ingegneristiche / Ingegneria elettrica</text>
 		<additional_input>False</additional_input>
@@ -4448,7 +4139,6 @@
 		<order>409</order>
 		<text lang="en">Engineering Sciences / Computer Science</text>
 		<text lang="de">Ingenieurwissenschaften / Informatik</text>
-		<text lang="es">Ciencias de la Ingeniería / Informática</text>
 		<text lang="fr">Sciences de l'ingénierie / Informatique</text>
 		<text lang="it">Scienze ingegneristiche / Informatica</text>
 		<additional_input>False</additional_input>
@@ -4462,7 +4152,6 @@
 		<order>410</order>
 		<text lang="en">Engineering Sciences / Construction Engineering and Architecture</text>
 		<text lang="de">Ingenieurwissenschaften / Bauwesen und Architektur</text>
-		<text lang="es">Ciencias de la ingeniería / Ingeniería de la construcción y arquitectura</text>
 		<text lang="fr">Sciences de l'ingénierie / Génie de la construction et architecture</text>
 		<text lang="it">Scienze ingegneristiche / Ingegneria civile</text>
 		<additional_input>False</additional_input>
@@ -4483,7 +4172,6 @@
 		<order>1</order>
 		<text lang="en">Law on the rights of audio support producers</text>
 		<text lang="de">Recht des Herstellers eines Tonträgers</text>
-		<text lang="es">Ley sobre los derechos de los productores de soportes de audio</text>
 		<text lang="fr">Loi sur les droits du fabricant de supports audio</text>
 		<text lang="it">Legge sui diritti del produttore di supporti audio</text>
 		<additional_input>False</additional_input>
@@ -4497,7 +4185,6 @@
 		<order>2</order>
 		<text lang="en">Law on the consulting rights of scientific reviewers</text>
 		<text lang="de">Recht des Verfassers sichtender wissenschaftlicher Ausgaben</text>
-		<text lang="es">Ley sobre los derechos de consulta de los revisores científicos</text>
 		<text lang="fr">Loi sur les droits de consultation scientifique de l'auteur</text>
 		<text lang="it">Legge sui diritti della revisione di pubblicazioni scientifiche</text>
 		<additional_input>False</additional_input>
@@ -4511,7 +4198,6 @@
 		<order>3</order>
 		<text lang="en">Law on rights radio senders</text>
 		<text lang="de">Recht des Sendeunternehmers</text>
-		<text lang="es">Ley de derechos de los emisores de radio</text>
 		<text lang="fr">Loi sur les droits d'un entrepreneur d'envoi</text>
 		<text lang="it">Legge sui diritti di un gestore radio</text>
 		<additional_input>False</additional_input>
@@ -4525,7 +4211,6 @@
 		<order>4</order>
 		<text lang="en">Law on database providers rights</text>
 		<text lang="de">Recht des Datenbankherstellers</text>
-		<text lang="es">Ley de derechos de los proveedores de bases de datos</text>
 		<text lang="fr">Loi sur les droits d'un fabricant de la base de données</text>
 		<text lang="it">Legge sui diritti di gestore di banche dati</text>
 		<additional_input>False</additional_input>
@@ -4539,7 +4224,6 @@
 		<order>6</order>
 		<text lang="en">Other copyright laws</text>
 		<text lang="de">Andere Urheberrechte</text>
-		<text lang="es">Otras leyes de derechos de autor</text>
 		<text lang="fr">Autres lois sur le droit d'auteur</text>
 		<text lang="it">Altre leggi sul diritto d'autore</text>
 		<additional_input>True</additional_input>
@@ -4553,7 +4237,6 @@
 		<order>7</order>
 		<text lang="en">No</text>
 		<text lang="de">Nein</text>
-		<text lang="es">No</text>
 		<text lang="fr">Non</text>
 		<text lang="it">No</text>
 		<additional_input>False</additional_input>
@@ -4574,7 +4257,6 @@
 		<order>0</order>
 		<text lang="en">The code will be published under the following license</text>
 		<text lang="de">Der Code wird unter folgender Lizenz veröffentlicht</text>
-		<text lang="es">El código se publicará bajo la siguiente licencia</text>
 		<text lang="fr">Le code sera publié sous la licence suivante</text>
 		<text lang="it">Il codice verrà pubblicato con la seguente licenza</text>
 		<additional_input>True</additional_input>
@@ -4588,7 +4270,6 @@
 		<order>1</order>
 		<text lang="en">Yet to be decided</text>
 		<text lang="de">Noch zu klären</text>
-		<text lang="es">Aún no se ha decidido</text>
 		<text lang="fr">À déterminer</text>
 		<text lang="it">Non ancora deciso</text>
 		<additional_input>False</additional_input>
@@ -4607,11 +4288,10 @@
 		<dc:comment/>
 		<optionset dc:uri="https://rdmorganiser.github.io/terms/options/software_license_types"/>
 		<order>1</order>
-		<text lang="en">Attribution (BY)</text>
-		<text lang="de">Namensnennung (BY)</text>
-		<text lang="es">Atribución (BY)</text>
-		<text lang="fr">Attribution (BY)</text>
-		<text lang="it">Attribuzione (BY)</text>
+		<text lang="en">Attribution</text>
+		<text lang="de">Namensnennung</text>
+		<text lang="fr">Attribution</text>
+		<text lang="it">Attribuzione</text>
 		<additional_input>False</additional_input>
 	</option>
 	<option dc:uri="https://rdmorganiser.github.io/terms/options/software_license_types/82">
@@ -4621,11 +4301,10 @@
 		<dc:comment/>
 		<optionset dc:uri="https://rdmorganiser.github.io/terms/options/software_license_types"/>
 		<order>2</order>
-		<text lang="en">Non-commercial (NC)</text>
-		<text lang="de">keine kommerzielle Nutzung (NC)</text>
-		<text lang="es">No comercial (NC)</text>
-		<text lang="fr">Pas d'utilisation commerciale (NC)</text>
-		<text lang="it">NonCommerciale (NC)</text>
+		<text lang="en">Non-commercial</text>
+		<text lang="de">keine kommerzielle Nutzung</text>
+		<text lang="fr">Pas d'utilisation commerciale</text>
+		<text lang="it">NonCommerciale</text>
 		<additional_input>False</additional_input>
 	</option>
 	<option dc:uri="https://rdmorganiser.github.io/terms/options/software_license_types/80">
@@ -4635,11 +4314,10 @@
 		<dc:comment/>
 		<optionset dc:uri="https://rdmorganiser.github.io/terms/options/software_license_types"/>
 		<order>3</order>
-		<text lang="en">No derivative work (ND)</text>
-		<text lang="de">keine Bearbeitung (ND)</text>
-		<text lang="es">Ninguna obra derivada (ND)</text>
-		<text lang="fr">Pas de modification (ND)</text>
-		<text lang="it">NonOpereDerivate (ND)</text>
+		<text lang="en">No derivative work</text>
+		<text lang="de">keine Bearbeitung</text>
+		<text lang="fr">Pas de modification</text>
+		<text lang="it">NonOpereDerivate</text>
 		<additional_input>False</additional_input>
 	</option>
 	<option dc:uri="https://rdmorganiser.github.io/terms/options/software_license_types/83">
@@ -4649,11 +4327,10 @@
 		<dc:comment/>
 		<optionset dc:uri="https://rdmorganiser.github.io/terms/options/software_license_types"/>
 		<order>4</order>
-		<text lang="en">Share-alike (SA)</text>
-		<text lang="de">Weitergabe unter gleichen Bedingungen (SA)</text>
-		<text lang="es">Acciones similares (SA)</text>
-		<text lang="fr">Partage dans les mêmes conditions (SA)</text>
-		<text lang="it">CondividiAlloStessoModo (SA)</text>
+		<text lang="en">Share-alike</text>
+		<text lang="de">Weitergabe unter gleichen Bedingungen</text>
+		<text lang="fr">Partage dans les mêmes conditions</text>
+		<text lang="it">CondividiAlloStessoModo</text>
 		<additional_input>False</additional_input>
 	</option>
 	<option dc:uri="https://rdmorganiser.github.io/terms/options/software_license_types/234">
@@ -4665,7 +4342,6 @@
 		<order>5</order>
 		<text lang="en">Other</text>
 		<text lang="de">Andere</text>
-		<text lang="es">Otros</text>
 		<text lang="fr">Autres</text>
 		<text lang="it">Altri</text>
 		<additional_input>True</additional_input>
@@ -4686,7 +4362,6 @@
 		<order>0</order>
 		<text lang="en">Created</text>
 		<text lang="de">Erzeugt</text>
-		<text lang="es">Creado</text>
 		<text lang="fr">Créé</text>
 		<text lang="it">Creato</text>
 		<additional_input>False</additional_input>
@@ -4700,7 +4375,6 @@
 		<order>1</order>
 		<text lang="en">Re-used</text>
 		<text lang="de">Nachgenutzt</text>
-		<text lang="es">Reutilizado</text>
 		<text lang="fr">Réutilisé</text>
 		<text lang="it">Riutilizzato</text>
 		<additional_input>False</additional_input>
@@ -4721,7 +4395,6 @@
 		<order>1</order>
 		<text lang="en">Business names (company names and work titles)</text>
 		<text lang="de">geschäftliche Bezeichnungen (Unternehmenskennzeichen und Werktitel)</text>
-		<text lang="es">Nombres de empresas (nombres de empresas y títulos de trabajo)</text>
 		<text lang="fr">Noms commerciaux (noms d'entreprises et titre de fonction)</text>
 		<text lang="it">Nomi commerciali (nomi di imprese e titoli di lavoro)</text>
 		<additional_input>False</additional_input>
@@ -4735,7 +4408,6 @@
 		<order>3</order>
 		<text lang="en">Geographical indications</text>
 		<text lang="de">geografische Herkunftsangaben</text>
-		<text lang="es">Indicaciones geográficas</text>
 		<text lang="fr">Indications géographiques</text>
 		<text lang="it">Indicazioni geografiche di origine</text>
 		<additional_input>False</additional_input>
@@ -4749,7 +4421,6 @@
 		<order>4</order>
 		<text lang="en">Plant Variety Protection (Plant Varieties)</text>
 		<text lang="de">Sortenschutz (Pflanzenzüchtungen)</text>
-		<text lang="es">Protección de las obtenciones vegetales (variedades de plantas)</text>
 		<text lang="fr">Protection des obtentions végétales (variétés végétales)</text>
 		<text lang="it">Protezione delle varietà vegetali</text>
 		<additional_input>False</additional_input>
@@ -4763,7 +4434,6 @@
 		<order>5</order>
 		<text lang="en">Patents</text>
 		<text lang="de">Patente</text>
-		<text lang="es">Patentes</text>
 		<text lang="fr">Brevets</text>
 		<text lang="it">Brevetti</text>
 		<additional_input>False</additional_input>
@@ -4777,7 +4447,6 @@
 		<order>6</order>
 		<text lang="en">Semiconductor protection or protection of topographies</text>
 		<text lang="de">Halbleiterschutz bzw. Schutz von Topografien</text>
-		<text lang="es">Protección de semiconductores o protección de topografías</text>
 		<text lang="fr">Protection des sémiconducteurs ou protection des topographies</text>
 		<text lang="it">Protezione dei semiconduttori o protezione delle topografie</text>
 		<additional_input>False</additional_input>
@@ -4791,7 +4460,6 @@
 		<order>7</order>
 		<text lang="en">Supplementary Protection Certificates</text>
 		<text lang="de">Ergänzende Schutzzertifikate</text>
-		<text lang="es">Certificados de protección complementaria</text>
 		<text lang="fr">Certificats de Protection Supplémentaires</text>
 		<text lang="it">Certificati di protezione supplementari</text>
 		<additional_input>False</additional_input>
@@ -4805,7 +4473,6 @@
 		<order>8</order>
 		<text lang="en">Utility models</text>
 		<text lang="de">Gebrauchsmuster</text>
-		<text lang="es">Modelos de utilidad</text>
 		<text lang="fr">Modèles d'utilité</text>
 		<text lang="it">Modelli di utilizzo</text>
 		<additional_input>False</additional_input>
@@ -4819,7 +4486,6 @@
 		<order>9</order>
 		<text lang="en">Trademark</text>
 		<text lang="de">Markenrecht</text>
-		<text lang="es">Marca comercial</text>
 		<text lang="fr">Marque déposée</text>
 		<text lang="it">Marchio depositato</text>
 		<additional_input>False</additional_input>
@@ -4833,7 +4499,6 @@
 		<order>10</order>
 		<text lang="en">Other</text>
 		<text lang="de">Andere</text>
-		<text lang="es">Otros</text>
 		<text lang="fr">Autres</text>
 		<text lang="it">Altri</text>
 		<additional_input>True</additional_input>
@@ -4847,7 +4512,6 @@
 		<order>10</order>
 		<text lang="en">No</text>
 		<text lang="de">Nein</text>
-		<text lang="es">No</text>
 		<text lang="fr">Non</text>
 		<text lang="it">No</text>
 		<additional_input>False</additional_input>
@@ -4868,7 +4532,6 @@
 		<order>1</order>
 		<text lang="en">Yes, internally with everyone, as long as they don't pass on the code externally</text>
 		<text lang="de">Ja, intern mit allen, solange sie den Code nicht veröffentlichen oder nach außen weitergeben</text>
-		<text lang="es">Sí, internamente con todos, siempre que no pasen el código externamente</text>
 		<text lang="fr">Oui, en interne avec tout le monde, tant qu'ils ne transmettent pas le code en externe</text>
 		<text lang="it">Sì, internamente con tutti, purché non rendano pubblico il codice</text>
 		<additional_input>False</additional_input>
@@ -4882,7 +4545,6 @@
 		<order>2</order>
 		<text lang="en">Yes, externally limited with individual approval</text>
 		<text lang="de">Ja, extern in begrenztem Umfang mit individueller Freigabe</text>
-		<text lang="es">Sí, limitado externamente con aprobación individual</text>
 		<text lang="fr">Oui, limité en externe avec approbation individuelle</text>
 		<text lang="it">Sì, esternamente in una cerchia ristretta con approvazione individuale</text>
 		<additional_input>False</additional_input>
@@ -4896,7 +4558,6 @@
 		<order>3</order>
 		<text lang="en">Yes, externally for everyone</text>
 		<text lang="de">Ja, extern für alle</text>
-		<text lang="es">Sí, externamente para todos</text>
 		<text lang="fr">Oui, en externe pour tout le monde</text>
 		<text lang="it">Sì, esternamente per tutti</text>
 		<additional_input>False</additional_input>
@@ -4910,7 +4571,6 @@
 		<order>4</order>
 		<text lang="en">No</text>
 		<text lang="de">Nein</text>
-		<text lang="es">No</text>
 		<text lang="fr">Non</text>
 		<text lang="it">No</text>
 		<additional_input>False</additional_input>
@@ -4931,7 +4591,6 @@
 		<order>1</order>
 		<text lang="en">Simple copying</text>
 		<text lang="de">Einfaches Kopieren</text>
-		<text lang="es">Copia simple</text>
 		<text lang="fr">Copie simple</text>
 		<text lang="it">Copia semplice</text>
 		<additional_input>False</additional_input>
@@ -4945,7 +4604,6 @@
 		<order>2</order>
 		<text lang="en">Version control system</text>
 		<text lang="de">Versionskontrollsystem</text>
-		<text lang="es">Sistema de control de versiones</text>
 		<text lang="fr">Système de contrôle de version</text>
 		<text lang="it">Sistema di controllo di versione</text>
 		<additional_input>True</additional_input>
@@ -4959,7 +4617,6 @@
 		<order>3</order>
 		<text lang="en">Other</text>
 		<text lang="de">Sonstiges</text>
-		<text lang="es">Otro</text>
 		<text lang="fr">Autre</text>
 		<text lang="it">Altro</text>
 		<additional_input>True</additional_input>
@@ -4973,7 +4630,6 @@
 		<order>4</order>
 		<text lang="en">Not yet decided</text>
 		<text lang="de">Noch nicht entschieden</text>
-		<text lang="es">Aún no se ha decidido</text>
 		<text lang="fr">Pas encore décidé</text>
 		<text lang="it">Non ancora deciso</text>
 		<additional_input>False</additional_input>
@@ -4994,7 +4650,6 @@
 		<order>1</order>
 		<text lang="en">Yes</text>
 		<text lang="de">Ja</text>
-		<text lang="es">Sí</text>
 		<text lang="fr">Oui</text>
 		<text lang="it">Sì</text>
 		<additional_input>True</additional_input>
@@ -5008,7 +4663,6 @@
 		<order>2</order>
 		<text lang="en">No</text>
 		<text lang="de">Nein</text>
-		<text lang="es">No</text>
 		<text lang="fr">Non</text>
 		<text lang="it">No</text>
 		<additional_input>False</additional_input>
@@ -5022,7 +4676,6 @@
 		<order>3</order>
 		<text lang="en">Not yet</text>
 		<text lang="de">Noch nicht</text>
-		<text lang="es">No todavía</text>
 		<text lang="fr">Pas encore</text>
 		<text lang="it">Non ancora</text>
 		<additional_input>False</additional_input>
@@ -5043,7 +4696,6 @@
 		<order>1</order>
 		<text lang="en">Yes</text>
 		<text lang="de">Ja</text>
-		<text lang="es">Sí</text>
 		<text lang="fr">Oui</text>
 		<text lang="it">Sì</text>
 		<additional_input>True</additional_input>
@@ -5057,7 +4709,6 @@
 		<order>2</order>
 		<text lang="en">No</text>
 		<text lang="de">Nein</text>
-		<text lang="es">No</text>
 		<text lang="fr">Non</text>
 		<text lang="it">No</text>
 		<additional_input>False</additional_input>

--- a/rdmorganiser/questions/horizon-europe.xml
+++ b/rdmorganiser/questions/horizon-europe.xml
@@ -37,7 +37,7 @@
 		<is_collection>False</is_collection>
 		<order>1</order>
 		<title lang="en">Basic information on the project</title>
-		<help lang="en">This questionnaire is intended for research projects funded by EU Horizon Europe. It is compiled according to the &lt;a href="https://ec.europa.eu/info/funding-tenders/opportunities/docs/2021-2027/horizon/temp-form/report/data-management-plan_he_en.docx" target=_blank&gt;Data Management Plan Template, Version 1.0 from May 5, 2021&lt;/a&gt;. Some of the EU questions are broken down into sub-questions. In addition, for many questions there is the option of answering the question on a database-specific basis. There is a suitable view for the output of the data management plan, which
+		<help lang="en">This questionnaire is intended for research projects funded by EU Horizon Europe. It is compiled according to the &lt;a href="https://ec.europa.eu/info/funding-tenders/opportunities/docs/2021-2027/horizon/temp-form/report/data-management-plan_he_en.docx" target=_blank&gt;Data Management Plan Template, Version 1.0 from May 5, 2021&lt;/a&gt;. Some of the EU questions are broken down into sub-questions. In addition, for many questions there is the option of answering the question on a dataset-specific basis. There is a suitable view for the output of the data management plan, which
 
 - outputs the data management plan in the deliverable form desired by the EU,
 - uses the original EU questions,
@@ -468,7 +468,7 @@ La sous-question &lt;i&gt;"et dans quel but allez-vous les réutiliser ?"&lt;/i&
 
 * quantitative online survey
 * 3D model / digital reconstruction of a stone age settlement
-* software developed within the project
+* scanning electron micrographs
 
 Please also explain whether this is a fixed data set stored at a certain point in time or whether it is created dynamically over a certain period of time.</help>
 		<text lang="en">What kind of dataset is it?</text>
@@ -479,7 +479,7 @@ Please also explain whether this is a fixed data set stored at a certain point i
 
 * quantitative Online-Befragung
 * 3D-Modellierung / digitale Rekonstruktion einer steinzeitlichen Siedlung
-* Software, die im Projekt entwickelt wird
+* rasterelektronenmikroskopische Aufnahmen
 
 Bitte erläutern Sie ergänzend, ob es sich um einen festen, zu einem bestimmten Zeitpunkt gespeicherten Datensatz handelt oder ob dieser dynamisch also laufend über einen bestimmten Zeitraum entsteht.</help>
 		<text lang="de">Um was für einen Datensatz handelt es sich?</text>
@@ -766,16 +766,14 @@ Si prega di spiegare anche se la raccolta di dati è fissa e memorizzata in un c
 		<verbose_name_plural lang="it"/>
 		<default_option/>
 		<default_external_id/>
-		<widget_type>checkbox</widget_type>
+		<widget_type>textarea</widget_type>
 		<value_type>text</value_type>
 		<maximum/>
 		<minimum/>
 		<step/>
 		<unit/>
 		<width/>
-		<optionsets>
-			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/dataset_origin"/>
-		</optionsets>
+		<optionsets/>
 		<conditions/>
 	</question>
 	<question dc:uri="https://rdmorganiser.github.io/terms/questions/horizon-europe/data_summary/provenance/creator_name">
@@ -900,23 +898,23 @@ Si prega di spiegare anche se la raccolta di dati è fissa e memorizzata in un c
 		<is_collection>True</is_collection>
 		<is_optional>False</is_optional>
 		<order>4</order>
-		<help lang="en">It is important to set the fundamental course as to whether or not the data will be permitted for reuse. Of course, the potential for subsequent use can not be the sole decision criterion, but legal impediments, such as Privacy, copyright and business secrets must be taken into account. Otherwise, consider the re-use potential against the disadvantages, e.g. a decrease in the readiness to participate and the expected extra effort of a data publication.</help>
-		<text lang="en">Which individuals, groups or institutions could be interested in re-using this dataset? What are possible scenarios?</text>
+		<help lang="en">It is important to set the fundamental course as to whether or not the data will be permitted for reuse. Of course, the potential for subsequent use can not be the sole decision criterion, but legal impediments, such as privacy, copyright and business secrets must be taken into account. Otherwise, consider the re-use potential against the disadvantages, e.g. a decrease in the readiness to participate and the expected extra effort of a data publication.</help>
+		<text lang="en">Which individuals, groups or institutions could be interested in re-using this dataset?</text>
 		<default_text lang="en"/>
 		<verbose_name lang="en"/>
 		<verbose_name_plural lang="en"/>
 		<help lang="de">Wichtig ist die grundsätzliche Weichenstellung, ob die Daten zur Nachnutzung zugelassen werden oder nicht. Selbstverständlich kann das Nachnutzungspotential dabei nicht alleiniges Entscheidungskriterium sein, sondern rechtliche Hinderungsgründe, wie z.B. Datenschutz, Urheberrecht und die Wahrung von Geschäftsgeheimnissen, müssen berücksichtigt werden. Wägen Sie ansonsten das Nachnutzungspotential gegen die Nachteile ab, beispielsweise gegen ein Absinken der Teilnahmebereitschaft und den zu erwartenden Mehraufwand einer Datenveröffentlichung.</help>
-		<text lang="de">Für welche Personen, Gruppen oder Institutionen könnte dieser Datensatz (für die Nachnutzung) von Interesse sein? Welche Konsequenzen hat das Nachnutzungspotential später für die Bereitstellung der Daten?</text>
+		<text lang="de">Für welche Personen, Gruppen oder Institutionen könnte dieser Datensatz (für die Nachnutzung) von Interesse sein?</text>
 		<default_text lang="de"/>
 		<verbose_name lang="de"/>
 		<verbose_name_plural lang="de"/>
 		<help lang="fr">C'est important de prendre une décision raisonnée, si les données doivent être partagées pour la réutilisation ou non. Bien sûr le potentiel pour la réutilisation ne peut pas être le seul critère pour la décision, mais on doit tenir compte aussi de restrictions légales, comme la sauvegarde de la vie privée, de la propriété intellectuelle et des secrets industriels. Dans les autres cas, le potentiel pour la réutilisation doit être pesé contre les désavantage, par exemple une diminution dans la disponibilité à coopérer où l'effort additionel prévu dû à la publication des données.</help>
-		<text lang="fr">Quels individus, groupes ou institutions pourraient être intéressés à réutiliser ce jeu de données?? Quels sont les scénarios possibles??</text>
+		<text lang="fr">Quels individus, groupes ou institutions pourraient être intéressés à réutiliser ce jeu de données??</text>
 		<default_text lang="fr"/>
 		<verbose_name lang="fr"/>
 		<verbose_name_plural lang="fr"/>
 		<help lang="it">È importante prendere una decisione ragionata, se i dati devono essere condivisi per il riutilizzo oppure no. Ovviamente, il potenziale per il riutilizzo non può essere l'unico criterio alla base della decisione, ma bisogna tenere conto anche di restrizioni legali, tra cui la privacy, la proprietà intellettuale e il segreto industriale. Escludendo questi casi, il potenziale per il riutilizzo va soppesato di fronte a possibili svantaggi, per esempio una diminuzione della disponibilità alla collaborazione e il prevedibile lavoro aggiuntivo dovuto al processo di pubblicazione.</help>
-		<text lang="it">Quali persone, categorie o istituzioni potrebbero essere interessate al riutilizzo di questa raccolta di dati? Quali sono gli scenari possibili?</text>
+		<text lang="it">Quali persone, categorie o istituzioni potrebbero essere interessate al riutilizzo di questa raccolta di dati?</text>
 		<default_text lang="it"/>
 		<verbose_name lang="it"/>
 		<verbose_name_plural lang="it"/>
@@ -1748,22 +1746,22 @@ Les bénéficiaires d'Horizon Europe doivent garantir un accès ouvert aux donn�
 		<is_collection>False</is_collection>
 		<is_optional>False</is_optional>
 		<order>5</order>
-		<help lang="en">One possible description: &lt;a href="https://wellcome.org/sites/default/files/governance-of-data-access-annexes-eagda-jun15.pdf" target="_blank" /&gt;</help>
+		<help lang="en"></help>
 		<text lang="en">If there are any restrictions on the re-use of this dataset, please explain why.</text>
 		<default_text lang="en"/>
 		<verbose_name lang="en"/>
 		<verbose_name_plural lang="en"/>
-		<help lang="de">Eine mögliche Beschreibung: &lt;a href="https://wellcome.org/sites/default/files/governance-of-data-access-annexes-eagda-jun15.pdf" target="_blank" /&gt;</help>
+		<help lang="de"></help>
 		<text lang="de">Sollte die Nachnutzung dieses Datensatzes Einschränkungen unterliegen, erläutern Sie bitte die Gründe.</text>
 		<default_text lang="de"/>
 		<verbose_name lang="de"/>
 		<verbose_name_plural lang="de"/>
-		<help lang="fr">Une description possible : &lt;a href="https://wellcome.org/sites/default/files/governance-of-data-access-annexes-eagda-jun15.pdf" target="_blank" /&gt;</help>
+		<help lang="fr"></help>
 		<text lang="fr">S'il existe des restrictions sur la réutilisation de ce jeu de données, veuillez expliquer pourquoi.</text>
 		<default_text lang="fr"/>
 		<verbose_name lang="fr"/>
 		<verbose_name_plural lang="fr"/>
-		<help lang="it">Una descrizione possibile: &lt;a href="https://wellcome.org/sites/default/files/governance-of-data-access-annexes-eagda-jun15.pdf" target="_blank" /&gt;</help>
+		<help lang="it"></help>
 		<text lang="it">Se ci sono restrizioni sul riutilizzo di questa raccolta di dati, si prega di giustificarle.</text>
 		<default_text lang="it"/>
 		<verbose_name lang="it"/>
@@ -1909,17 +1907,15 @@ Les bénéficiaires d'Horizon Europe doivent garantir un accès ouvert aux donn�
 
 - &lt;i&gt;Will metadata be made openly available and licenced under a public domain dedication CC0, as per the Grant Agreement? If not, please clarify why. Will metadata contain information to enable the user to access the data?&lt;/i&gt;
 
-- &lt;i&gt;If an embargo is applied to give time to publish or seek protection of the intellectual property (e.g. patents), specify why and how long this will apply, bearing in mind that research data should be made available as soon as possible.&lt;/i&gt;
+- &lt;i&gt;How long will the data remain available and findable? Will metadata be guaranteed to remain available after data are no longer available?&lt;/i&gt;
 
-- &lt;i&gt;How long will the data remain available and findable? Will metadata be guaranteed to remain available after data are no longer available?&lt;/i&gt;</help>
+- &lt;i&gt;Will documentation or reference about any software be needed to access or read the data be included? Will it be possible to include the relevant software (e.g. in open source code)?&lt;/i&gt;</help>
 		<verbose_name lang="en">dataset</verbose_name>
 		<verbose_name_plural lang="en">datasets</verbose_name_plural>
 		<title lang="de">Zugänglichkeit: Metadaten</title>
 		<help lang="de">&lt;a href="https://ec.europa.eu/info/funding-tenders/opportunities/docs/2021-2027/horizon/temp-form/report/data-management-plan_he_en.docx" target=_blank&gt;Originalfragen:&lt;/a&gt;
 
 - &lt;i&gt;Will metadata be made openly available and licenced under a public domain dedication CC0, as per the Grant Agreement? If not, please clarify why. Will metadata contain information to enable the user to access the data?&lt;/i&gt;
-
-- &lt;i&gt;If an embargo is applied to give time to publish or seek protection of the intellectual property (e.g. patents), specify why and how long this will apply, bearing in mind that research data should be made available as soon as possible.&lt;/i&gt;
 
 - &lt;i&gt;How long will the data remain available and findable? Will metadata be guaranteed to remain available after data are no longer available?&lt;/i&gt;
 
@@ -1930,7 +1926,6 @@ Les bénéficiaires d'Horizon Europe doivent garantir un accès ouvert aux donn�
 		<help lang="fr">&lt;a href="https://ec.europa.eu/info/funding-tenders/opportunities/docs/2021-2027/horizon/temp-form/report/data-management-plan_he_en.docx" target=_blank&gt;Questions initiales :&lt;/a&gt;
 
 - &lt;i&gt;Les métadonnées seront-elles rendues librement accessibles et concédées sous une licence de domaine public CC0, conformément à l'accord de subvention ? Si non, veuillez préciser pourquoi. Les métadonnées contiendront-elles des informations nécessaire à l'accès aux données ?&lt;/i&gt;
-- &lt;i&gt;Si un embargo est appliqué pour donner le temps de publier ou de demander la protection de la propriété intellectuelle (par exemple, des brevets), précisez la durée et la raison, en gardant à l'esprit que les données de recherche doivent être mises à disposition dès que possible. &lt;/i&gt;
 - &lt;i&gt;Combien de temps les données resteront-elles disponibles et trouvables ? Les métadonnées resteront-elles disponibles une fois que les données ne seront plus disponibles ?&lt;/i&gt;</help>
 		<verbose_name lang="fr">jeu de données</verbose_name>
 		<verbose_name_plural lang="fr">jeux de données</verbose_name_plural>
@@ -2385,8 +2380,8 @@ A qualified reference is a cross-reference that explains its intent. For example
 		<default_text lang="en"/>
 		<verbose_name lang="en"/>
 		<verbose_name_plural lang="en"/>
-		<help lang="de">Ein qualifizierter Verweis ist ein Querverweis, der seine Absicht erklärt. Zum Beispiel ist "X ist Regulator von Y" eine viel qualifiziertere Referenz als "X ist mit Y verbunden", oder "X siehe auch Y". Ziel ist es daher, möglichst viele sinnvolle Verknüpfungen zwischen (Meta-)Datenressourcen zu schaffen, um das Kontextwissen über die Daten zu bereichern.</help>
-		<text lang="de">Werden Ihre Daten geeignete Verweise auf andere Daten enthalten (z. B. auf andere Daten aus Ihrem Projekt oder auf Datensätze aus früheren Forschungsarbeiten)?</text>
+		<help lang="de">Ein qualifizierte Referenz ist ein Querverweis, der seine Absicht erklärt. Zum Beispiel ist "X ist Regulator von Y" eine viel qualifiziertere Referenz als "X ist mit Y verbunden", oder "X siehe auch Y". Ziel ist es daher, möglichst viele sinnvolle Verknüpfungen zwischen (Meta-)Datenressourcen zu schaffen, um das Kontextwissen über die Daten zu bereichern.</help>
+		<text lang="de">Werden Ihre Daten qualifizierte Referenzen auf andere Daten enthalten (z. B. auf andere Daten aus Ihrem Projekt oder auf Datensätze aus früheren Forschungsarbeiten)?</text>
 		<default_text lang="de"/>
 		<verbose_name lang="de"/>
 		<verbose_name_plural lang="de"/>
@@ -3405,7 +3400,7 @@ Si ce plan de gestion des données est généré à l'aide de la vue associée, 
 		<verbose_name lang="en"/>
 		<verbose_name_plural lang="en"/>
 		<help lang="de"/>
-		<text lang="de">Wie lange müssen die Daten aufbewahrt werden?</text>
+		<text lang="de">Wie lange werden die Daten aufbewahrt werden?</text>
 		<default_text lang="de"/>
 		<verbose_name lang="de"/>
 		<verbose_name_plural lang="de"/>
@@ -3474,7 +3469,7 @@ Si ce plan de gestion des données est généré à l'aide de la vue associée, 
 		<default_text lang="en"/>
 		<verbose_name lang="en"/>
 		<verbose_name_plural lang="en"/>
-		<help lang="de">Beispiele: Grundlage einer Publikation; Potenzial für Nachnutzung; rechtliche oder vertragliche Auflagen; gesellschaftliche oder politisch Relevanz; Qualitätserwägungen; Wiederherstellbarkeit; usw.</help>
+		<help lang="de">Beispiele: Grundlage einer Publikation; Potenzial für Nachnutzung; rechtliche oder vertragliche Auflagen; gesellschaftliche oder politische Relevanz; Qualitätserwägungen; Wiederherstellbarkeit; usw.</help>
 		<text lang="de">Auf Basis welcher Kriterien / Regeln werden die Daten zur Archivierung (nach Projektende) ausgesucht?</text>
 		<default_text lang="de"/>
 		<verbose_name lang="de"/>
@@ -4261,12 +4256,6 @@ Auf diese beiden Fragen beziehen sich alle Detailfragen bis zum Ende des Abschni
 		<verbose_name_plural lang="en"/>
 		<help lang="de">Daten oder Software können Urheber- oder anderen Schutzrechten unterliegen. Die Rechtslage kann selbst in der EU von Land zu Land erheblich abweichen. In Deutschland sind nach dem Urheberrechtsgesetz (UrhG) Werke der Literatur, Wissenschaft und Kunst, die eine "persönliche geistige Schöpfung" darstellen, urheberrechtlich geschützt. Der urheberrechtliche Schutz erlischt 70 Jahre nach dem Tod der bzw. des Urheberin/s. Reine Daten, z.B. Messdaten oder Surveydaten, aber auch Metadaten (bis auf ggf. "beschreibende" Metadaten) sind hingegen nicht schutzfähig. In § 2 nennt das UrhG folgende geschützte Werkarten, wobei die Aufzählung nicht abschließend ist:
 
-
-
-
-
-																							  
-
  * Sprachwerke, wie Schriftwerke, Reden und Computerprogramme
  * Werke der Musik
  * pantomimische Werke einschließlich Werke der Tanzkunst
@@ -4274,7 +4263,7 @@ Auf diese beiden Fragen beziehen sich alle Detailfragen bis zum Ende des Abschni
  * Lichtbildwerke einschließlich der Werke, die ähnlich wie Lichtbildwerke geschaffen werden
  * Darstellungen wissenschaftlicher oder technischer Art wie Zeichnungen, Pläne, Karten, Skizzen, Tabellen und plastische Darstellungen.
 
- Nach § 3 sind auch "Übersetzungen und andere Bearbeitungen" von Werken geschützt, die persönliche geistige Schöpfungen des Bearbeiters sind". Schließlich sind nach § 4 auch Sammelwerke und Datenbankwerke geschützt, was im Bereich Forschungsdaten durchaus relevant sein kann. Sammelbankwerke werden dabei definiert als "Sammlungen von Werken, Daten oder anderen unabhängigen Elementen, die aufgrund der Auswahl oder Anordnung der Elemente eine persönliche geistige Schöpfung sind". Bei einem "Datenbankwerk im Sinne des Gesetzes" handelt es sich um ein "Sammelwerk, dessen Elemente systematisch oder methodisch angeordnet und einzeln mit Hilfe elektronischer Mittel oder auf andere Weise zugänglich sind". Weitere relevante Schutzrechte können gewerbliche Schutzrechte wie Patente, Gebrauchsmuster, Sortenschutz [bei Pflanzenzüchtungen], Halbleiterschutz, Marken, geographische Herkunftsangaben, eingetragene Designs oder geschäftliche Bezeichnungen sein.</help>
+ Nach § 3 sind auch "Übersetzungen und andere Bearbeitungen" von Werken geschützt, die persönliche geistige Schöpfungen des Bearbeiters sind". Schließlich sind nach § 4 auch Sammelwerke und Datenbankwerke geschützt, was im Bereich Forschungsdaten durchaus relevant sein kann. Sammelwerke werden dabei definiert als "Sammlungen von Werken, Daten oder anderen unabhängigen Elementen, die aufgrund der Auswahl oder Anordnung der Elemente eine persönliche geistige Schöpfung sind". Bei einem "Datenbankwerk im Sinne des Gesetzes" handelt es sich um ein "Sammelwerk, dessen Elemente systematisch oder methodisch angeordnet und einzeln mit Hilfe elektronischer Mittel oder auf andere Weise zugänglich sind". Weitere relevante Schutzrechte können gewerbliche Schutzrechte wie Patente, Gebrauchsmuster, Sortenschutz [bei Pflanzenzüchtungen], Halbleiterschutz, Marken, geographische Herkunftsangaben, eingetragene Designs oder geschäftliche Bezeichnungen sein.</help>
 		<text lang="de">Werden Daten genutzt und/oder erstellt, die durch Urheber- oder verwandte Schutzrechte geschützt sind?</text>
 		<default_text lang="de"/>
 		<verbose_name lang="de"/>
@@ -4330,7 +4319,9 @@ Auf diese beiden Fragen beziehen sich alle Detailfragen bis zum Ende des Abschni
 		<help lang="it"/>
 		<verbose_name lang="it">raccolta di dati</verbose_name>
 		<verbose_name_plural lang="it">raccolte di dati</verbose_name_plural>
-		<conditions/>
+		<conditions>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/intellectual_property_rights"/>
+		</conditions>
 	</questionset>
 	<question dc:uri="https://rdmorganiser.github.io/terms/questions/horizon-europe/ethics/intellectual-property-rights-dataset/copyrights">
 		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
@@ -4548,7 +4539,7 @@ Dans ce qui suit, vous disposerez d'un espace jusqu'à la fin du questionnaire p
 		<questionset/>
 		<is_collection>True</is_collection>
 		<order>2</order>
-		<title lang="en">project partners</title>
+		<title lang="en">Project partners</title>
 		<help lang="en"/>
 		<verbose_name lang="en">project partner</verbose_name>
 		<verbose_name_plural lang="en">project partners</verbose_name_plural>
@@ -4577,7 +4568,7 @@ Dans ce qui suit, vous disposerez d'un espace jusqu'à la fin du questionnaire p
 		<is_optional>False</is_optional>
 		<order>0</order>
 		<help lang="en">Please insert the name of project partner in detail.</help>
-		<text lang="en">project partner</text>
+		<text lang="en">Project partner</text>
 		<default_text lang="en"/>
 		<verbose_name lang="en"/>
 		<verbose_name_plural lang="en"/>
@@ -4627,7 +4618,7 @@ Dans ce qui suit, vous disposerez d'un espace jusqu'à la fin du questionnaire p
 		<verbose_name_plural lang="en"/>
 		<help lang="de">Immer mehr Hochschulen und wissenschaftliche Einrichtungen verabschieden Leitlinien oder Richtlinien (oft auch als "Policies" bezeichnet) zum Forschungsdatenmanagement. Diese enthalten unter anderem Empfehlungen und/oder Vorgaben zum Umgang mit Forschungsdaten, die die Wissenschaftlerinnen und Wissenschaftler der Einrichtung beachten sollten oder müssen (je nach Grad der Verbindlichkeit).
 
-Eine &lt;a href="https://www.forschungsdaten.org/index.php/Data_Policies#Institutionelle_Policies" target="_blank"&gt;Sammlung institutioneller Leitlinien deutscher Universitäten und Forschungseinrichtungen&lt;/a&gt; wird auf Forschungsdaten.org gepflegt.</help>
+Eine &lt;a href="https://www.forschungsdaten.org/index.php/Data_Policies#Institutionelle_Policies" target="_blank"&gt;Sammlung institutioneller Leitlinien deutscher Universitäten und Forschungseinrichtungen&lt;/a&gt; wird auf forschungsdaten.org gepflegt.</help>
 					 
 		<text lang="de">Gibt es an Ihrer Einrichtung Regeln oder Richtlinien zum Umgang mit den im Projekt erhobenen Forschungsdaten? Wenn ja, skizzieren Sie diese kurz und verweisen Sie ggf. auf weiterführende Informationen. Geben Sie bitte auch an, welchen Grad an Verbindlichkeit sie haben.</text>
 											

--- a/rdmorganiser/questions/horizon-europe.xml
+++ b/rdmorganiser/questions/horizon-europe.xml
@@ -2380,7 +2380,7 @@ A qualified reference is a cross-reference that explains its intent. For example
 		<default_text lang="en"/>
 		<verbose_name lang="en"/>
 		<verbose_name_plural lang="en"/>
-		<help lang="de">Ein qualifizierte Referenz ist ein Querverweis, der seine Absicht erklärt. Zum Beispiel ist "X ist Regulator von Y" eine viel qualifiziertere Referenz als "X ist mit Y verbunden", oder "X siehe auch Y". Ziel ist es daher, möglichst viele sinnvolle Verknüpfungen zwischen (Meta-)Datenressourcen zu schaffen, um das Kontextwissen über die Daten zu bereichern.</help>
+		<help lang="de">Eine qualifizierte Referenz ist ein Querverweis, der seine Absicht erklärt. Zum Beispiel ist "X ist Regulator von Y" eine viel qualifiziertere Referenz als "X ist mit Y verbunden", oder "X siehe auch Y". Ziel ist es daher, möglichst viele sinnvolle Verknüpfungen zwischen (Meta-)Datenressourcen zu schaffen, um das Kontextwissen über die Daten zu bereichern.</help>
 		<text lang="de">Werden Ihre Daten qualifizierte Referenzen auf andere Daten enthalten (z. B. auf andere Daten aus Ihrem Projekt oder auf Datensätze aus früheren Forschungsarbeiten)?</text>
 		<default_text lang="de"/>
 		<verbose_name lang="de"/>


### PR DESCRIPTION
Some issues can only be seen if you read the whole in silence... 

I have found a number of issues in our offer for Horizon Europe projects. In this pull request are my recommendations concerning the catalog horizon-europe.xml. The most important alteration is presumably the replacement of a wrongly cited original question (No. 7). The numbering follows the sequence of questions in the catalog.

1. Typing error correction in help text for question set horizon-europe/general/general "Basic information on the project": 

"In addition, for many questions there is the option of answering the question on a dataset-specific basis."

instead of

"In addition, for many questions there is the option of answering the question on a database-specific basis."


2. Replacement of example in help text for question horizon-europe/data_summary/type/data_kind "What kind of dataset is it?"

"scanning electron micrographs" // "rasterelektronenmikroskopische Aufnahmen"

instead of

"software developed within the project" // "Software, die im Projekt entwickelt wird"

Reason: European Commission (EC) classifies software into "other research output", not into research data.


3. Text area for question horizon-europe/data_summary/provenance/provenance "What is the provenance of the data?"

Reason: We don't really know which parts of data provenance are important for research data management. A description of data provenance may be detailled and needs space for longer texts. Additionally, the help text doesn't match the option set that is used now.


4. Typing error correction in help text for question horizon-europe/data_summary/data_utility/reuse_scenario "Which individuals, groups or institutions could be interested in re-using this dataset? What are possible scenarios?"

"such as privacy" instead of "such as Privacy"


5. Shortening question text for question horizon-europe/data_summary/data_utility/reuse_scenario "Which individuals, groups or institutions could be interested in re-using this dataset? What are possible scenarios?"

Deleting "What are possible scenarios?" // "Welche Konsequenzen hat das Nachnutzungspotential später für die Bereitstellung der Daten?" // "Quels sont les scénarios possibles??" // "Quali sono gli scenari possibili?"

Reason: The deleted second question doesn't match the option set, which is used for this question because entering longer texts is very uncomfortable. The second question is also not of importance for EC.


6. Deletion of help in question horizon-europe/fair_data/accessible_data/access_restrictions_explanation "If there are any restrictions on the re-use of this dataset, please explain why."

Deleted: "One possible description" (above textarea for answer)

Reason: Help text unnecessary in this manner. Hidden link cannot be clicked and the link target, a Welcome Trust document, contains very general information.


7. Wrong original question replaced in questionset horizon-europe/fair_data/accessible_metadata Accessibility: metadata

"Will documentation or reference about any software be needed to access or read the data be included? Will it be possible to include the relevant software (e.g. in open source code)?"

instead of 

"If an embargo is applied to give time to publish or seek protection of the intellectual property (e.g. patents), specify why and how long this will apply, bearing in mind that research data should be made available as soon as possible."


8. Wording in translation in question horizon-europe/fair_data/interoperable_data/qualified_references "Will your data include qualified references to other data (e.g. other data from your project, or datasets from previous research)?"

"qualifizierte Referenzen" instead of "geeignete Verweise"


9. Correction of translation in question "How long will the data be stored?"

"Wie lange werden die Daten aufbewahrt werden?"

instead of

"Wie lange müssen die Daten aufbewahrt werden?"


10. Typing error correction in help text for question horizon-europe/resources/selection/preservation__criteria "What are the criteria / rules for the selection of the data to be archived (after the end of the project)?"

"gesellschaftliche oder politische Relevanz"

instead of

"gesellschaftliche oder politisch Relevanz"


11. Typing error correction in help text for question horizon-europe/ethics/intellectual-property-rights-yesno/yesno "Does the project use and/or produce data that is protected by intellectual or industrial property rights?"

"Sammelwerke" instead of "Sammelbankwerke"


12. Enable condition in questionset horizon-europe/ethics/intellectual-property-rights-dataset "Intellectual property rights II"


13. Typing error correction in questionset horizon-europe/rdm_regulations/project-partners-partner

"Project partners" instead of "project partners"


14. Typing error correction in question horizon-europe/rdm_regulations/project-partners-partner/name

"Project partner" instead of "project partner"


15. Typing error correction in help text for question horizon-europe/rdm_regulations/project-partners-partner/rdm_policy "Does your institution have rules or guidelines for the handling of research data? If yes, please briefly outline them and refer to more detailed sources of information if necessary. Please also indicate, if the rules / guidelines are mandatory or optional."

"forschungsdaten.org" instead of "Forschungsdaten.org"