### PR TITLE
Fix: removed invisible UTF8 characters that cause an import error if …

### DIFF
--- a/shared/nfdi4ing/NFDI4Ing_template/NFDI4Ing_options.xml
+++ b/shared/nfdi4ing/NFDI4Ing_template/NFDI4Ing_options.xml
@@ -136,7 +136,7 @@
         <dc:comment/>
         <optionset dc:uri="https://rdmo.nfdi4ing.de/terms/options/NFDI_ds_what"/>
         <order>11</order>
-        <text lang="en">Stream data (e.g. the continuously supplied values ​​of a temperature sensor)</text>
+        <text lang="en">Stream data (e.g. the continuously supplied values of a temperature sensor)</text>
         <text lang="de">Streamdaten (z.B. die kontinuierlich gelieferten Werte eines Temperatursensors)</text>
         <additional_input>False</additional_input>
     </option>


### PR DESCRIPTION
…the target db table options_option has the default charset latin1.

(Two occurrences of U+200B Zero Width Space character in the English version of text for "Stream data...")