### PR TITLE
Added attribute "re-usable" for the SMP catalog

### DIFF
--- a/rdmorganiser/domain/rdmo.xml
+++ b/rdmorganiser/domain/rdmo.xml
@@ -1876,6 +1876,13 @@
 		<dc:comment>introduced by the Max Planck Digital Library to implement the Software Management Plan</dc:comment>
 		<parent dc:uri="https://rdmorganiser.github.io/terms/domain/smp"/>
 	</attribute>
+	<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/smp/re-usable">
+		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
+		<key>re-usable</key>
+		<path>smp/re-usable</path>
+		<dc:comment/>
+		<parent dc:uri="https://rdmorganiser.github.io/terms/domain/smp"/>
+	</attribute>
 	<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/smp/relation-SMP-DMP">
 		<uri_prefix>https://rdmorganiser.github.io/terms/</uri_prefix>
 		<key>relation-SMP-DMP</key>
@@ -2034,13 +2041,6 @@
 		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
 		<key>application-class</key>
 		<path>smp/application-class</path>
-		<dc:comment/>
-		<parent dc:uri="https://rdmorganiser.github.io/terms/domain/smp"/>
-	</attribute>
-	<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/smp/re-usable">
-		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
-		<key>re-usable</key>
-		<path>smp/re-usable</path>
 		<dc:comment/>
 		<parent dc:uri="https://rdmorganiser.github.io/terms/domain/smp"/>
 	</attribute>

--- a/rdmorganiser/domain/rdmo.xml
+++ b/rdmorganiser/domain/rdmo.xml
@@ -2037,4 +2037,11 @@
 		<dc:comment/>
 		<parent dc:uri="https://rdmorganiser.github.io/terms/domain/smp"/>
 	</attribute>
+	<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/smp/re-usable">
+		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
+		<key>re-usable</key>
+		<path>smp/re-usable</path>
+		<dc:comment/>
+		<parent dc:uri="https://rdmorganiser.github.io/terms/domain/smp"/>
+	</attribute>
 </rdmo>


### PR DESCRIPTION
This attribut is needed for the question https://rdmorganiser.github.io/terms/questions/smp/technical/preservation/re-usable in the SMP-questions catalog but didn't exist yet.