### PR TITLE
MAUS Updates

### DIFF
--- a/rdmorganiser/questions/questions-smp-subset.xml
+++ b/rdmorganiser/questions/questions-smp-subset.xml
@@ -1,0 +1,917 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdmo xmlns:dc="http://purl.org/dc/elements/1.1/" created="2026-01-08T10:07:30.568071+01:00" required="2.1.0" version="2.3.2">
+	<catalog dc:uri="https://rdmorganiser.github.io/terms/questions/smp">
+		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
+		<uri_path>smp</uri_path>
+		<dc:comment>This software project management catalogue was developed by the Max Planck Digital Library in 2022. Thanks to all our team colleagues for their support.
+This SMP template was inspired by some documentation, specially:
+* https://www.software.ac.uk/resources/guides/software-management-plans
+* https://opencarp.org/about/software-management-plan</dc:comment>
+		<order>98</order>
+		<title lang="en">Software Management Plan for Researchers</title>
+		<help lang="en">This catalogue is for the management of scientific software projects. It supports scientists in the development and project organisation of software developments through fifty questions in different topic blocks. This is version 3.0 of the catalogue.</help>
+		<title lang="de">Software-Management-Plan für Forschende</title>
+		<help lang="de">Dieser Katalog ist für das Management von wissenschaftlichen Software-Projekten. Er unterstützt Wissenschaftler_innen bei der Entwicklung und der Projektorganisation von Software-Entwicklungen durch fünfzig Fragen in unterschiedlichen Themenblöcken. Dies ist Version 3.0.</help>
+		<title lang="fr">Plan de gestion des logiciels pour chercheurs</title>
+		<help lang="fr">Ce catalogue est destiné à la gestion de projets de logiciels scientifiques. Il aide les scientifiques à développer et à organiser des projets de développement de logiciels grâce à cinquante questions réparties en différents blocs thématiques. Il s'agit de la version 3.0.</help>
+		<title lang="it">Piano di gestione del software per ricercatori</title>
+		<help lang="it">Questo catalogo è destinato alla gestione di progetti software scientifici. Supporta gli scienziati nello sviluppo e nell'organizzazione di progetti software con cinquanta domande in diversi blocchi tematici. Questa è la versione 3.0.</help>
+		<title lang="es">Plan de gestión del software para investigadores</title>
+		<help lang="es">Este catálogo está destinado a la gestión de proyectos de software científico. Apoya a los científicos en el desarrollo y la organización de proyectos de desarrollo de software con cincuenta preguntas en diferentes bloques temáticos. Se trata de la versión 3.0.</help>
+		<sections>
+			<section dc:uri="https://rdmorganiser.github.io/terms/questions/smp/general" order="0"/>
+			<section dc:uri="https://rdmorganiser.github.io/terms/questions/smp/technical" order="1"/>
+			<section dc:uri="https://rdmorganiser.github.io/terms/questions/smp/quality-assurance" order="2"/>
+			<section dc:uri="https://rdmorganiser.github.io/terms/questions/smp/release-and-publish" order="3"/>
+			<section dc:uri="https://rdmorganiser.github.io/terms/questions/smp/legal-and-ethics" order="4"/>
+		</sections>
+	</catalog>
+	<section dc:uri="https://rdmorganiser.github.io/terms/questions/smp/general">
+		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
+		<uri_path>smp/general</uri_path>
+		<dc:comment/>
+		<title lang="en">General</title>
+		<title lang="de">Allgemein</title>
+		<title lang="fr"/>
+		<title lang="it"/>
+		<title lang="es"/>
+		<pages>
+			<page dc:uri="https://rdmorganiser.github.io/terms/questions/smp/general/topic" order="0"/>
+			<page dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner" order="1"/>
+			<page dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-funding" order="2"/>
+			<page dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/schedule" order="3"/>
+			<page dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-management" order="4"/>
+			<page dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/software-requirements" order="5"/>
+		</pages>
+	</section>
+	<page dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner">
+		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
+		<uri_path>smp/general/project-partner</uri_path>
+		<dc:comment/>
+		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/partner/id"/>
+		<is_collection>True</is_collection>
+		<title lang="en">Contributor(s)</title>
+		<help lang="en"/>
+		<verbose_name lang="en"/>
+		<title lang="de">Beitragende</title>
+		<help lang="de"/>
+		<verbose_name lang="de"/>
+		<title lang="fr"/>
+		<help lang="fr"/>
+		<verbose_name lang="fr"/>
+		<title lang="it"/>
+		<help lang="it"/>
+		<verbose_name lang="it"/>
+		<title lang="es"/>
+		<help lang="es"/>
+		<verbose_name lang="es"/>
+		<questionsets>
+			<questionset dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner/employment" order="7"/>
+		</questionsets>
+		<questions>
+			<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner/type" order="0"/>
+			<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner/orcid-autocomplete" order="1"/>
+			<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner/family-name" order="2"/>
+			<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner/given-name" order="3"/>
+			<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner/name" order="4"/>
+			<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner/orcid" order="5"/>
+			<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner/website" order="6"/>
+		</questions>
+		<conditions>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/application-class-2"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/application-class-3"/>
+		</conditions>
+	</page>
+	<questionset dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner/employment">
+		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
+		<uri_path>smp/general/project-partner/employment</uri_path>
+		<dc:comment/>
+		<attribute/>
+		<is_collection>True</is_collection>
+		<title lang="en">Role(s) and Affiliation(s)</title>
+		<help lang="en"/>
+		<verbose_name lang="en"/>
+		<title lang="de">Rolle(n) und Affiliation(en)</title>
+		<help lang="de"/>
+		<verbose_name lang="de"/>
+		<title lang="fr"/>
+		<help lang="fr"/>
+		<verbose_name lang="fr"/>
+		<title lang="it"/>
+		<help lang="it"/>
+		<verbose_name lang="it"/>
+		<title lang="es"/>
+		<help lang="es"/>
+		<verbose_name lang="es"/>
+		<questionsets/>
+		<questions>
+			<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner/role" order="0"/>
+			<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner/affiliation/ror-autocomplete" order="1"/>
+			<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner/affiliation" order="2"/>
+			<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner/affiliation/ror_id" order="3"/>
+		</questions>
+		<conditions/>
+	</questionset>
+	<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner/role">
+		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
+		<uri_path>smp/general/project-partner/role</uri_path>
+		<dc:comment/>
+		<attribute dc:uri="https://rdmo.mpdl.mpg.de/terms/domain/project/partner/role"/>
+		<is_collection>False</is_collection>
+		<is_optional>False</is_optional>
+		<help lang="en"/>
+		<text lang="en">Role</text>
+		<default_text lang="en"/>
+		<verbose_name lang="en"/>
+		<help lang="de"/>
+		<text lang="de">Rolle</text>
+		<default_text lang="de"/>
+		<verbose_name lang="de"/>
+		<help lang="fr"/>
+		<text lang="fr"/>
+		<default_text lang="fr"/>
+		<verbose_name lang="fr"/>
+		<help lang="it"/>
+		<text lang="it"/>
+		<default_text lang="it"/>
+		<verbose_name lang="it"/>
+		<help lang="es"/>
+		<text lang="es"/>
+		<default_text lang="es"/>
+		<verbose_name lang="es"/>
+		<default_option/>
+		<default_external_id/>
+		<widget_type>text</widget_type>
+		<value_type>text</value_type>
+		<maximum/>
+		<minimum/>
+		<step/>
+		<unit/>
+		<width/>
+		<optionsets/>
+		<conditions/>
+	</question>
+	<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner/affiliation/ror-autocomplete">
+		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
+		<uri_path>smp/general/project-partner/affiliation/ror-autocomplete</uri_path>
+		<dc:comment/>
+		<attribute dc:uri="https://rdmo.mpdl.mpg.de/terms/domain/project/partner/affiliation/ror-autocomplete"/>
+		<is_collection>False</is_collection>
+		<is_optional>True</is_optional>
+		<help lang="en">Type a name or a ROR id and choose the right organization from the matching options</help>
+		<text lang="en">ROR search</text>
+		<default_text lang="en"/>
+		<verbose_name lang="en"/>
+		<help lang="de">Geben Sie einen Namen oder eine ROR id ein und wählen Sie die richtige Organisation aus den Optionen aus</help>
+		<text lang="de">ROR-Suche</text>
+		<default_text lang="de"/>
+		<verbose_name lang="de"/>
+		<help lang="fr"/>
+		<text lang="fr"/>
+		<default_text lang="fr"/>
+		<verbose_name lang="fr"/>
+		<help lang="it"/>
+		<text lang="it"/>
+		<default_text lang="it"/>
+		<verbose_name lang="it"/>
+		<help lang="es"/>
+		<text lang="es"/>
+		<default_text lang="es"/>
+		<verbose_name lang="es"/>
+		<default_option/>
+		<default_external_id/>
+		<widget_type>select</widget_type>
+		<value_type>text</value_type>
+		<maximum/>
+		<minimum/>
+		<step/>
+		<unit/>
+		<width/>
+		<optionsets>
+			<optionset dc:uri="https://rdmo.mpdl.mpg.de/terms/options/ror-provider"/>
+		</optionsets>
+		<conditions>
+			<condition dc:uri="https://rdmo.mpdl.mpg.de/terms/conditions/partner_without_ror_id"/>
+		</conditions>
+	</question>
+	<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner/affiliation">
+		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
+		<uri_path>smp/general/project-partner/affiliation</uri_path>
+		<dc:comment/>
+		<attribute dc:uri="https://rdmo.mpdl.mpg.de/terms/domain/project/partner/affiliation"/>
+		<is_collection>False</is_collection>
+		<is_optional>False</is_optional>
+		<help lang="en"/>
+		<text lang="en">Affiliation</text>
+		<default_text lang="en"/>
+		<verbose_name lang="en"/>
+		<help lang="de"/>
+		<text lang="de">Affiliation</text>
+		<default_text lang="de"/>
+		<verbose_name lang="de"/>
+		<help lang="fr"/>
+		<text lang="fr"/>
+		<default_text lang="fr"/>
+		<verbose_name lang="fr"/>
+		<help lang="it"/>
+		<text lang="it"/>
+		<default_text lang="it"/>
+		<verbose_name lang="it"/>
+		<help lang="es"/>
+		<text lang="es"/>
+		<default_text lang="es"/>
+		<verbose_name lang="es"/>
+		<default_option/>
+		<default_external_id/>
+		<widget_type>text</widget_type>
+		<value_type>text</value_type>
+		<maximum/>
+		<minimum/>
+		<step/>
+		<unit/>
+		<width/>
+		<optionsets/>
+		<conditions/>
+	</question>
+	<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner/affiliation/ror_id">
+		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
+		<uri_path>smp/general/project-partner/affiliation/ror_id</uri_path>
+		<dc:comment/>
+		<attribute dc:uri="https://rdmo.mpdl.mpg.de/terms/domain/project/partner/affiliation/ror-id"/>
+		<is_collection>False</is_collection>
+		<is_optional>False</is_optional>
+		<help lang="en"/>
+		<text lang="en">ROR ID</text>
+		<default_text lang="en"/>
+		<verbose_name lang="en"/>
+		<help lang="de"/>
+		<text lang="de">ROR ID</text>
+		<default_text lang="de"/>
+		<verbose_name lang="de"/>
+		<help lang="fr"/>
+		<text lang="fr"/>
+		<default_text lang="fr"/>
+		<verbose_name lang="fr"/>
+		<help lang="it"/>
+		<text lang="it"/>
+		<default_text lang="it"/>
+		<verbose_name lang="it"/>
+		<help lang="es"/>
+		<text lang="es"/>
+		<default_text lang="es"/>
+		<verbose_name lang="es"/>
+		<default_option/>
+		<default_external_id/>
+		<widget_type>text</widget_type>
+		<value_type>text</value_type>
+		<maximum/>
+		<minimum/>
+		<step/>
+		<unit/>
+		<width/>
+		<optionsets/>
+		<conditions/>
+	</question>
+	<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner/type">
+		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
+		<uri_path>smp/general/project-partner/type</uri_path>
+		<dc:comment/>
+		<attribute dc:uri="https://rdmo.mpdl.mpg.de/terms/domain/project/partner/type"/>
+		<is_collection>False</is_collection>
+		<is_optional>False</is_optional>
+		<help lang="en">Following the cff schema, project contributors can be of two types: person or entity. An example entity contributor would be a research group. For more details, check the &lt;a href=&quot;https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#authors&quot;&gt;CFF Schema Guide&lt;/a&gt;.</help>
+		<text lang="en">Type</text>
+		<default_text lang="en"/>
+		<verbose_name lang="en"/>
+		<help lang="de">Nach dem cff-Schema können Projektbeitragende zwei Typen haben: Person oder Entität. Eine Beispielentität wäre eine Forschungsgruppe. Weitere Informationen finden Sie unter diesem Link: &lt;a href=&quot;https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#authors&quot;&gt;&lt;i&gt;CFF Schema Guide&lt;/i&gt;&lt;/a&gt;.</help>
+		<text lang="de">Typ</text>
+		<default_text lang="de"/>
+		<verbose_name lang="de"/>
+		<help lang="fr"/>
+		<text lang="fr"/>
+		<default_text lang="fr"/>
+		<verbose_name lang="fr"/>
+		<help lang="it"/>
+		<text lang="it"/>
+		<default_text lang="it"/>
+		<verbose_name lang="it"/>
+		<help lang="es"/>
+		<text lang="es"/>
+		<default_text lang="es"/>
+		<verbose_name lang="es"/>
+		<default_option/>
+		<default_external_id/>
+		<widget_type>radio</widget_type>
+		<value_type>option</value_type>
+		<maximum/>
+		<minimum/>
+		<step/>
+		<unit/>
+		<width/>
+		<optionsets>
+			<optionset dc:uri="https://rdmo.mpdl.mpg.de/terms/options/partner-types"/>
+		</optionsets>
+		<conditions/>
+	</question>
+	<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner/orcid-autocomplete">
+		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
+		<uri_path>smp/general/project-partner/orcid-autocomplete</uri_path>
+		<dc:comment/>
+		<attribute dc:uri="https://rdmo.mpdl.mpg.de/terms/domain/project/partner/orcid-autocomplete"/>
+		<is_collection>False</is_collection>
+		<is_optional>True</is_optional>
+		<help lang="en">Type a name and affiliation or an ORCID and choose the right person from the matching options</help>
+		<text lang="en">ORCID search</text>
+		<default_text lang="en"/>
+		<verbose_name lang="en"/>
+		<help lang="de">Geben Sie einen Namen und eine Affiliation oder eine ORCID ein und wählen Sie die richtige Person aus den Optionen aus</help>
+		<text lang="de">ORCID-Suche</text>
+		<default_text lang="de"/>
+		<verbose_name lang="de"/>
+		<help lang="fr"/>
+		<text lang="fr"/>
+		<default_text lang="fr"/>
+		<verbose_name lang="fr"/>
+		<help lang="it"/>
+		<text lang="it"/>
+		<default_text lang="it"/>
+		<verbose_name lang="it"/>
+		<help lang="es"/>
+		<text lang="es"/>
+		<default_text lang="es"/>
+		<verbose_name lang="es"/>
+		<default_option/>
+		<default_external_id/>
+		<widget_type>select</widget_type>
+		<value_type>text</value_type>
+		<maximum/>
+		<minimum/>
+		<step/>
+		<unit/>
+		<width/>
+		<optionsets>
+			<optionset dc:uri="https://rdmo.mpdl.mpg.de/terms/options/orcid-provider"/>
+		</optionsets>
+		<conditions>
+			<condition dc:uri="https://rdmo.mpdl.mpg.de/terms/conditions/partner_with_type_person"/>
+		</conditions>
+	</question>
+	<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner/family-name">
+		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
+		<uri_path>smp/general/project-partner/family-name</uri_path>
+		<dc:comment/>
+		<attribute dc:uri="https://rdmo.mpdl.mpg.de/terms/domain/project/partner/family-name"/>
+		<is_collection>False</is_collection>
+		<is_optional>False</is_optional>
+		<help lang="en"/>
+		<text lang="en">Family name(s)</text>
+		<default_text lang="en"/>
+		<verbose_name lang="en"/>
+		<help lang="de"/>
+		<text lang="de">Familienname(n)</text>
+		<default_text lang="de"/>
+		<verbose_name lang="de"/>
+		<help lang="fr"/>
+		<text lang="fr"/>
+		<default_text lang="fr"/>
+		<verbose_name lang="fr"/>
+		<help lang="it"/>
+		<text lang="it"/>
+		<default_text lang="it"/>
+		<verbose_name lang="it"/>
+		<help lang="es"/>
+		<text lang="es"/>
+		<default_text lang="es"/>
+		<verbose_name lang="es"/>
+		<default_option/>
+		<default_external_id/>
+		<widget_type>text</widget_type>
+		<value_type>text</value_type>
+		<maximum/>
+		<minimum/>
+		<step/>
+		<unit/>
+		<width/>
+		<optionsets/>
+		<conditions>
+			<condition dc:uri="https://rdmo.mpdl.mpg.de/terms/conditions/partner_with_type_person"/>
+		</conditions>
+	</question>
+	<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner/given-name">
+		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
+		<uri_path>smp/general/project-partner/given-name</uri_path>
+		<dc:comment/>
+		<attribute dc:uri="https://rdmo.mpdl.mpg.de/terms/domain/project/partner/given-name"/>
+		<is_collection>False</is_collection>
+		<is_optional>False</is_optional>
+		<help lang="en"/>
+		<text lang="en">Given name(s)</text>
+		<default_text lang="en"/>
+		<verbose_name lang="en"/>
+		<help lang="de"/>
+		<text lang="de">Rufname(n)</text>
+		<default_text lang="de"/>
+		<verbose_name lang="de"/>
+		<help lang="fr"/>
+		<text lang="fr"/>
+		<default_text lang="fr"/>
+		<verbose_name lang="fr"/>
+		<help lang="it"/>
+		<text lang="it"/>
+		<default_text lang="it"/>
+		<verbose_name lang="it"/>
+		<help lang="es"/>
+		<text lang="es"/>
+		<default_text lang="es"/>
+		<verbose_name lang="es"/>
+		<default_option/>
+		<default_external_id/>
+		<widget_type>text</widget_type>
+		<value_type>text</value_type>
+		<maximum/>
+		<minimum/>
+		<step/>
+		<unit/>
+		<width/>
+		<optionsets/>
+		<conditions>
+			<condition dc:uri="https://rdmo.mpdl.mpg.de/terms/conditions/partner_with_type_person"/>
+		</conditions>
+	</question>
+	<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner/name">
+		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
+		<uri_path>smp/general/project-partner/name</uri_path>
+		<dc:comment/>
+		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/partner/name"/>
+		<is_collection>False</is_collection>
+		<is_optional>False</is_optional>
+		<help lang="en"/>
+		<text lang="en">Name</text>
+		<default_text lang="en"/>
+		<verbose_name lang="en"/>
+		<help lang="de"/>
+		<text lang="de">Name</text>
+		<default_text lang="de"/>
+		<verbose_name lang="de"/>
+		<help lang="fr"/>
+		<text lang="fr"/>
+		<default_text lang="fr"/>
+		<verbose_name lang="fr"/>
+		<help lang="it"/>
+		<text lang="it"/>
+		<default_text lang="it"/>
+		<verbose_name lang="it"/>
+		<help lang="es"/>
+		<text lang="es"/>
+		<default_text lang="es"/>
+		<verbose_name lang="es"/>
+		<default_option/>
+		<default_external_id/>
+		<widget_type>text</widget_type>
+		<value_type>text</value_type>
+		<maximum/>
+		<minimum/>
+		<step/>
+		<unit/>
+		<width/>
+		<optionsets/>
+		<conditions>
+			<condition dc:uri="https://rdmo.mpdl.mpg.de/terms/conditions/partner_with_type_entity"/>
+		</conditions>
+	</question>
+	<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner/orcid">
+		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
+		<uri_path>smp/general/project-partner/orcid</uri_path>
+		<dc:comment/>
+		<attribute dc:uri="https://rdmo.mpdl.mpg.de/terms/domain/project/partner/orcid"/>
+		<is_collection>False</is_collection>
+		<is_optional>False</is_optional>
+		<help lang="en"/>
+		<text lang="en">ORCID</text>
+		<default_text lang="en"/>
+		<verbose_name lang="en"/>
+		<help lang="de"/>
+		<text lang="de">ORCID</text>
+		<default_text lang="de"/>
+		<verbose_name lang="de"/>
+		<help lang="fr"/>
+		<text lang="fr"/>
+		<default_text lang="fr"/>
+		<verbose_name lang="fr"/>
+		<help lang="it"/>
+		<text lang="it"/>
+		<default_text lang="it"/>
+		<verbose_name lang="it"/>
+		<help lang="es"/>
+		<text lang="es"/>
+		<default_text lang="es"/>
+		<verbose_name lang="es"/>
+		<default_option/>
+		<default_external_id/>
+		<widget_type>text</widget_type>
+		<value_type>text</value_type>
+		<maximum/>
+		<minimum/>
+		<step/>
+		<unit/>
+		<width/>
+		<optionsets/>
+		<conditions>
+			<condition dc:uri="https://rdmo.mpdl.mpg.de/terms/conditions/partner_with_type_person"/>
+		</conditions>
+	</question>
+	<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner/website">
+		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
+		<uri_path>smp/general/project-partner/website</uri_path>
+		<dc:comment/>
+		<attribute dc:uri="https://rdmo.mpdl.mpg.de/terms/domain/project/partner/website"/>
+		<is_collection>False</is_collection>
+		<is_optional>False</is_optional>
+		<help lang="en"/>
+		<text lang="en">Website</text>
+		<default_text lang="en"/>
+		<verbose_name lang="en"/>
+		<help lang="de"/>
+		<text lang="de">Webseite</text>
+		<default_text lang="de"/>
+		<verbose_name lang="de"/>
+		<help lang="fr"/>
+		<text lang="fr"/>
+		<default_text lang="fr"/>
+		<verbose_name lang="fr"/>
+		<help lang="it"/>
+		<text lang="it"/>
+		<default_text lang="it"/>
+		<verbose_name lang="it"/>
+		<help lang="es"/>
+		<text lang="es"/>
+		<default_text lang="es"/>
+		<verbose_name lang="es"/>
+		<default_option/>
+		<default_external_id/>
+		<widget_type>text</widget_type>
+		<value_type>text</value_type>
+		<maximum/>
+		<minimum/>
+		<step/>
+		<unit/>
+		<width/>
+		<optionsets/>
+		<conditions>
+			<condition dc:uri="https://rdmo.mpdl.mpg.de/terms/conditions/partner_with_type_entity"/>
+		</conditions>
+	</question>
+	<page dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-funding">
+		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
+		<uri_path>smp/general/project-funding</uri_path>
+		<dc:comment/>
+		<attribute/>
+		<is_collection>False</is_collection>
+		<title lang="en">Funding</title>
+		<short_title lang="en"/>
+		<help lang="en"/>
+		<verbose_name lang="en"/>
+		<title lang="de">Finanzierung</title>
+		<short_title lang="de"/>
+		<help lang="de"/>
+		<verbose_name lang="de"/>
+		<title lang="fr"/>
+		<short_title lang="fr"/>
+		<help lang="fr"/>
+		<verbose_name lang="fr"/>
+		<title lang="it"/>
+		<short_title lang="it"/>
+		<help lang="it"/>
+		<verbose_name lang="it"/>
+		<title lang="es"/>
+		<short_title lang="es"/>
+		<help lang="es"/>
+		<verbose_name lang="es"/>
+		<questionsets/>
+		<questions>
+			<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-funding/funding" order="0"/>
+		</questions>
+		<conditions>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/application-class-1"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/application-class-2"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/application-class-3"/>
+		</conditions>
+	</page>
+	<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-funding/funding">
+		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
+		<uri_path>smp/general/project-funding/funding</uri_path>
+		<dc:comment/>
+		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/funder"/>
+		<is_collection>False</is_collection>
+		<is_optional>False</is_optional>
+		<help lang="en">Here, for example, personnel or financial resources from the regular budget or already existing project funds can be mentioned.
+
+Scientific software is becoming increasingly important as a source of knowledge. Therefore, the development of software in a scientific context is also becoming more and more relevant for funding organisations. A software management plan can be a useful basis for applying for (partial) project funding, as software is increasingly considered worthy of funding.
+
+For further reference, we recommend these publications:
+
+* Rand et al., Visibility of Research Software Engineers in research funding, 2022, Software Sustainability Institute Blog, &lt;a href=&quot;https://www.software.ac.uk/blog/2022-06-20-visibility-research-software-engineers-research-funding&quot; target=&quot;_blank&quot;&gt;https://www.software.ac.uk/blog/2022-06-20-visibility-research-software-engineers-research-funding&lt;/a&gt;.
+* Strasser et al. (2022): 10 Simple Rules for Funding Scientific Open Source Software, &lt;a href=&quot;https://doi.org/10.5281/ZENODO.6611500&quot; target=&quot;_blank&quot;&gt;https://doi.org/10.5281/zenodo.6611500&lt;/a&gt;.</help>
+		<text lang="en">Is there existing (financial/personnel) resources or will there be specific funding for the software development?</text>
+		<default_text lang="en"/>
+		<verbose_name lang="en"/>
+		<help lang="de">Hier können beispielsweise personellen oder finanzielle Mittel aus dem regulären Haushalt oder bereits vorhandene Projektmittel erwähnt werden.
+
+Wissenschaftliche Software gewinnt als Erkenntnisgewinn zunehmend an Bedeutung. Daher wird die Entwicklung von Software im wissenschaftlichen Kontext auch für Förderorganisationen zunehmend relevanter. Ein Software-Management-Plan kann daher eine sinnvolle Grundlage für eine Beantragung von (Teil-)Projektmitteln sein, da Software zunehmend auch als förderwürdig erachtet wird.
+
+Als weiterführenden Hinweise empfehlen wir diese Publikationen:
+
+* Rand et al., Visibility of Research Software Engineers in research funding, 2022, Software Sustainability Institute Blog, &lt;a href=&quot;https://www.software.ac.uk/blog/2022-06-20-visibility-research-software-engineers-research-funding&quot; target=&quot;_blank&quot;&gt;https://www.software.ac.uk/blog/2022-06-20-visibility-research-software-engineers-research-funding&lt;/a&gt;.
+* Strasser et al. (2022): 10 Simple Rules for Funding Scientific Open Source Software, &lt;a href=&quot;https://doi.org/10.5281/ZENODO.6611500&quot; target=&quot;_blank&quot;&gt;https://doi.org/10.5281/zenodo.6611500&lt;/a&gt;.</help>
+		<text lang="de">Gibt es existierende (personellen/finanziellen) Ressourcen oder wird es eine spezielle Finanzierung für die Softwareentwicklung geben?</text>
+		<default_text lang="de"/>
+		<verbose_name lang="de"/>
+		<help lang="fr"/>
+		<text lang="fr"/>
+		<default_text lang="fr"/>
+		<verbose_name lang="fr"/>
+		<help lang="it"/>
+		<text lang="it"/>
+		<default_text lang="it"/>
+		<verbose_name lang="it"/>
+		<help lang="es"/>
+		<text lang="es"/>
+		<default_text lang="es"/>
+		<verbose_name lang="es"/>
+		<default_option/>
+		<default_external_id/>
+		<widget_type>textarea</widget_type>
+		<value_type>text</value_type>
+		<maximum/>
+		<minimum/>
+		<step/>
+		<unit/>
+		<width/>
+		<optionsets/>
+		<conditions>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/application-class-1"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/application-class-2"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/application-class-3"/>
+		</conditions>
+	</question>
+	<page dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/schedule">
+		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
+		<uri_path>smp/general/schedule</uri_path>
+		<dc:comment/>
+		<attribute/>
+		<is_collection>False</is_collection>
+		<title lang="en">Schedule</title>
+		<help lang="en"/>
+		<verbose_name lang="en"/>
+		<title lang="de">Zeitplan</title>
+		<help lang="de"/>
+		<verbose_name lang="de"/>
+		<title lang="fr"/>
+		<help lang="fr"/>
+		<verbose_name lang="fr"/>
+		<title lang="it"/>
+		<help lang="it"/>
+		<verbose_name lang="it"/>
+		<title lang="es"/>
+		<help lang="es"/>
+		<verbose_name lang="es"/>
+		<questionsets/>
+		<questions>
+			<question dc:uri="https://rdmorganiser.github.io/terms/questions/smp/general/schedule/start-date" order="1"/>
+			<question dc:uri="https://rdmorganiser.github.io/terms/questions/smp/general/schedule/end-date" order="2"/>
+		</questions>
+		<conditions>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/application-class-1"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/application-class-2"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/application-class-3"/>
+		</conditions>
+	</page>
+	<page dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-management">
+		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
+		<uri_path>smp/general/project-management</uri_path>
+		<dc:comment/>
+		<attribute/>
+		<is_collection>False</is_collection>
+		<title lang="en">Project Management</title>
+		<help lang="en"/>
+		<verbose_name lang="en"/>
+		<title lang="de">Projekt-Management</title>
+		<help lang="de"/>
+		<verbose_name lang="de"/>
+		<title lang="fr"/>
+		<help lang="fr"/>
+		<verbose_name lang="fr"/>
+		<title lang="it"/>
+		<help lang="it"/>
+		<verbose_name lang="it"/>
+		<title lang="es"/>
+		<help lang="es"/>
+		<verbose_name lang="es"/>
+		<questionsets/>
+		<questions>
+			<question dc:uri="https://rdmorganiser.github.io/terms/questions/smp/general/project-management/development-process" order="0"/>
+			<question dc:uri="https://rdmorganiser.github.io/terms/questions/smp/general/project-management/track-tasks" order="1"/>
+			<question dc:uri="https://rdmorganiser.github.io/terms/questions/smp/general/project-management/specification-sheet" order="2"/>
+		</questions>
+		<conditions>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/application-class-1"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/application-class-2"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/application-class-3"/>
+		</conditions>
+	</page>
+	<page dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/software-requirements">
+		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
+		<uri_path>smp/general/software-requirements</uri_path>
+		<dc:comment/>
+		<attribute/>
+		<is_collection>False</is_collection>
+		<title lang="en">Development Requirements</title>
+		<help lang="en"/>
+		<verbose_name lang="en"/>
+		<title lang="de">Entwicklungsanforderungen</title>
+		<help lang="de"/>
+		<verbose_name lang="de"/>
+		<title lang="fr"/>
+		<help lang="fr"/>
+		<verbose_name lang="fr"/>
+		<title lang="it"/>
+		<help lang="it"/>
+		<verbose_name lang="it"/>
+		<title lang="es"/>
+		<help lang="es"/>
+		<verbose_name lang="es"/>
+		<questionsets/>
+		<questions>
+			<question dc:uri="https://rdmorganiser.github.io/terms/questions/smp/general/software-requirements/institutional-requirements" order="0"/>
+			<question dc:uri="https://rdmorganiser.github.io/terms/questions/smp/general/software-requirements/community-requirements" order="1"/>
+		</questions>
+		<conditions>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/application-class-1"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/application-class-2"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/application-class-3"/>
+		</conditions>
+	</page>
+	<section dc:uri="https://rdmorganiser.github.io/terms/questions/smp/technical">
+		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
+		<uri_path>smp/technical</uri_path>
+		<dc:comment/>
+		<title lang="en">Technical</title>
+		<title lang="de">Technische Informationen</title>
+		<title lang="fr"/>
+		<title lang="it"/>
+		<title lang="es"/>
+		<pages>
+			<page dc:uri="https://rdmorganiser.github.io/terms/questions/smp/technical/code" order="0"/>
+			<page dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/technical/components" order="1"/>
+			<page dc:uri="https://rdmorganiser.github.io/terms/questions/smp/technical/Infrastructure" order="2"/>
+			<page dc:uri="https://rdmorganiser.github.io/terms/questions/smp/technical/preservation" order="3"/>
+			<page dc:uri="https://rdmorganiser.github.io/terms/questions/smp/technical/security" order="4"/>
+		</pages>
+	</section>
+	<page dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/technical/components">
+		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
+		<uri_path>smp/technical/components</uri_path>
+		<dc:comment/>
+		<attribute/>
+		<is_collection>False</is_collection>
+		<title lang="en">Third-Party Components and Libraries</title>
+		<help lang="en"/>
+		<verbose_name lang="en"/>
+		<title lang="de">Externe Komponenten und Bibliotheken</title>
+		<help lang="de"/>
+		<verbose_name lang="de"/>
+		<title lang="fr"/>
+		<help lang="fr"/>
+		<verbose_name lang="fr"/>
+		<title lang="it"/>
+		<help lang="it"/>
+		<verbose_name lang="it"/>
+		<title lang="es"/>
+		<help lang="es"/>
+		<verbose_name lang="es"/>
+		<questionsets/>
+		<questions>
+			<question dc:uri="https://rdmorganiser.github.io/terms/questions/smp/technical/components/external-components" order="0"/>
+			<question dc:uri="https://rdmorganiser.github.io/terms/questions/smp/technical/components/third-party-licenses" order="1"/>
+			<question dc:uri="https://rdmorganiser.github.io/terms/questions/smp/technical/components/track-external-software" order="2"/>
+			<question dc:uri="https://rdmorganiser.github.io/terms/questions/smp/technical/components/web-services" order="3"/>
+			<question dc:uri="https://rdmorganiser.github.io/terms/questions/smp/technical/components/qualified-references" order="4"/>
+		</questions>
+		<conditions/>
+	</page>
+	<page dc:uri="https://rdmorganiser.github.io/terms/questions/smp/release-and-publish/metadata">
+		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
+		<uri_path>smp/release-and-publish/metadata</uri_path>
+		<dc:comment/>
+		<attribute/>
+		<is_collection>False</is_collection>
+		<title lang="en">Metadata</title>
+		<help lang="en"/>
+		<verbose_name lang="en"/>
+		<title lang="de">Metadaten</title>
+		<help lang="de"/>
+		<verbose_name lang="de"/>
+		<title lang="fr"/>
+		<help lang="fr"/>
+		<verbose_name lang="fr"/>
+		<title lang="it"/>
+		<help lang="it"/>
+		<verbose_name lang="it"/>
+		<title lang="es"/>
+		<help lang="es"/>
+		<verbose_name lang="es"/>
+		<questionsets/>
+		<questions>
+			<question dc:uri="https://rdmorganiser.github.io/terms/questions/smp/release-and-publish/metadata/assign-metadata" order="0"/>
+			<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/release-and-publish/metadata/software-pid" order="1"/>
+		</questions>
+		<conditions/>
+	</page>
+	<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/release-and-publish/metadata/software-pid">
+		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
+		<uri_path>smp/release-and-publish/metadata/software-pid</uri_path>
+		<dc:comment/>
+		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/smp/software-pid"/>
+		<is_collection>True</is_collection>
+		<is_optional>False</is_optional>
+		<help lang="en">For long-term availability and clear allocation, it is recommended to publish the software (version) with a persistent identifier. This recommendation goes hand in hand with &lt;a href=&quot;https://doi.org/10.15497/RDA00068&quot; target=&quot;_blank&quot;&gt;FAIR4RS&lt;/a&gt; F3 and &lt;a href=&quot;https://wissenschaftliche-integritaet.de/en/code-of-conduct/cross-phase-quality-assurance/&quot; target=&quot;_blank&quot;&gt;guideline 7 in the DFG Code &quot;Guidelines for Safeguarding Good Scientific Practice&quot;&lt;/a&gt;. After &lt;a href=&quot;https://doi.org/10.15497/RDA00068&quot; target=&quot;_blank&quot;&gt;FAIR4RS&lt;/a&gt; F1.1, it may also be useful to place a separate identifier on the individual software versions or components. An example of a persistent identifier is the Digital Object Identifier (DOI). In terms of research software, for example, a GitHub/GitLab Zenodo integration can generate a citable object including DOI.</help>
+		<text lang="en">Do you give a persistent identifier for you software?</text>
+		<default_text lang="en"/>
+		<verbose_name lang="en"/>
+		<help lang="de">Für die langfristige Verfügbarkeit und die klare Zuordnung ist es empfehlenswert, die Software(-version) mit einem persistenten Identifikator zu veröffentlichen. Diese Empfehlung geht einher mit &lt;a href=&quot;https://doi.org/10.15497/RDA00068&quot; target=&quot;_blank&quot;&gt;FAIR4RS&lt;/a&gt; F3 und der &lt;a href=&quot;https://wissenschaftliche-integritaet.de/kodex/phasenubergreifende-qualitatssicherung/&quot; target=&quot;_blank&quot;&gt;Leitlinie 7 im DFG-Kodex &quot;Leitlinien zur Sicherung guter wissenschaftlicher Praxis&quot;&lt;/a&gt;. Ein Beispiel für einen persistenten Identifikator ist etwa der Digital Object Identifier (DOI). Nach &lt;a href=&quot;https://doi.org/10.15497/RDA00068&quot; target=&quot;_blank&quot;&gt;FAIR4RS&lt;/a&gt; F1.1 kann es auch sinnvoll sein auf die einzelnen Software-Versionen oder -Komponenten einen eigenen Identifier zu legen. Bezogen auf Forschungssoftware kann beispielsweise eine GitHub-/GitLab-Zenodo-Integration ein zitierfähiges Objekt samt DOI erzeugen.</help>
+		<text lang="de">Geben Sie einen dauerhaften Identifikator für Ihre Software an?</text>
+		<default_text lang="de"/>
+		<verbose_name lang="de"/>
+		<help lang="fr"/>
+		<text lang="fr"/>
+		<default_text lang="fr"/>
+		<verbose_name lang="fr"/>
+		<help lang="it"/>
+		<text lang="it"/>
+		<default_text lang="it"/>
+		<verbose_name lang="it"/>
+		<help lang="es"/>
+		<text lang="es"/>
+		<default_text lang="es"/>
+		<verbose_name lang="es"/>
+		<default_option/>
+		<default_external_id/>
+		<widget_type>checkbox</widget_type>
+		<value_type>text</value_type>
+		<maximum/>
+		<minimum/>
+		<step/>
+		<unit/>
+		<width/>
+		<optionsets>
+			<optionset dc:uri="https://rdmorganiser.github.io/terms/options/software_identifier"/>
+		</optionsets>
+		<conditions>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/application-class-1"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/application-class-2"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/application-class-3"/>
+		</conditions>
+	</question>
+	<section dc:uri="https://rdmorganiser.github.io/terms/questions/smp/legal-and-ethics">
+		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
+		<uri_path>smp/legal-and-ethics</uri_path>
+		<dc:comment/>
+		<title lang="en">Legal and Ethics</title>
+		<title lang="de">Rechtliche und ethische Fragen</title>
+		<title lang="fr"/>
+		<title lang="it"/>
+		<title lang="es"/>
+		<pages>
+			<page dc:uri="https://rdmorganiser.github.io/terms/questions/smp/legal-and-ethics/intellectual-rights" order="0"/>
+			<page dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/legal-and-ethics/license" order="1"/>
+			<page dc:uri="https://rdmorganiser.github.io/terms/questions/smp/legal-and-ethics/dual-use" order="2"/>
+		</pages>
+	</section>
+	<page dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/legal-and-ethics/license">
+		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
+		<uri_path>smp/legal-and-ethics/license</uri_path>
+		<dc:comment/>
+		<attribute/>
+		<is_collection>False</is_collection>
+		<title lang="en">License(s)</title>
+		<help lang="en"/>
+		<verbose_name lang="en"/>
+		<title lang="de">Lizenz(en)</title>
+		<help lang="de"/>
+		<verbose_name lang="de"/>
+		<title lang="fr"/>
+		<help lang="fr"/>
+		<verbose_name lang="fr"/>
+		<title lang="it"/>
+		<help lang="it"/>
+		<verbose_name lang="it"/>
+		<title lang="es"/>
+		<help lang="es"/>
+		<verbose_name lang="es"/>
+		<questionsets/>
+		<questions>
+			<question dc:uri="https://rdmorganiser.github.io/terms/questions/smp/legal-and-ethics/license/software-license" order="0"/>
+		</questions>
+		<conditions/>
+	</page>
+</rdmo>

--- a/rdmorganiser/questions/questions-smp.xml
+++ b/rdmorganiser/questions/questions-smp.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<rdmo xmlns:dc="http://purl.org/dc/elements/1.1/" created="2024-03-12T14:56:06.262241+01:00" version="2.1.3">
+<rdmo xmlns:dc="http://purl.org/dc/elements/1.1/" created="2026-01-08T10:07:30.568071+01:00" required="2.1.0" version="2.3.2">
 	<catalog dc:uri="https://rdmorganiser.github.io/terms/questions/smp">
 		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
 		<uri_path>smp</uri_path>
@@ -37,10 +37,11 @@ This SMP template was inspired by some documentation, specially:
 		<title lang="es"/>
 		<pages>
 			<page dc:uri="https://rdmorganiser.github.io/terms/questions/smp/general/topic" order="0"/>
-			<page dc:uri="https://rdmorganiser.github.io/terms/questions/smp/general/project-partner" order="1"/>
-			<page dc:uri="https://rdmorganiser.github.io/terms/questions/smp/general/schedule" order="2"/>
-			<page dc:uri="https://rdmorganiser.github.io/terms/questions/smp/general/project-management" order="3"/>
-			<page dc:uri="https://rdmorganiser.github.io/terms/questions/smp/general/software-requirements" order="4"/>
+			<page dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner" order="1"/>
+			<page dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-funding" order="2"/>
+			<page dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/schedule" order="3"/>
+			<page dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-management" order="4"/>
+			<page dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/software-requirements" order="5"/>
 		</pages>
 	</section>
 	<page dc:uri="https://rdmorganiser.github.io/terms/questions/smp/general/topic">
@@ -365,16 +366,54 @@ Folgende (ausgewählte) Plattformen können hierbei helfen:
 		<optionsets/>
 		<conditions/>
 	</question>
-	<page dc:uri="https://rdmorganiser.github.io/terms/questions/smp/general/project-partner">
-		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
+	<page dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner">
+		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
 		<uri_path>smp/general/project-partner</uri_path>
 		<dc:comment/>
-		<attribute/>
-		<is_collection>False</is_collection>
-		<title lang="en">Software Project Partner(s)</title>
+		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/partner/id"/>
+		<is_collection>True</is_collection>
+		<title lang="en">Contributor(s)</title>
 		<help lang="en"/>
 		<verbose_name lang="en"/>
-		<title lang="de">Software-Projektpartner</title>
+		<title lang="de">Beitragende</title>
+		<help lang="de"/>
+		<verbose_name lang="de"/>
+		<title lang="fr"/>
+		<help lang="fr"/>
+		<verbose_name lang="fr"/>
+		<title lang="it"/>
+		<help lang="it"/>
+		<verbose_name lang="it"/>
+		<title lang="es"/>
+		<help lang="es"/>
+		<verbose_name lang="es"/>
+		<questionsets>
+			<questionset dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner/employment" order="7"/>
+		</questionsets>
+		<questions>
+			<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner/type" order="0"/>
+			<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner/orcid-autocomplete" order="1"/>
+			<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner/family-name" order="2"/>
+			<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner/given-name" order="3"/>
+			<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner/name" order="4"/>
+			<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner/orcid" order="5"/>
+			<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner/website" order="6"/>
+		</questions>
+		<conditions>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/application-class-2"/>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/application-class-3"/>
+		</conditions>
+	</page>
+	<questionset dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner/employment">
+		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
+		<uri_path>smp/general/project-partner/employment</uri_path>
+		<dc:comment/>
+		<attribute/>
+		<is_collection>True</is_collection>
+		<title lang="en">Role(s) and Affiliation(s)</title>
+		<help lang="en"/>
+		<verbose_name lang="en"/>
+		<title lang="de">Rolle(n) und Affiliation(en)</title>
 		<help lang="de"/>
 		<verbose_name lang="de"/>
 		<title lang="fr"/>
@@ -388,28 +427,270 @@ Folgende (ausgewählte) Plattformen können hierbei helfen:
 		<verbose_name lang="es"/>
 		<questionsets/>
 		<questions>
-			<question dc:uri="https://rdmorganiser.github.io/terms/questions/smp/general/project-partner/project-participants" order="0"/>
-			<question dc:uri="https://rdmorganiser.github.io/terms/questions/smp/general/project-partner/funding" order="2"/>
+			<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner/role" order="0"/>
+			<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner/affiliation/ror-autocomplete" order="1"/>
+			<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner/affiliation" order="2"/>
+			<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner/affiliation/ror_id" order="3"/>
 		</questions>
-		<conditions>
-			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/application-class-1"/>
-			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/application-class-2"/>
-			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/application-class-3"/>
-		</conditions>
-	</page>
-	<question dc:uri="https://rdmorganiser.github.io/terms/questions/smp/general/project-partner/project-participants">
-		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
-		<uri_path>smp/general/project-partner/project-participants</uri_path>
+		<conditions/>
+	</questionset>
+	<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner/role">
+		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
+		<uri_path>smp/general/project-partner/role</uri_path>
 		<dc:comment/>
-		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/partner"/>
-		<is_collection>True</is_collection>
+		<attribute dc:uri="https://rdmo.mpdl.mpg.de/terms/domain/project/partner/role"/>
+		<is_collection>False</is_collection>
 		<is_optional>False</is_optional>
-		<help lang="en">Please enter the name and contact details as well as institution, position as well as role in the software project, if applicable.</help>
-		<text lang="en">Who are the project participants that deal with this software?</text>
+		<help lang="en"/>
+		<text lang="en">Role</text>
 		<default_text lang="en"/>
 		<verbose_name lang="en"/>
-		<help lang="de">Bitte geben Sie den Namen und Kontaktdaten sowie ggf. Institution und Position sowie Rolle im Software-Projekt.</help>
-		<text lang="de">Wer sind die Projektteilnehmer, die an dieser Software arbeiten?</text>
+		<help lang="de"/>
+		<text lang="de">Rolle</text>
+		<default_text lang="de"/>
+		<verbose_name lang="de"/>
+		<help lang="fr"/>
+		<text lang="fr"/>
+		<default_text lang="fr"/>
+		<verbose_name lang="fr"/>
+		<help lang="it"/>
+		<text lang="it"/>
+		<default_text lang="it"/>
+		<verbose_name lang="it"/>
+		<help lang="es"/>
+		<text lang="es"/>
+		<default_text lang="es"/>
+		<verbose_name lang="es"/>
+		<default_option/>
+		<default_external_id/>
+		<widget_type>text</widget_type>
+		<value_type>text</value_type>
+		<maximum/>
+		<minimum/>
+		<step/>
+		<unit/>
+		<width/>
+		<optionsets/>
+		<conditions/>
+	</question>
+	<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner/affiliation/ror-autocomplete">
+		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
+		<uri_path>smp/general/project-partner/affiliation/ror-autocomplete</uri_path>
+		<dc:comment/>
+		<attribute dc:uri="https://rdmo.mpdl.mpg.de/terms/domain/project/partner/affiliation/ror-autocomplete"/>
+		<is_collection>False</is_collection>
+		<is_optional>True</is_optional>
+		<help lang="en">Type a name or a ROR id and choose the right organization from the matching options</help>
+		<text lang="en">ROR search</text>
+		<default_text lang="en"/>
+		<verbose_name lang="en"/>
+		<help lang="de">Geben Sie einen Namen oder eine ROR id ein und wählen Sie die richtige Organisation aus den Optionen aus</help>
+		<text lang="de">ROR-Suche</text>
+		<default_text lang="de"/>
+		<verbose_name lang="de"/>
+		<help lang="fr"/>
+		<text lang="fr"/>
+		<default_text lang="fr"/>
+		<verbose_name lang="fr"/>
+		<help lang="it"/>
+		<text lang="it"/>
+		<default_text lang="it"/>
+		<verbose_name lang="it"/>
+		<help lang="es"/>
+		<text lang="es"/>
+		<default_text lang="es"/>
+		<verbose_name lang="es"/>
+		<default_option/>
+		<default_external_id/>
+		<widget_type>select</widget_type>
+		<value_type>text</value_type>
+		<maximum/>
+		<minimum/>
+		<step/>
+		<unit/>
+		<width/>
+		<optionsets>
+			<optionset dc:uri="https://rdmo.mpdl.mpg.de/terms/options/ror-provider"/>
+		</optionsets>
+		<conditions>
+			<condition dc:uri="https://rdmo.mpdl.mpg.de/terms/conditions/partner_without_ror_id"/>
+		</conditions>
+	</question>
+	<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner/affiliation">
+		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
+		<uri_path>smp/general/project-partner/affiliation</uri_path>
+		<dc:comment/>
+		<attribute dc:uri="https://rdmo.mpdl.mpg.de/terms/domain/project/partner/affiliation"/>
+		<is_collection>False</is_collection>
+		<is_optional>False</is_optional>
+		<help lang="en"/>
+		<text lang="en">Affiliation</text>
+		<default_text lang="en"/>
+		<verbose_name lang="en"/>
+		<help lang="de"/>
+		<text lang="de">Affiliation</text>
+		<default_text lang="de"/>
+		<verbose_name lang="de"/>
+		<help lang="fr"/>
+		<text lang="fr"/>
+		<default_text lang="fr"/>
+		<verbose_name lang="fr"/>
+		<help lang="it"/>
+		<text lang="it"/>
+		<default_text lang="it"/>
+		<verbose_name lang="it"/>
+		<help lang="es"/>
+		<text lang="es"/>
+		<default_text lang="es"/>
+		<verbose_name lang="es"/>
+		<default_option/>
+		<default_external_id/>
+		<widget_type>text</widget_type>
+		<value_type>text</value_type>
+		<maximum/>
+		<minimum/>
+		<step/>
+		<unit/>
+		<width/>
+		<optionsets/>
+		<conditions/>
+	</question>
+	<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner/affiliation/ror_id">
+		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
+		<uri_path>smp/general/project-partner/affiliation/ror_id</uri_path>
+		<dc:comment/>
+		<attribute dc:uri="https://rdmo.mpdl.mpg.de/terms/domain/project/partner/affiliation/ror-id"/>
+		<is_collection>False</is_collection>
+		<is_optional>False</is_optional>
+		<help lang="en"/>
+		<text lang="en">ROR ID</text>
+		<default_text lang="en"/>
+		<verbose_name lang="en"/>
+		<help lang="de"/>
+		<text lang="de">ROR ID</text>
+		<default_text lang="de"/>
+		<verbose_name lang="de"/>
+		<help lang="fr"/>
+		<text lang="fr"/>
+		<default_text lang="fr"/>
+		<verbose_name lang="fr"/>
+		<help lang="it"/>
+		<text lang="it"/>
+		<default_text lang="it"/>
+		<verbose_name lang="it"/>
+		<help lang="es"/>
+		<text lang="es"/>
+		<default_text lang="es"/>
+		<verbose_name lang="es"/>
+		<default_option/>
+		<default_external_id/>
+		<widget_type>text</widget_type>
+		<value_type>text</value_type>
+		<maximum/>
+		<minimum/>
+		<step/>
+		<unit/>
+		<width/>
+		<optionsets/>
+		<conditions/>
+	</question>
+	<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner/type">
+		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
+		<uri_path>smp/general/project-partner/type</uri_path>
+		<dc:comment/>
+		<attribute dc:uri="https://rdmo.mpdl.mpg.de/terms/domain/project/partner/type"/>
+		<is_collection>False</is_collection>
+		<is_optional>False</is_optional>
+		<help lang="en">Following the cff schema, project contributors can be of two types: person or entity. An example entity contributor would be a research group. For more details, check the &lt;a href=&quot;https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#authors&quot;&gt;CFF Schema Guide&lt;/a&gt;.</help>
+		<text lang="en">Type</text>
+		<default_text lang="en"/>
+		<verbose_name lang="en"/>
+		<help lang="de">Nach dem cff-Schema können Projektbeitragende zwei Typen haben: Person oder Entität. Eine Beispielentität wäre eine Forschungsgruppe. Weitere Informationen finden Sie unter diesem Link: &lt;a href=&quot;https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#authors&quot;&gt;&lt;i&gt;CFF Schema Guide&lt;/i&gt;&lt;/a&gt;.</help>
+		<text lang="de">Typ</text>
+		<default_text lang="de"/>
+		<verbose_name lang="de"/>
+		<help lang="fr"/>
+		<text lang="fr"/>
+		<default_text lang="fr"/>
+		<verbose_name lang="fr"/>
+		<help lang="it"/>
+		<text lang="it"/>
+		<default_text lang="it"/>
+		<verbose_name lang="it"/>
+		<help lang="es"/>
+		<text lang="es"/>
+		<default_text lang="es"/>
+		<verbose_name lang="es"/>
+		<default_option/>
+		<default_external_id/>
+		<widget_type>radio</widget_type>
+		<value_type>option</value_type>
+		<maximum/>
+		<minimum/>
+		<step/>
+		<unit/>
+		<width/>
+		<optionsets>
+			<optionset dc:uri="https://rdmo.mpdl.mpg.de/terms/options/partner-types"/>
+		</optionsets>
+		<conditions/>
+	</question>
+	<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner/orcid-autocomplete">
+		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
+		<uri_path>smp/general/project-partner/orcid-autocomplete</uri_path>
+		<dc:comment/>
+		<attribute dc:uri="https://rdmo.mpdl.mpg.de/terms/domain/project/partner/orcid-autocomplete"/>
+		<is_collection>False</is_collection>
+		<is_optional>True</is_optional>
+		<help lang="en">Type a name and affiliation or an ORCID and choose the right person from the matching options</help>
+		<text lang="en">ORCID search</text>
+		<default_text lang="en"/>
+		<verbose_name lang="en"/>
+		<help lang="de">Geben Sie einen Namen und eine Affiliation oder eine ORCID ein und wählen Sie die richtige Person aus den Optionen aus</help>
+		<text lang="de">ORCID-Suche</text>
+		<default_text lang="de"/>
+		<verbose_name lang="de"/>
+		<help lang="fr"/>
+		<text lang="fr"/>
+		<default_text lang="fr"/>
+		<verbose_name lang="fr"/>
+		<help lang="it"/>
+		<text lang="it"/>
+		<default_text lang="it"/>
+		<verbose_name lang="it"/>
+		<help lang="es"/>
+		<text lang="es"/>
+		<default_text lang="es"/>
+		<verbose_name lang="es"/>
+		<default_option/>
+		<default_external_id/>
+		<widget_type>select</widget_type>
+		<value_type>text</value_type>
+		<maximum/>
+		<minimum/>
+		<step/>
+		<unit/>
+		<width/>
+		<optionsets>
+			<optionset dc:uri="https://rdmo.mpdl.mpg.de/terms/options/orcid-provider"/>
+		</optionsets>
+		<conditions>
+			<condition dc:uri="https://rdmo.mpdl.mpg.de/terms/conditions/partner_with_type_person"/>
+		</conditions>
+	</question>
+	<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner/family-name">
+		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
+		<uri_path>smp/general/project-partner/family-name</uri_path>
+		<dc:comment/>
+		<attribute dc:uri="https://rdmo.mpdl.mpg.de/terms/domain/project/partner/family-name"/>
+		<is_collection>False</is_collection>
+		<is_optional>False</is_optional>
+		<help lang="en"/>
+		<text lang="en">Family name(s)</text>
+		<default_text lang="en"/>
+		<verbose_name lang="en"/>
+		<help lang="de"/>
+		<text lang="de">Familienname(n)</text>
 		<default_text lang="de"/>
 		<verbose_name lang="de"/>
 		<help lang="fr"/>
@@ -435,13 +716,212 @@ Folgende (ausgewählte) Plattformen können hierbei helfen:
 		<width/>
 		<optionsets/>
 		<conditions>
+			<condition dc:uri="https://rdmo.mpdl.mpg.de/terms/conditions/partner_with_type_person"/>
+		</conditions>
+	</question>
+	<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner/given-name">
+		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
+		<uri_path>smp/general/project-partner/given-name</uri_path>
+		<dc:comment/>
+		<attribute dc:uri="https://rdmo.mpdl.mpg.de/terms/domain/project/partner/given-name"/>
+		<is_collection>False</is_collection>
+		<is_optional>False</is_optional>
+		<help lang="en"/>
+		<text lang="en">Given name(s)</text>
+		<default_text lang="en"/>
+		<verbose_name lang="en"/>
+		<help lang="de"/>
+		<text lang="de">Rufname(n)</text>
+		<default_text lang="de"/>
+		<verbose_name lang="de"/>
+		<help lang="fr"/>
+		<text lang="fr"/>
+		<default_text lang="fr"/>
+		<verbose_name lang="fr"/>
+		<help lang="it"/>
+		<text lang="it"/>
+		<default_text lang="it"/>
+		<verbose_name lang="it"/>
+		<help lang="es"/>
+		<text lang="es"/>
+		<default_text lang="es"/>
+		<verbose_name lang="es"/>
+		<default_option/>
+		<default_external_id/>
+		<widget_type>text</widget_type>
+		<value_type>text</value_type>
+		<maximum/>
+		<minimum/>
+		<step/>
+		<unit/>
+		<width/>
+		<optionsets/>
+		<conditions>
+			<condition dc:uri="https://rdmo.mpdl.mpg.de/terms/conditions/partner_with_type_person"/>
+		</conditions>
+	</question>
+	<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner/name">
+		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
+		<uri_path>smp/general/project-partner/name</uri_path>
+		<dc:comment/>
+		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/partner/name"/>
+		<is_collection>False</is_collection>
+		<is_optional>False</is_optional>
+		<help lang="en"/>
+		<text lang="en">Name</text>
+		<default_text lang="en"/>
+		<verbose_name lang="en"/>
+		<help lang="de"/>
+		<text lang="de">Name</text>
+		<default_text lang="de"/>
+		<verbose_name lang="de"/>
+		<help lang="fr"/>
+		<text lang="fr"/>
+		<default_text lang="fr"/>
+		<verbose_name lang="fr"/>
+		<help lang="it"/>
+		<text lang="it"/>
+		<default_text lang="it"/>
+		<verbose_name lang="it"/>
+		<help lang="es"/>
+		<text lang="es"/>
+		<default_text lang="es"/>
+		<verbose_name lang="es"/>
+		<default_option/>
+		<default_external_id/>
+		<widget_type>text</widget_type>
+		<value_type>text</value_type>
+		<maximum/>
+		<minimum/>
+		<step/>
+		<unit/>
+		<width/>
+		<optionsets/>
+		<conditions>
+			<condition dc:uri="https://rdmo.mpdl.mpg.de/terms/conditions/partner_with_type_entity"/>
+		</conditions>
+	</question>
+	<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner/orcid">
+		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
+		<uri_path>smp/general/project-partner/orcid</uri_path>
+		<dc:comment/>
+		<attribute dc:uri="https://rdmo.mpdl.mpg.de/terms/domain/project/partner/orcid"/>
+		<is_collection>False</is_collection>
+		<is_optional>False</is_optional>
+		<help lang="en"/>
+		<text lang="en">ORCID</text>
+		<default_text lang="en"/>
+		<verbose_name lang="en"/>
+		<help lang="de"/>
+		<text lang="de">ORCID</text>
+		<default_text lang="de"/>
+		<verbose_name lang="de"/>
+		<help lang="fr"/>
+		<text lang="fr"/>
+		<default_text lang="fr"/>
+		<verbose_name lang="fr"/>
+		<help lang="it"/>
+		<text lang="it"/>
+		<default_text lang="it"/>
+		<verbose_name lang="it"/>
+		<help lang="es"/>
+		<text lang="es"/>
+		<default_text lang="es"/>
+		<verbose_name lang="es"/>
+		<default_option/>
+		<default_external_id/>
+		<widget_type>text</widget_type>
+		<value_type>text</value_type>
+		<maximum/>
+		<minimum/>
+		<step/>
+		<unit/>
+		<width/>
+		<optionsets/>
+		<conditions>
+			<condition dc:uri="https://rdmo.mpdl.mpg.de/terms/conditions/partner_with_type_person"/>
+		</conditions>
+	</question>
+	<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner/website">
+		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
+		<uri_path>smp/general/project-partner/website</uri_path>
+		<dc:comment/>
+		<attribute dc:uri="https://rdmo.mpdl.mpg.de/terms/domain/project/partner/website"/>
+		<is_collection>False</is_collection>
+		<is_optional>False</is_optional>
+		<help lang="en"/>
+		<text lang="en">Website</text>
+		<default_text lang="en"/>
+		<verbose_name lang="en"/>
+		<help lang="de"/>
+		<text lang="de">Webseite</text>
+		<default_text lang="de"/>
+		<verbose_name lang="de"/>
+		<help lang="fr"/>
+		<text lang="fr"/>
+		<default_text lang="fr"/>
+		<verbose_name lang="fr"/>
+		<help lang="it"/>
+		<text lang="it"/>
+		<default_text lang="it"/>
+		<verbose_name lang="it"/>
+		<help lang="es"/>
+		<text lang="es"/>
+		<default_text lang="es"/>
+		<verbose_name lang="es"/>
+		<default_option/>
+		<default_external_id/>
+		<widget_type>text</widget_type>
+		<value_type>text</value_type>
+		<maximum/>
+		<minimum/>
+		<step/>
+		<unit/>
+		<width/>
+		<optionsets/>
+		<conditions>
+			<condition dc:uri="https://rdmo.mpdl.mpg.de/terms/conditions/partner_with_type_entity"/>
+		</conditions>
+	</question>
+	<page dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-funding">
+		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
+		<uri_path>smp/general/project-funding</uri_path>
+		<dc:comment/>
+		<attribute/>
+		<is_collection>False</is_collection>
+		<title lang="en">Funding</title>
+		<short_title lang="en"/>
+		<help lang="en"/>
+		<verbose_name lang="en"/>
+		<title lang="de">Finanzierung</title>
+		<short_title lang="de"/>
+		<help lang="de"/>
+		<verbose_name lang="de"/>
+		<title lang="fr"/>
+		<short_title lang="fr"/>
+		<help lang="fr"/>
+		<verbose_name lang="fr"/>
+		<title lang="it"/>
+		<short_title lang="it"/>
+		<help lang="it"/>
+		<verbose_name lang="it"/>
+		<title lang="es"/>
+		<short_title lang="es"/>
+		<help lang="es"/>
+		<verbose_name lang="es"/>
+		<questionsets/>
+		<questions>
+			<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-funding/funding" order="0"/>
+		</questions>
+		<conditions>
+			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/application-class-1"/>
 			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/application-class-2"/>
 			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/application-class-3"/>
 		</conditions>
-	</question>
-	<question dc:uri="https://rdmorganiser.github.io/terms/questions/smp/general/project-partner/funding">
-		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
-		<uri_path>smp/general/project-partner/funding</uri_path>
+	</page>
+	<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-funding/funding">
+		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
+		<uri_path>smp/general/project-funding/funding</uri_path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/funder"/>
 		<is_collection>False</is_collection>
@@ -496,16 +976,16 @@ Als weiterführenden Hinweise empfehlen wir diese Publikationen:
 			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/application-class-3"/>
 		</conditions>
 	</question>
-	<page dc:uri="https://rdmorganiser.github.io/terms/questions/smp/general/schedule">
-		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
+	<page dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/schedule">
+		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
 		<uri_path>smp/general/schedule</uri_path>
 		<dc:comment/>
 		<attribute/>
 		<is_collection>False</is_collection>
-		<title lang="en">Software Project Schedule</title>
+		<title lang="en">Schedule</title>
 		<help lang="en"/>
 		<verbose_name lang="en"/>
-		<title lang="de">Zeitplan für Softwareprojekte</title>
+		<title lang="de">Zeitplan</title>
 		<help lang="de"/>
 		<verbose_name lang="de"/>
 		<title lang="fr"/>
@@ -606,16 +1086,16 @@ Als weiterführenden Hinweise empfehlen wir diese Publikationen:
 		<optionsets/>
 		<conditions/>
 	</question>
-	<page dc:uri="https://rdmorganiser.github.io/terms/questions/smp/general/project-management">
-		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
+	<page dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-management">
+		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
 		<uri_path>smp/general/project-management</uri_path>
 		<dc:comment/>
 		<attribute/>
 		<is_collection>False</is_collection>
-		<title lang="en">Software Project Management</title>
+		<title lang="en">Project Management</title>
 		<help lang="en"/>
 		<verbose_name lang="en"/>
-		<title lang="de">Software-Projekt-Management</title>
+		<title lang="de">Projekt-Management</title>
 		<help lang="de"/>
 		<verbose_name lang="de"/>
 		<title lang="fr"/>
@@ -784,16 +1264,16 @@ Beispiele für Anwendungen sind etwa eigenständige Ticket-Systeme wie Jira oder
 			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/application-class-3"/>
 		</conditions>
 	</question>
-	<page dc:uri="https://rdmorganiser.github.io/terms/questions/smp/general/software-requirements">
-		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
+	<page dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/software-requirements">
+		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
 		<uri_path>smp/general/software-requirements</uri_path>
 		<dc:comment/>
 		<attribute/>
 		<is_collection>False</is_collection>
-		<title lang="en">Software Development Requirements</title>
+		<title lang="en">Development Requirements</title>
 		<help lang="en"/>
 		<verbose_name lang="en"/>
-		<title lang="de">Anforderungen an die Softwareentwicklung</title>
+		<title lang="de">Entwicklungsanforderungen</title>
 		<help lang="de"/>
 		<verbose_name lang="de"/>
 		<title lang="fr"/>
@@ -925,7 +1405,7 @@ Parallel dazu ist es empfehlenswert, sich mit den FAIR Principles for Research S
 		<title lang="es"/>
 		<pages>
 			<page dc:uri="https://rdmorganiser.github.io/terms/questions/smp/technical/code" order="0"/>
-			<page dc:uri="https://rdmorganiser.github.io/terms/questions/smp/technical/components" order="1"/>
+			<page dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/technical/components" order="1"/>
 			<page dc:uri="https://rdmorganiser.github.io/terms/questions/smp/technical/Infrastructure" order="2"/>
 			<page dc:uri="https://rdmorganiser.github.io/terms/questions/smp/technical/preservation" order="3"/>
 			<page dc:uri="https://rdmorganiser.github.io/terms/questions/smp/technical/security" order="4"/>
@@ -1045,13 +1525,13 @@ An dieser Stelle bietet es sich zusätzlich an, zu dokumentieren, ob technische 
 			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/application-class-3"/>
 		</conditions>
 	</question>
-	<page dc:uri="https://rdmorganiser.github.io/terms/questions/smp/technical/components">
-		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
+	<page dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/technical/components">
+		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
 		<uri_path>smp/technical/components</uri_path>
 		<dc:comment/>
 		<attribute/>
 		<is_collection>False</is_collection>
-		<title lang="en">Third Party Components and Libraries</title>
+		<title lang="en">Third-Party Components and Libraries</title>
 		<help lang="en"/>
 		<verbose_name lang="en"/>
 		<title lang="de">Externe Komponenten und Bibliotheken</title>
@@ -2496,7 +2976,7 @@ Weitere Literaturhinweise zu dem Thema können ebenfalls interessant sein:
 		<questionsets/>
 		<questions>
 			<question dc:uri="https://rdmorganiser.github.io/terms/questions/smp/release-and-publish/metadata/assign-metadata" order="0"/>
-			<question dc:uri="https://rdmorganiser.github.io/terms/questions/smp/release-and-publish/metadata/software-pid" order="1"/>
+			<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/release-and-publish/metadata/software-pid" order="1"/>
 		</questions>
 		<conditions/>
 	</page>
@@ -2543,12 +3023,12 @@ Beispielsweise mit einer &lt;a href=&quot;https://citation-file-format.github.io
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://rdmorganiser.github.io/terms/questions/smp/release-and-publish/metadata/software-pid">
-		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
+	<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/release-and-publish/metadata/software-pid">
+		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
 		<uri_path>smp/release-and-publish/metadata/software-pid</uri_path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/smp/software-pid"/>
-		<is_collection>False</is_collection>
+		<is_collection>True</is_collection>
 		<is_optional>False</is_optional>
 		<help lang="en">For long-term availability and clear allocation, it is recommended to publish the software (version) with a persistent identifier. This recommendation goes hand in hand with &lt;a href=&quot;https://doi.org/10.15497/RDA00068&quot; target=&quot;_blank&quot;&gt;FAIR4RS&lt;/a&gt; F3 and &lt;a href=&quot;https://wissenschaftliche-integritaet.de/en/code-of-conduct/cross-phase-quality-assurance/&quot; target=&quot;_blank&quot;&gt;guideline 7 in the DFG Code &quot;Guidelines for Safeguarding Good Scientific Practice&quot;&lt;/a&gt;. After &lt;a href=&quot;https://doi.org/10.15497/RDA00068&quot; target=&quot;_blank&quot;&gt;FAIR4RS&lt;/a&gt; F1.1, it may also be useful to place a separate identifier on the individual software versions or components. An example of a persistent identifier is the Digital Object Identifier (DOI). In terms of research software, for example, a GitHub/GitLab Zenodo integration can generate a citable object including DOI.</help>
 		<text lang="en">Do you give a persistent identifier for you software?</text>
@@ -2806,7 +3286,7 @@ Beispielsweise mit einer &lt;a href=&quot;https://citation-file-format.github.io
 		<title lang="es"/>
 		<pages>
 			<page dc:uri="https://rdmorganiser.github.io/terms/questions/smp/legal-and-ethics/intellectual-rights" order="0"/>
-			<page dc:uri="https://rdmorganiser.github.io/terms/questions/smp/legal-and-ethics/license" order="1"/>
+			<page dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/legal-and-ethics/license" order="1"/>
 			<page dc:uri="https://rdmorganiser.github.io/terms/questions/smp/legal-and-ethics/dual-use" order="2"/>
 		</pages>
 	</section>
@@ -2927,16 +3407,16 @@ Beispielsweise mit einer &lt;a href=&quot;https://citation-file-format.github.io
 			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/application-class-3"/>
 		</conditions>
 	</question>
-	<page dc:uri="https://rdmorganiser.github.io/terms/questions/smp/legal-and-ethics/license">
-		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
+	<page dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/legal-and-ethics/license">
+		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
 		<uri_path>smp/legal-and-ethics/license</uri_path>
 		<dc:comment/>
 		<attribute/>
 		<is_collection>False</is_collection>
-		<title lang="en">License</title>
+		<title lang="en">License(s)</title>
 		<help lang="en"/>
 		<verbose_name lang="en"/>
-		<title lang="de">Lizenzen</title>
+		<title lang="de">Lizenz(en)</title>
 		<help lang="de"/>
 		<verbose_name lang="de"/>
 		<title lang="fr"/>

--- a/rdmorganiser/questions/questions-smp.xml
+++ b/rdmorganiser/questions/questions-smp.xml
@@ -39,9 +39,9 @@ This SMP template was inspired by some documentation, specially:
 			<page dc:uri="https://rdmorganiser.github.io/terms/questions/smp/general/topic" order="0"/>
 			<page dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-partner" order="1"/>
 			<page dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-funding" order="2"/>
-			<page dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/schedule" order="3"/>
-			<page dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-management" order="4"/>
-			<page dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/software-requirements" order="5"/>
+			<page dc:uri="https://rdmorganiser.github.io/terms/questions/smp/general/schedule" order="3"/>
+			<page dc:uri="https://rdmorganiser.github.io/terms/questions/smp/general/project-management" order="4"/>
+			<page dc:uri="https://rdmorganiser.github.io/terms/questions/smp/general/software-requirements" order="5"/>
 		</pages>
 	</section>
 	<page dc:uri="https://rdmorganiser.github.io/terms/questions/smp/general/topic">
@@ -911,7 +911,7 @@ Folgende (ausgewählte) Plattformen können hierbei helfen:
 		<verbose_name lang="es"/>
 		<questionsets/>
 		<questions>
-			<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-funding/funding" order="0"/>
+			<question dc:uri="https://rdmorganiser.github.io/terms/questions/smp/general/project-funding/funding" order="0"/>
 		</questions>
 		<conditions>
 			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/application-class-1"/>
@@ -919,8 +919,8 @@ Folgende (ausgewählte) Plattformen können hierbei helfen:
 			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/application-class-3"/>
 		</conditions>
 	</page>
-	<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-funding/funding">
-		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
+	<question dc:uri="https://rdmorganiser.github.io/terms/questions/smp/general/project-funding/funding">
+		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
 		<uri_path>smp/general/project-funding/funding</uri_path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/funder"/>
@@ -976,8 +976,8 @@ Als weiterführenden Hinweise empfehlen wir diese Publikationen:
 			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/application-class-3"/>
 		</conditions>
 	</question>
-	<page dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/schedule">
-		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
+	<page dc:uri="https://rdmorganiser.github.io/terms/questions/smp/general/schedule">
+		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
 		<uri_path>smp/general/schedule</uri_path>
 		<dc:comment/>
 		<attribute/>
@@ -1086,8 +1086,8 @@ Als weiterführenden Hinweise empfehlen wir diese Publikationen:
 		<optionsets/>
 		<conditions/>
 	</question>
-	<page dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/project-management">
-		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
+	<page dc:uri="https://rdmorganiser.github.io/terms/questions/smp/general/project-management">
+		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
 		<uri_path>smp/general/project-management</uri_path>
 		<dc:comment/>
 		<attribute/>
@@ -1264,8 +1264,8 @@ Beispiele für Anwendungen sind etwa eigenständige Ticket-Systeme wie Jira oder
 			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/application-class-3"/>
 		</conditions>
 	</question>
-	<page dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/general/software-requirements">
-		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
+	<page dc:uri="https://rdmorganiser.github.io/terms/questions/smp/general/software-requirements">
+		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
 		<uri_path>smp/general/software-requirements</uri_path>
 		<dc:comment/>
 		<attribute/>
@@ -1405,7 +1405,7 @@ Parallel dazu ist es empfehlenswert, sich mit den FAIR Principles for Research S
 		<title lang="es"/>
 		<pages>
 			<page dc:uri="https://rdmorganiser.github.io/terms/questions/smp/technical/code" order="0"/>
-			<page dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/technical/components" order="1"/>
+			<page dc:uri="https://rdmorganiser.github.io/terms/questions/smp/technical/components" order="1"/>
 			<page dc:uri="https://rdmorganiser.github.io/terms/questions/smp/technical/Infrastructure" order="2"/>
 			<page dc:uri="https://rdmorganiser.github.io/terms/questions/smp/technical/preservation" order="3"/>
 			<page dc:uri="https://rdmorganiser.github.io/terms/questions/smp/technical/security" order="4"/>
@@ -1525,8 +1525,8 @@ An dieser Stelle bietet es sich zusätzlich an, zu dokumentieren, ob technische 
 			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/application-class-3"/>
 		</conditions>
 	</question>
-	<page dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/technical/components">
-		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
+	<page dc:uri="https://rdmorganiser.github.io/terms/questions/smp/technical/components">
+		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
 		<uri_path>smp/technical/components</uri_path>
 		<dc:comment/>
 		<attribute/>
@@ -2976,7 +2976,7 @@ Weitere Literaturhinweise zu dem Thema können ebenfalls interessant sein:
 		<questionsets/>
 		<questions>
 			<question dc:uri="https://rdmorganiser.github.io/terms/questions/smp/release-and-publish/metadata/assign-metadata" order="0"/>
-			<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/release-and-publish/metadata/software-pid" order="1"/>
+			<question dc:uri="https://rdmorganiser.github.io/terms/questions/smp/release-and-publish/metadata/software-pid" order="1"/>
 		</questions>
 		<conditions/>
 	</page>
@@ -3023,8 +3023,8 @@ Beispielsweise mit einer &lt;a href=&quot;https://citation-file-format.github.io
 		<optionsets/>
 		<conditions/>
 	</question>
-	<question dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/release-and-publish/metadata/software-pid">
-		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
+	<question dc:uri="https://rdmorganiser.github.io/terms/questions/smp/release-and-publish/metadata/software-pid">
+		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
 		<uri_path>smp/release-and-publish/metadata/software-pid</uri_path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/smp/software-pid"/>
@@ -3286,7 +3286,7 @@ Beispielsweise mit einer &lt;a href=&quot;https://citation-file-format.github.io
 		<title lang="es"/>
 		<pages>
 			<page dc:uri="https://rdmorganiser.github.io/terms/questions/smp/legal-and-ethics/intellectual-rights" order="0"/>
-			<page dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/legal-and-ethics/license" order="1"/>
+			<page dc:uri="https://rdmorganiser.github.io/terms/questions/smp/legal-and-ethics/license" order="1"/>
 			<page dc:uri="https://rdmorganiser.github.io/terms/questions/smp/legal-and-ethics/dual-use" order="2"/>
 		</pages>
 	</section>

--- a/rdmorganiser/questions/questions-smp.xml
+++ b/rdmorganiser/questions/questions-smp.xml
@@ -3407,8 +3407,8 @@ Beispielsweise mit einer &lt;a href=&quot;https://citation-file-format.github.io
 			<condition dc:uri="https://rdmorganiser.github.io/terms/conditions/application-class-3"/>
 		</conditions>
 	</question>
-	<page dc:uri="https://rdmo.mpdl.mpg.de/terms/questions/smp/legal-and-ethics/license">
-		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
+	<page dc:uri="https://rdmorganiser.github.io/terms/questions/smp/legal-and-ethics/license">
+		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
 		<uri_path>smp/legal-and-ethics/license</uri_path>
 		<dc:comment/>
 		<attribute/>

--- a/rdmorganiser/questions/readme-SMP-Update.md
+++ b/rdmorganiser/questions/readme-SMP-Update.md
@@ -26,7 +26,8 @@ The first 3 views are templates for the corresponding metadata files. `view-smp-
 
 ## History
 
-The SMP catalog was developed at the Max Planck Digital Library to support scientists developing research software documenting the development work....  
+The SMP catalog was created at the Max Planck Digital Library (Max Planck Information and Technology) to support scientists developing research software to plan and document their work. This catalog was inspired by some documentation, specially https://www.software.ac.uk/resources/guides/software-management-plans and https://opencarp.org/about/software-management-plan.
+
 The first version (2021-2023) was developed by Yves Vincent Grossmann, including a FAIR4RS view by Jan Matthiesen.  
-The second version (2026) was developed by Laura Bahamón Jiménez within the DFG project MAUS (MAschinelle Unterstützung von Software-Management-Plänen), ...
+The second version (2026) was developed within the DFG project MAUS (MAschinelle Unterstützung von Software-Management-Plänen), including 4 views (`view-smp-citation.xml`, `view-smp-codemeta.xml`, `view-smp-readme.xml`, `view-smp-report.xml`)
 

--- a/rdmorganiser/questions/readme-SMP-Update.md
+++ b/rdmorganiser/questions/readme-SMP-Update.md
@@ -30,4 +30,36 @@ The SMP catalog was created at the Max Planck Digital Library (Max Planck Inform
 
 The first version (2021-2023) was developed by Yves Vincent Grossmann, including a FAIR4RS view by Jan Matthiesen.  
 The second version (2026) was developed within the DFG project MAUS (MAschinelle Unterstützung von Software-Management-Plänen), including 4 views (`view-smp-citation.xml`, `view-smp-codemeta.xml`, `view-smp-readme.xml`, `view-smp-report.xml`)
+# Software Management Plan for Researchers
 
+## Scope
+
+The Software Management Plan for Researchers has been created at the Max Planck Digital Library (Max Planck Information and Technology) and included in the collection of the RDMO core catalogs.  
+It was designed to support scientists developing research software to plan and document their work. Its structure was inspired by some documentation, specially https://www.software.ac.uk/resources/guides/software-management-plans and https://opencarp.org/about/software-management-plan.  
+The first version (2021-2023) was developed by Yves Vincent Grossmann, with a contribution by Jan Matthiesen.  
+The second version (2026) was developed within the DFG project [MAUS (MAschinelle Unterstützung von Software-Management-Plänen)](https://gepris.dfg.de/gepris/projekt/543616919).
+
+## Content
+
+The RDMO package for SMPs contains the following components:
+
+- A question catalog: `questions-smp.xml`.
+- 
+    - a subset of `questions-smp.xml` (`questions-smp-subset.xml`) containing only updated or added catalog elements. We also included the parent element, so that it is clear where the updated / element belongs (for example, if a new question was added, we also included the new question's page)
+    - 
+
+- Attributes, conditions and optionsets already included in the core RDMO package.
+- Five views (export templates):
+    - `view-smp-citation.xml`
+    - `view-smp-codemeta.xml`
+    - `view-smp-readme.xml`
+    - `view-smp-report.xml`
+  - `view-FAIR4RS.xml`
+
+The first 3 views generate the corresponding metadata files required by software repositories. `view-smp-report.xml` displays the answers in the SMP project as a continuous-text report. `view-FAIR4RS.xml` displays the answers structured according to the FAIR principles for research software.
+
+## Dependencies
+
+The 2026 version of the catalog contains a call to 2 option set providers - ORCID and ROR - which requires a previous installation of the following plugins: ....
+
+If you want to automatically carry the exported metadata files to a software repository, you additional need the following plugins: .....

--- a/rdmorganiser/questions/readme-SMP-Update.md
+++ b/rdmorganiser/questions/readme-SMP-Update.md
@@ -1,4 +1,4 @@
-# MAUS Updates
+# Updates from the project [MAUS](https://gepris.dfg.de/gepris/projekt/543616919)
 
 ## General remarks
 

--- a/rdmorganiser/questions/readme-SMP-Update.md
+++ b/rdmorganiser/questions/readme-SMP-Update.md
@@ -24,18 +24,32 @@ We added 4 views for the SMP catalog:
 
 The first 3 views are templates for the corresponding metadata files. `view-smp-report.xml` is a template that displays the answers in the SMP project as a continuous-text report.
 
+## Dependencies
+
+The 2026 version of the catalog contains a call to 2 option set providers - ORCID and ROR - which requires a previous installation of the following plugins:
+- https://github.com/MPDL/rdmo-plugins-orcid -> the fork of https://github.com/rdmorganiser/rdmo-plugins-orcid adapted for the SMP catalog
+- https://github.com/MPDL/rdmo-plugins-ror -> the fork of https://github.com/rdmorganiser/rdmo-plugins-ror adapted for the SMP catalog
+
+If you want to automatically carry the exported metadata files to a software repository on GitHub or GitLab, you additionally need the following plugins:
+- https://github.com/rdmorganiser/rdmo-plugins-github
+- https://github.com/rdmorganiser/rdmo-plugins-gitlab
+
 ## History
 
 The SMP catalog was created at the Max Planck Digital Library (Max Planck Information and Technology) to support scientists developing research software to plan and document their work. This catalog was inspired by some documentation, specially https://www.software.ac.uk/resources/guides/software-management-plans and https://opencarp.org/about/software-management-plan.
 
 The first version (2021-2023) was developed by Yves Vincent Grossmann, including a FAIR4RS view by Jan Matthiesen.  
 The second version (2026) was developed within the DFG project MAUS (MAschinelle Unterstützung von Software-Management-Plänen), including 4 views (`view-smp-citation.xml`, `view-smp-codemeta.xml`, `view-smp-readme.xml`, `view-smp-report.xml`)
+
+#####################################################################################################
+
 # Software Management Plan for Researchers
 
 ## Scope
 
 The Software Management Plan for Researchers has been created at the Max Planck Digital Library (Max Planck Information and Technology) and included in the collection of the RDMO core catalogs.  
 It was designed to support scientists developing research software to plan and document their work. Its structure was inspired by some documentation, specially https://www.software.ac.uk/resources/guides/software-management-plans and https://opencarp.org/about/software-management-plan.  
+
 The first version (2021-2023) was developed by Yves Vincent Grossmann, with a contribution by Jan Matthiesen.  
 The second version (2026) was developed within the DFG project [MAUS (MAschinelle Unterstützung von Software-Management-Plänen)](https://gepris.dfg.de/gepris/projekt/543616919).
 
@@ -44,9 +58,7 @@ The second version (2026) was developed within the DFG project [MAUS (MAschinell
 The RDMO package for SMPs contains the following components:
 
 - A question catalog: `questions-smp.xml`.
-- 
-    - a subset of `questions-smp.xml` (`questions-smp-subset.xml`) containing only updated or added catalog elements. We also included the parent element, so that it is clear where the updated / element belongs (for example, if a new question was added, we also included the new question's page)
-    - 
+- a subset of `questions-smp.xml` (`questions-smp-subset.xml`) containing only updated or added catalog elements. We also included the parent element, so that it is clear where the updated / element belongs (for example, if a new question was added, we also included the new question's page)
 
 - Attributes, conditions and optionsets already included in the core RDMO package.
 - Five views (export templates):
@@ -54,12 +66,16 @@ The RDMO package for SMPs contains the following components:
     - `view-smp-codemeta.xml`
     - `view-smp-readme.xml`
     - `view-smp-report.xml`
-  - `view-FAIR4RS.xml`
+    - `view-FAIR4RS.xml`
 
 The first 3 views generate the corresponding metadata files required by software repositories. `view-smp-report.xml` displays the answers in the SMP project as a continuous-text report. `view-FAIR4RS.xml` displays the answers structured according to the FAIR principles for research software.
 
 ## Dependencies
 
-The 2026 version of the catalog contains a call to 2 option set providers - ORCID and ROR - which requires a previous installation of the following plugins: ....
+The 2026 version of the catalog contains a call to 2 option set providers - ORCID and ROR - which requires a previous installation of the following plugins:
+- https://github.com/MPDL/rdmo-plugins-orcid -> the fork of https://github.com/rdmorganiser/rdmo-plugins-orcid adapted for the SMP catalog
+- https://github.com/MPDL/rdmo-plugins-ror -> the fork of https://github.com/rdmorganiser/rdmo-plugins-ror adapted for the SMP catalog
 
-If you want to automatically carry the exported metadata files to a software repository, you additional need the following plugins: .....
+If you want to automatically carry the exported metadata files to a software repository on GitHub or GitLab, you additionally need the following plugins:
+- https://github.com/rdmorganiser/rdmo-plugins-github
+- https://github.com/rdmorganiser/rdmo-plugins-gitlab

--- a/rdmorganiser/questions/readme-SMP-Update.md
+++ b/rdmorganiser/questions/readme-SMP-Update.md
@@ -23,3 +23,10 @@ We added 4 views for the SMP catalog:
     - `view-smp-report.xml`
 
 The first 3 views are templates for the corresponding metadata files. `view-smp-report.xml` is a template that displays the answers in the SMP project as a continuous-text report.
+
+## History
+
+The SMP catalog was developed at the Max Planck Digital Library to support scientists developing research software documenting the development work....  
+The first version (2021-2023) was developed by Yves Vincent Grossmann, including a FAIR4RS view by Jan Matthiesen.  
+The second version (2026) was developed by Laura Bahamón Jiménez within the DFG project MAUS (MAschinelle Unterstützung von Software-Management-Plänen), ...
+

--- a/rdmorganiser/questions/readme-SMP-Update.md
+++ b/rdmorganiser/questions/readme-SMP-Update.md
@@ -1,0 +1,25 @@
+# MAUS Updates
+
+## General remarks
+
+- All additions / updates were made with the uri prefix: `https://rdmo.mpdl.mpg.de/terms`
+
+## Updates to SMP catalog
+
+- We are including:
+    - our current version of the whole SMP catalog, i.e. an updated version of `questions-smp.xml` of this repo
+    - a subset of `questions-smp.xml` (`questions-smp-subset.xml`) containing only updated or added catalog elements. We also included the parent element, so that it is clear where the updated / element belongs (for example, if a new question was added, we also included the new question's page)
+
+- The main modifications were:
+    - the structuring of the project contributors (before: Software Project Partner(s))
+    - the inclusion of 2 option set providers: ORCID and ROR
+
+## New Views
+
+We added 4 views for the SMP catalog:
+    - `view-smp-citation.xml`
+    - `view-smp-codemeta.xml`
+    - `view-smp-readme.xml`
+    - `view-smp-report.xml`
+
+The first 3 views are templates for the corresponding metadata files. `view-smp-report.xml` is a template that displays the answers in the SMP project as a continuous-text report.

--- a/rdmorganiser/views/view-smp-citation.xml
+++ b/rdmorganiser/views/view-smp-citation.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdmo xmlns:dc="http://purl.org/dc/elements/1.1/" created="2026-05-26T17:31:31.970612+02:00" required="2.1.0" version="2.4.4">
+	<view dc:uri="https://rdmo.mpdl.mpg.de/terms/views/smp-citation">
+		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
+		<uri_path>smp-citation</uri_path>
+		<dc:comment>Helper view of a CITATION file for Research Software.</dc:comment>
+		<order>0</order>
+		<title lang="en">SMP Citation Template</title>
+		<help lang="en">Helper view of a CITATION file for Research Software.</help>
+		<title lang="de">SMP Citation Template</title>
+		<help lang="de">Hilfe-Ansicht einer CITATION-Datei für Forschungssoftware.</help>
+		<catalogs>
+			<catalog dc:uri="https://rdmorganiser.github.io/terms/questions/smp"/>
+		</catalogs>
+		<template>{% load view_tags %}
+{% get_set 'project/partner/id' as partners %}
+{% get_value 'project/title' as title %}
+{% get_value 'project/schedule/project_end' as release_date %}
+{% get_values 'smp/software-pid' as software_pids %}
+{% get_values 'smp/software-license' as software_licenses %}
+&lt;pre&gt;
+cff-version: 1.2.0
+message: &quot;If you use this software, please cite it as below.&quot;
+title: {% if ' ' in title.value %}&quot;{{ title.value }}&quot;{% else %}{{  title.value}}{% endif %}
+type: software
+{% if partners|length %}authors:{% for p in partners %} {% with p_set_index_str=p.set_index|stringformat:&quot;s&quot; %} {% get_set_value p 'project/partner/type' as p_type %} {% get_set_value p 'project/partner/family-name' as p_family_name %} {% get_set_value p 'project/partner/given-name' as p_given_name %} {% get_set_value p 'project/partner/name' as p_name %} {% get_set_value p 'project/partner/orcid' as p_orcid %} {% get_set_value p 'project/partner/website' as p_website %} {% get_values 'project/partner/affiliation' p_set_index_str as p_affiliations %}
+    {% if p_type.option_uri == 'https://rdmo.mpdl.mpg.de/terms/options/partner-types/person' %}- family-names: {% if ' ' in p_family_name.value or p_family_name.value == '' %}&quot;{{ p_family_name.value }}&quot;{% else %}{{ p_family_name.value }}{% endif %}&lt;br&gt;      given-names: {% if ' ' in p_given_name.value or p_given_name.value == '' %}&quot;{{ p_given_name.value }}&quot;{% else %}{{ p_given_name.value }}{% endif %}{% if p_orcid.value %}&lt;br&gt;      orcid: {{ p_orcid.value }}{% endif %}{% elif p_type.option_uri == 'https://rdmo.mpdl.mpg.de/terms/options/partner-types/entity' %}- name: {% if ' ' in p_name.value or p_name.value == '' %}&quot;{{ p_name.value }}&quot;{% else %}{{ p_name.value }}{% endif %}{% if p_website.value %}&lt;br&gt;      website: {{ p_website.value }}{% endif %}{% endif %}{% if p_affiliations|length %}&lt;br&gt;      affiliation: &quot;{% for a in p_affiliations %}{{ a.value }}{% if not forloop.last %} &amp; {% endif %}{% endfor %}&quot;{% endif %}{% endwith %}{% endfor %}
+{% endif %}{% if software_pids|length == 1 %}{% if software_pids.0.option_text == 'DOI' or software_pids.0.option_text == 'URL' %}{{ software_pids.0.option_text|lower }}: {% if ' ' in software_pids.0.text or software_pids.0.text == '' %}&quot;{{ software_pids.0.text }}&quot;{% else %}{{ software_pids.0.text }}{% endif %}&lt;br&gt;{% else %}identifiers: {% for sp in software_pids %}
+    - type: {% if sp.option_text == 'Software Heritage Identifier' %}swh{% else %}{{ sp.option_text|lower }}{% endif %}
+      value: {% if ' ' in sp.text or sp.text == '' %}&quot;{{ sp.text }}&quot;{% else %}{{ sp.text }}{% endif %}{% endfor %}{% endif %}{% elif software_pids|length &gt; 1 %}identifiers: {% for sp in software_pids %}
+    - type: {% if sp.option_text == 'Software Heritage Identifier' %}swh{% else %}{{ sp.option_text|lower }}{% endif %}
+      value: {% if ' ' in sp.text or sp.text == '' %}&quot;{{ sp.text }}&quot;{% else %}{{ sp.text }}{% endif %}{% endfor %}
+{% endif %}{% if software_licenses|length == 1 %}license: {% if software_licenses.0.text %}{% if ' ' in software_licenses.0.text or software_licenses.0.text == '' %}&quot;{{ software_licenses.0.text }}&quot;{% else %}{{ software_licenses.0.text }}{% endif %}{% else %}{{ software_licenses.0.option_text }}{% endif %}
+{% elif software_licenses|length &gt; 1 %}license: {% for sl in software_licenses %}{% if forloop.first %}&lt;br&gt;{% endif %}    {% if sl.text %}{% if ' ' in sl.text or sl.text == '' %}- &quot;{{ sl.text }}&quot;{% else %}- {{ sl.text }}{% endif %}{% else %}- {{ sl.option_text }}{% endif %}
+{% endfor %}{% endif %}{% if release_date %}date-released: {{ release_date.value|date:&quot;Y-m-d&quot; }}{% endif %}
+&lt;/pre&gt;</template>
+	</view>
+</rdmo>

--- a/rdmorganiser/views/view-smp-codemeta.xml
+++ b/rdmorganiser/views/view-smp-codemeta.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdmo xmlns:dc="http://purl.org/dc/elements/1.1/" created="2026-06-02T12:21:28.466422+02:00" required="2.1.0" version="2.4.4">
+	<view dc:uri="https://rdmo.mpdl.mpg.de/terms/views/smp-codemeta">
+		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
+		<uri_path>smp-codemeta</uri_path>
+		<dc:comment>Helper view of a CodeMeta file for Research Software.</dc:comment>
+		<order>0</order>
+		<title lang="en">SMP CodeMeta Template</title>
+		<help lang="en">Helper view of a CodeMeta file for Research Software.</help>
+		<title lang="de">SMP CodeMeta Template</title>
+		<help lang="de">Hilfe-Ansicht einer CodeMeta-Datei für Forschungssoftware.</help>
+		<title lang="fr"/>
+		<help lang="fr"/>
+		<title lang="it"/>
+		<help lang="it"/>
+		<title lang="es"/>
+		<help lang="es"/>
+		<catalogs>
+			<catalog dc:uri="https://rdmorganiser.github.io/terms/questions/smp"/>
+		</catalogs>
+		<template>{% load view_tags %}
+{% get_values 'project/research_field' as research_fields %}
+{% get_set 'project/partner/id' as partners %}
+{% get_value 'project/title' as title %}
+{% get_value 'project/schedule/project_end' as release_date %}
+{% get_values 'smp/software-pid' as software_pids %}
+{% get_values 'smp/software-license' as software_licenses %}
+{% get_values 'smp/language' as programming_languages %}
+&lt;pre&gt;
+{
+    &quot;@context&quot;: &quot;https://w3id.org/codemeta/3.0&quot;,
+    &quot;name&quot;: &quot;{{ title.value }}&quot;,
+    &quot;@type&quot;: &quot;SoftwareSourceCode&quot;{% if research_fields|length == 1 %},    
+    &quot;applicationCategory&quot;: &quot;{{ research_fields.0.value }}&quot;{% elif research_fields|length &gt; 1 %},
+    &quot;applicationCategory&quot;: [
+        {% for rf in research_fields %}&quot;{{ rf.value }}&quot;{% if not forloop.last %},
+        {% endif %}{% endfor %}
+    ]{% endif %}{% if partners|length %},
+    &quot;contributor&quot;: [{% for p in partners %} {% with p_set_index_str=p.set_index|stringformat:&quot;s&quot; %} {% get_set_value p 'project/partner/type' as p_type %} {% get_set_value p 'project/partner/family-name' as p_family_name %} {% get_set_value p 'project/partner/given-name' as p_given_name %} {% get_set_value p 'project/partner/name' as p_name %} {% get_set_value p 'project/partner/orcid' as p_orcid %} {% get_set_value p 'project/partner/website' as p_website %} {% get_values 'project/partner/affiliation' p_set_index_str as p_affiliations %} {% get_values 'project/partner/affiliation/ror-id' p_set_index_str as p_ror_ids %} {% get_values 'project/partner/role' p_set_index_str as p_roles %}
+        {% if p_type.option_uri == 'https://rdmo.mpdl.mpg.de/terms/options/partner-types/person' %}{
+            {% if p_orcid.value %}&quot;@id&quot;: &quot;{{ p_orcid.value }}&quot;,
+            {% endif %}&quot;@type&quot;: &quot;Person&quot;,
+            &quot;familyName&quot;: &quot;{{ p_family_name.value }}&quot;,
+            &quot;givenName&quot;: &quot;{{ p_given_name.value }}&quot;{% elif p_type.option_uri == 'https://rdmo.mpdl.mpg.de/terms/options/partner-types/entity' %}{
+            {% if p_website.value %}&quot;@id&quot;: &quot;{{ p_website.value }}&quot;,
+            {% endif %}&quot;@type&quot;: &quot;Organization&quot;,
+            &quot;name&quot;: &quot;{{ p_name.value }}&quot;{% endif %}{% if p_affiliations|length and p_affiliations|length == 1 and p_affiliations.0.value %},
+            &quot;affiliation&quot;: {
+                {% if p_ror_ids|length and p_ror_ids.0.value %}&quot;@id&quot;: &quot;{{ p_ror_ids.0.value }}&quot;,
+                {% else %}{% endif %}&quot;@type&quot;: &quot;Organization&quot;,
+                &quot;name&quot;: &quot;{{ p_affiliations.0.value }}&quot;
+            }{% elif p_affiliations|length and p_affiliations|length &gt; 1 %},
+            &quot;affiliation&quot;: [
+                {% for p_affiliation in p_affiliations %}{% if not forloop.first %}    {% endif %}{% if p_affiliation.value %}{ {% if p_ror_ids|length %}{% for p_ror_id in p_ror_ids %}{% if p_ror_id.set_index == p_affiliation.set_index and p_ror_id.value %}
+                    &quot;@id&quot;: &quot;{{ p_ror_id.value }}&quot;,{% endif %}{% endfor %}
+                    {% else %}
+                    {% endif %}&quot;@type&quot;: &quot;Organization&quot;,
+                    &quot;name&quot;: &quot;{{ p_affiliation.value }}&quot;
+                }{% if not forloop.last %}, {% endif %}{% endif %}
+            {% endfor %}]{% endif %}
+        {% if p_type.option_uri %}}{% endif %}{% if p_orcid.value or p_website.value %}{%if p_roles|length %},
+        {% for p_role in p_roles %}{% if p_role.value %}{
+            &quot;@type&quot;: &quot;Role&quot;,
+            &quot;contributor&quot;: &quot;{% if p_orcid.value %}{{ p_orcid.value }}{% elif p_website.value %}{{ p_website.value }}{% endif %}&quot;,
+            &quot;roleName&quot;: &quot;{{ p_role.value }}&quot;
+        }{% if not forloop.last %}, 
+        {% endif %}{% endif %}{% endfor %}{% endif %}{% endif %}{% if not forloop.last %}{% if p_type.option_uri %},{% endif %}{% endif %}{% endwith %}{% endfor %}
+    ]{% endif %}{% if software_licenses|length == 1 %},
+    &quot;license&quot;: {% if software_licenses.0.text %}&quot;{{ software_licenses.0.text }}&quot;{% else %}&quot;https://spdx.org/licenses/{{ software_licenses.0.option_text }}&quot;{% endif %}{% elif software_licenses|length &gt; 1 %},
+    &quot;license&quot;: [
+        {% for sl in software_licenses %}{% if sl.text %}&quot;{{ sl.text }}&quot;{% else %}&quot;https://spdx.org/licenses/{{ sl.option_text }}&quot;{% endif %}{% if not forloop.last %},
+        {% endif %}{% endfor %}
+    ]{% endif %}{% if software_pids|length == 1 %},
+    &quot;identifier&quot;: {
+        &quot;@type&quot;: &quot;PropertyValue&quot;,
+        &quot;propertyID&quot;: &quot;{{ software_pids.0.option_text|lower }}&quot;,
+        &quot;value&quot;:  &quot;{{ software_pids.0.text }}&quot;
+    }{% elif software_pids|length &gt; 1 %},
+    &quot;identifier&quot;: [{% for sp in software_pids %}
+        {
+            &quot;@type&quot;: &quot;PropertyValue&quot;,
+            &quot;propertyID&quot;: &quot;{{ sp.option_text|lower }}&quot;,
+            &quot;value&quot;:  &quot;{{ sp.text }}&quot;
+        }{% if not forloop.last %}, {% endif %}{% endfor %}
+    ]{% endif %}{% if release_date.value %},
+    &quot;datePublished&quot;: &quot;{{ release_date.value|date:&quot;Y-m-d&quot; }}&quot;{% endif %}{% if programming_languages|length == 1 %},
+    &quot;programmingLanguage&quot;: &quot;{{ programming_languages.0.value }}&quot;{% elif programming_languages|length &gt; 1 %},
+    &quot;programmingLanguage&quot;: [
+        {% for pl in programming_languages %}{% if not forloop.first %}    {% endif %}&quot;{{ pl.value }}&quot;{% if not forloop.last %},{% endif %}
+    {% endfor %}]{% endif %}
+}
+&lt;/pre&gt;</template>
+	</view>
+</rdmo>

--- a/rdmorganiser/views/view-smp-readme.xml
+++ b/rdmorganiser/views/view-smp-readme.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdmo xmlns:dc="http://purl.org/dc/elements/1.1/" created="2026-05-29T15:43:06.514036+02:00" required="2.1.0" version="2.4.4">
+	<view dc:uri="https://rdmo.mpdl.mpg.de/terms/views/smp-readme">
+		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
+		<uri_path>smp-readme</uri_path>
+		<dc:comment>Helper view of a README file for Research Software.</dc:comment>
+		<order>0</order>
+		<title lang="en">SMP Readme Template</title>
+		<help lang="en">Helper view of a README file for Research Software.</help>
+		<title lang="de">SMP Readme Template</title>
+		<help lang="de">Hilfe-Ansicht einer README-Datei für Forschungssoftware.</help>
+		<catalogs>
+			<catalog dc:uri="https://rdmorganiser.github.io/terms/questions/smp"/>
+		</catalogs>
+		<template>{% load view_tags %}
+{% get_value 'project/title' as title %}
+{% get_values 'project/research_field' as research_fields %}
+{% get_value 'project/research_question/title' as research_question_title %}
+{% get_set 'project/partner/id' as partners %}
+{% get_values 'smp/software-license' as software_licenses %}
+
+{# ############# #}
+{# PROJECT TITLE #}
+{# ############# #}
+&lt;h1&gt;{{ title.value }}&lt;/h1&gt;
+
+{# ################# #}
+{# RESEARCH FIELD(S) #}
+{# ################# #}
+{% if research_fields|length %}
+    &lt;p&gt;This software belongs to the research field{{ research_fields|pluralize }}: {% if research_fields|length == 1 %}{{ research_fields.0.value }}
+        {% elif research_fields|length &gt; 1 %}
+        &lt;ul&gt;
+        {% for rf in research_fields %}
+            &lt;li&gt;{{ rf.value }}&lt;/li&gt;
+        {% endfor %}
+        &lt;/ul&gt;
+        {% endif %}
+    &lt;/p&gt;
+{% endif %}
+
+{# ######################################### #}
+{# INTENDED USE AND CONTRIBUTION TO RESEARCH #}
+{# ######################################### #}
+{% if research_question_title and research_question_title.value != '' %}
+    &lt;p&gt;Its intended use and its contribution to research:&lt;/p&gt;
+    &lt;p&gt;{{ research_question_title.value|linebreaks }}&lt;/p&gt;
+{% endif %}
+
+{# ############## #}
+{# CONTRIBUTOR(S) #}
+{# ############## #}
+{% if partners|length %}
+    &lt;p&gt;Contributor{{ partners|pluralize }}:
+    &lt;ul&gt;
+    {% for p in partners %}
+        {% with p_set_index_str=p.set_index|stringformat:'s' %}
+        {% get_set_value p 'project/partner/type' as p_type %}
+        {% get_set_value p 'project/partner/orcid' as p_orcid %}
+        {% get_set_value p 'project/partner/website' as p_website %}
+        {% get_set_value p 'project/partner/given-name' as p_given_name %}
+        {% get_set_value p 'project/partner/family-name' as p_family_name %}
+        {% get_set_value p 'project/partner/name' as p_name %}
+        {% get_values 'project/partner/affiliation' p_set_index_str as p_affiliations %}
+        {% get_values 'project/partner/role' p_set_index_str as p_roles %}
+        &lt;li&gt;{% if p_type.option_uri == 'https://rdmo.mpdl.mpg.de/terms/options/partner-types/person' and p_given_name.value and p_family_name.value %}{{ p_given_name.value }} {{ p_family_name.value }}{% elif p_type.option_uri == 'https://rdmo.mpdl.mpg.de/terms/options/partner-types/entity' and p_name.value %}{{ p_name.value }}{% else %}{{ p.value }}{% endif %}{% if p_type.option_uri == 'https://rdmo.mpdl.mpg.de/terms/options/partner-types/person' and p_orcid.value %} ({{ p_orcid.value }}){% elif p_type.option_uri == 'https://rdmo.mpdl.mpg.de/terms/options/partner-types/entity' and p_website.value %} ({{ p_website.value }}){% endif %}{% if p_affiliations %}, {% for a in p_affiliations %}{% for r in p_roles %}{% if r.set_index == a.set_index %}{{ r.value }} at {% endif %}{% endfor %}{{ a.value }}{% if not forloop.last %} &amp; {% endif %}{% endfor %}{% else %}{% if p_roles %}, {% for r in p_roles %}{{ r.value }}{% if not forloop.last %} &amp; {% endif %}{% endfor %}{% endif %}{% endif %}&lt;/li&gt;
+        {% endwith %}
+    {% endfor %}
+    &lt;/ul&gt;
+    &lt;/p&gt;
+{% endif %}
+
+{# ########## #}
+{# LICENSE(S) #}
+{# ########## #}
+{% if software_licenses|length %}
+    &lt;p&gt;Software license{{ software_licenses|pluralize }}: {% if software_licenses|length == 1 %}{% if software_licenses.0.text %}{{ software_licenses.0.text }}{% else %}{{ software_licenses.0.option_text }}{% endif %}
+    {% elif software_licenses|length &gt; 1 %}
+    &lt;ul&gt;
+        {% for sl in software_licenses %}
+        &lt;li&gt;{% if sl.text %}{{ sl.text }}{% else %}{{ sl.option_text }}{% endif %}&lt;/li&gt;
+        {% endfor %}
+    &lt;/ul&gt;
+    {% endif %}
+    &lt;/p&gt;
+{% endif %}</template>
+	</view>
+</rdmo>

--- a/rdmorganiser/views/view-smp-report.xml
+++ b/rdmorganiser/views/view-smp-report.xml
@@ -1,0 +1,1136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdmo xmlns:dc="http://purl.org/dc/elements/1.1/" created="2026-05-29T16:25:05.875188+02:00" required="2.1.0" version="2.4.4">
+	<view dc:uri="https://rdmo.mpdl.mpg.de/terms/views/smp-report">
+		<uri_prefix>https://rdmo.mpdl.mpg.de/terms</uri_prefix>
+		<uri_path>smp-report</uri_path>
+		<dc:comment/>
+		<order>0</order>
+		<title lang="en">SMP Report</title>
+		<help lang="en">View of all answers in SMP projects, in a report format</help>
+		<title lang="de">SMP-Report</title>
+		<help lang="de">Ansicht aller Antworten in einem SMP-Projekt, formatiert als Report</help>
+		<title lang="fr"/>
+		<help lang="fr"/>
+		<title lang="it"/>
+		<help lang="it"/>
+		<title lang="es"/>
+		<help lang="es"/>
+		<catalogs/>
+		<template>{% load view_tags %}
+{% load core_tags %}
+
+{% if project.catalog.uri != 'https://rdmorganiser.github.io/terms/questions/smp' %}
+
+  &lt;h2&gt;SMP Report&lt;/h2&gt;
+  &lt;p&gt;This view only works for projects with the Software Management Plan catalogue.&lt;/p&gt;
+
+{% else %}
+
+{% get_value 'project/title' as title %}
+&lt;h1&gt;{{ title.value }}&lt;/h1&gt;
+
+{% with sections=project.catalog.sections %}
+
+{# ############### #}
+{# SECTION GENERAL #}
+{# ############### #}
+{% comment %}
+    0. topic
+        0. project-title
+        1. research-field
+        2. application-class
+        3. intended-use
+        4. buy-or-make
+    1. project-partner 
+    2. project-funding
+        0. funding
+    3. schedule
+        0. start-date
+        1. end-date
+    4. project-management
+        0. development-process
+        1. track-tasks
+        2. specification-sheet
+    5. development-requirements
+        0. institutional-requirements
+        1. community-requirements
+{% endcomment %}
+
+{# VALUES OF SECTION GENERAL #}
+
+{# topic #}
+{% get_value 'https://rdmorganiser.github.io/terms/domain/project/title' as software_project_title  %}
+{% get_values 'project/research_field' as research_fields %}
+{% get_value 'smp/application-class' as application_class %}
+{% get_value 'project/research_question/title' as research_question_title %}
+{% get_value 'smp/buy-or-make' as buy_or_make %}
+
+{# project-partner #}
+{% get_set 'project/partner/id' as partners %}
+
+{# project-funding #}
+{% get_value 'project/funder' as funder %}
+
+{# schedule #}
+{% get_value 'project/schedule/project_start' as project_start_date %}
+{% get_value 'project/schedule/project_end' as project_end_date %}
+
+{# project-management #}
+{% get_value 'smp/development-process' as development_process %}
+{% get_values 'smp/track-tasks' as tracking_methods %}
+{% get_value 'smp/specification-sheet' as ss %}
+
+{# development-requirements #}
+{% get_value 'smp/institutional-requirements' as institutional_requirements %}
+{% get_value 'smp/community-requirements' as community_requirements %}
+
+{% if software_project_title or research_fields|length or application_class or research_question_title or buy_or_make or partners or funder or project_start_date or project_end_date or development_process or tracking_methods|length or ss or institutional_requirements or community_requirements %}
+&lt;h2&gt;General&lt;/h2&gt;
+{% with section_pages=sections.0.elements %}
+  {% comment %}
+    Pages:
+    0. topic
+    1. project-partner 
+    2. project-funding
+    3. schedule
+    4. project-management
+    5. software-requirements
+  {% endcomment %}
+
+  {% check_element section_pages.0 project=project as topic_page_result %}
+  {% if topic_page_result %}
+    {% comment %}
+      Questions:
+      0. project-title
+      1. research-field
+      2. application-class
+      3. intended-use
+      4. buy-or-make
+    {% endcomment %}
+
+    {% with page_questions=section_pages.0.elements %}
+    {% if software_project_title or research_fields|length or application_class or research_question_title or buy_or_make %}
+    &lt;h3&gt;Topic&lt;/h3&gt;
+      
+      {% check_element page_questions.0 project=project as software_project_title_question_result %}
+      {% if software_project_title_question_result %}
+        {% if software_project_title %}
+        &lt;p&gt;The title of the software project is: {{ software_project_title.value }}&lt;/p&gt;
+        {% endif %}
+      {% endif %}
+
+      {% check_element page_questions.1 project=project as rf_question_result %}
+      {% if rf_question_result %}
+        {% if research_fields|length %}
+        &lt;p&gt;The software belongs to the research field{{ research_fields|pluralize }}: {% if research_fields|length == 1 %}{{ research_fields.0.value }}
+          {% elif research_fields|length &gt; 1 %}
+          &lt;ul&gt;
+          {% for rf in research_fields %}
+            &lt;li&gt;{{ rf.value }}&lt;/li&gt;
+          {% endfor %}
+          &lt;/ul&gt;
+          {% endif %}
+        &lt;/p&gt;
+        {% endif %}
+      {% endif %}
+    
+      {% check_element page_questions.2 project=project as ac_question_result %}
+      {% if ac_question_result %}
+        {% if application_class %}
+        &lt;p&gt;It is categorized in {{ application_class.value }}&lt;/p&gt;
+        {% endif %}
+      {% endif %}
+    
+      {% check_element page_questions.3 project=project as rq_question_result %}
+      {% if rq_question_result %}
+        {% if research_question_title %}
+        &lt;p&gt;Its intended use and its contribution to research:&lt;/p&gt;
+        &lt;div class="textarea"&gt;{{ research_question_title.value|linebreaks }}&lt;/div&gt;
+        {% endif %}
+      {% endif %}
+      
+      {% check_element page_questions.4 project=project as novelty_question_result %}
+      {% if novelty_question_result %}
+        {% if buy_or_make %}
+        &lt;p&gt;Its novelty:&lt;/p&gt;
+        &lt;div class="textarea"&gt;{{ buy_or_make.value|linebreaks }}&lt;/div&gt;
+        {% endif %}
+      {% endif %}
+
+    {% endif %}
+    {% endwith %} 
+  {% endif %}
+  
+  {% check_element section_pages.1 project=project as partner_page_result %}
+  {% if partner_page_result %}
+    {% if partners %}
+    &lt;h3&gt;Contributor{{ partners|pluralize }}&lt;/h3&gt;
+      &lt;ul&gt;
+      {% for p in partners %}
+        {% with p_set_index_str=p.set_index|stringformat:'s' %}
+        {% get_set_value p 'project/partner/type' as p_type %}
+        {% get_set_value p 'project/partner/orcid' as p_orcid %}
+        {% get_set_value p 'project/partner/website' as p_website %}
+        {% get_set_value p 'project/partner/given-name' as p_given_name %}
+        {% get_set_value p 'project/partner/family-name' as p_family_name %}
+        {% get_set_value p 'project/partner/name' as p_name %}
+        {% get_values 'project/partner/affiliation' p_set_index_str as p_affiliations %}
+        {% get_values 'project/partner/role' p_set_index_str as p_roles %}
+
+        &lt;li&gt;{% if p_type.option_uri == 'https://rdmo.mpdl.mpg.de/terms/options/partner-types/person' and p_given_name.value and p_family_name.value %}{{ p_given_name.value }} {{ p_family_name.value }}{% elif p_type.option_uri == 'https://rdmo.mpdl.mpg.de/terms/options/partner-types/entity' and p_name.value %}{{ p_name.value }}{% else %}{{ p.value }}{% endif %}{% if p_type.option_uri == 'https://rdmo.mpdl.mpg.de/terms/options/partner-types/person' and p_orcid.value %} ({{ p_orcid.value }}){% endif %}{% if p_type.option_uri == 'https://rdmo.mpdl.mpg.de/terms/options/partner-types/entity' and p_website.value %} ({{ p_website.value }}){% endif %}{% if p_affiliations %}, {% for a in p_affiliations %}{% for r in p_roles %}{% if r.set_index == a.set_index %}{{ r.value }} at {% endif %}{% endfor %}{{ a.value }}{% if not forloop.last %} &amp; {% endif %}{% endfor %}{% endif %}&lt;/li&gt;
+        
+        {% endwith %}
+      {% endfor %}
+      &lt;/ul&gt;
+    {% endif %}
+  {% endif %}
+  
+  {% check_element section_pages.2 project=project as funding_page_result %}
+  {% if funding_page_result %}
+    {% if funder %}
+    &lt;h3&gt;Funding&lt;/h3&gt;
+    {% with page_questions=section_pages.2.elements %}
+      {% comment %}
+        Questions:
+        0. funding    
+      {% endcomment %}
+    
+      {% check_element page_questions.0 project=project as funding_question_result %}
+      {% if funding_question_result %}
+        {% if funder %}
+        &lt;p&gt;Existing (financial or personnel) resources or specific funding for the software development:&lt;/p&gt;
+        &lt;div class="textarea"&gt;{{ funder.value|linebreaks }}&lt;/div&gt;
+        {% endif %}
+      {% endif %}
+  
+    {% endwith %}
+    {% endif %}
+  
+  {% endif %}
+  
+  {% check_element section_pages.3 project=project as schedule_page_result %}
+  {% if schedule_page_result %}
+    {% if project_start_date or project_end_date %}
+    &lt;h3&gt;Schedule&lt;/h3&gt;
+    {% with page_questions=section_pages.3.elements %}
+      {% comment %}
+        Questions:
+        0. start-date
+        1. end-date
+      {% endcomment %}
+    
+      {% check_element page_questions.0 project=project as sd_question_result %}
+      {% if sd_question_result %}
+        {% if project_start_date %}
+        &lt;p&gt;Project's start date: {{ project_start_date.value }}&lt;/p&gt;
+        {% endif %}
+      {% endif %}
+
+      {% check_element page_questions.1 project=project as ed_question_result %}
+      {% if ed_question_result %}
+        {% if project_end_date %}
+        &lt;p&gt;Project's end date: {{ project_end_date.value }}&lt;/p&gt;
+        {% endif %}
+      {% endif %}
+
+    {% endwith %}
+    {% endif %}
+  
+  {% endif %}
+  
+  {% check_element section_pages.4 project=project as pm_page_result %}
+  {% if pm_page_result %}
+    {% if development_process or tracking_methods|length or ss %}
+    &lt;h3&gt;Project Management&lt;/h3&gt;
+    {% with page_questions=section_pages.4.elements %}
+      {% comment %}
+        Questions:
+        0. development-process
+        1. track-tasks
+        2. specification-sheet
+      {% endcomment %}
+    
+      {% check_element page_questions.0 project=project as dp_question_result %}
+      {% if dp_question_result %}
+        {% if development_process %}
+        &lt;p&gt;Development process and roles:&lt;/p&gt;
+        &lt;div class="textarea"&gt;{{ development_process.value|linebreaks }}&lt;/div&gt;
+        {% endif %}
+      {% endif %}
+    
+      {% check_element page_questions.1 project=project as tm_question_result %}
+      {% if tm_question_result %}
+        {% if tracking_methods|length %}
+        &lt;p&gt;Tasks and use cases will be tracked with: {% if tracking_methods|length == 1 %}{{ tracking_methods.0.value }}
+          {% elif tracking_methods|length &gt; 1 %}
+          &lt;ul&gt;
+          {% for tm in tracking_methods %}
+            &lt;li&gt;{{ tm.value }}&lt;/li&gt;
+          {% endfor %}
+          &lt;/ul&gt;
+          {% endif %} 
+        &lt;/p&gt;
+        {% endif %}
+      {% endif %}
+    
+      {% check_element page_questions.2 project=project as ss_question_result %}
+      {% if ss_question_result %}
+        {% if ss %}
+        &lt;p&gt;{% if ss.is_true %}The software's most important requirements will be (briefly) outlined by a specification document.
+        {% else %}There will not be any specification document outlining the software's most important requirements.
+        {% endif %}
+        &lt;/p&gt;
+        {% endif %}
+      {% endif %}
+
+    {% endwith %}
+    {% endif %}
+
+  {% endif %}
+
+  {% check_element section_pages.5 project=project as sr_page_result %}
+  {% if sr_page_result %}
+    {% if institutional_requirements or community_requirements %}
+    &lt;h3&gt;Development Requirements&lt;/h3&gt;
+    {% with page_questions=section_pages.5.elements %}
+      {% comment %}
+        Questions:
+        0. institutional-requirements
+        1. community-requirements
+      {% endcomment %}
+    
+      {% check_element page_questions.0 project=project as ir_question_result %}
+      {% if ir_question_result %}
+        {% if institutional_requirements %}
+        &lt;p&gt;Institutional requirements for software development:&lt;/p&gt;
+        &lt;div class="textarea"&gt;{{ institutional_requirements.value|linebreaks }}&lt;/div&gt;
+        {% endif %}
+      {% endif %}
+
+      {% check_element page_questions.1 project=project as cr_question_result %}
+      {% if cr_question_result %}
+        {% if community_requirements %}
+        &lt;p&gt;Requirements for software development from other parties:&lt;/p&gt;
+        &lt;div class="textarea"&gt;{{ community_requirements.value|linebreaks }}&lt;/div&gt;
+        {% endif %}
+      {% endif %}
+
+    {% endwith %}
+    {% endif %}
+      
+  {% endif %}  
+
+{% endwith %}
+{% endif %}
+
+{# ############################################################################################# #}
+{# ################# #}
+{# SECTION TECHNICAL #}
+{# ################# #}
+{% comment %}
+    0. code
+        0. language
+        1. versioning
+    1. third-party-components
+        0. external-components
+        1. third-party-licenses
+        2. track-external-software
+        3. web-services
+        4. qualified-references
+    2. infrastructure
+        0. infrastructure-required
+        1. infrastructure-existing
+        2. technical-support
+    3. preservation
+        0. re-usable
+        1. preservation
+    4. security
+        0. security
+        1. safety
+{% endcomment %}
+
+{# VALUES OF SECTION TECHNICAL #}
+
+{# code #}
+{% get_values 'smp/language' as programming_languages %}
+{% get_value 'smp/versioning' as versioning %}
+
+{# third-party-components #}
+{% get_value 'smp/external-components' as external_components %}
+{% get_value 'smp/third-party-licenses' as third_party_licenses %}
+{% get_value 'smp/track-external-software' as track_external_software %}
+{% get_value 'smp/web-services' as web_services %}
+{% get_value 'smp/qualified-references' as qualified_references %}
+
+{# infrastructure #}
+{% get_value 'smp/infrastructure-required' as infrastructure_required %}
+{% get_value 'smp/infrastructure-existing' as infrastructure_existing %}
+{% get_value 'smp/technical-support' as technical_support %}
+
+{# preservation #}
+{% get_value 'smp/re-usable' as reusable %}
+{% get_value 'smp/preservation' as preservation %}
+
+{# security #}
+{% get_value 'smp/security' as security %}
+{% get_value 'smp/safety' as safety %}
+
+{% if programming_languages|length or versioning or external_components or third_party_licenses or track_external_software or web_services or qualified_references or infrastructure_required or infrastructure_existing or technical_support or reusable or preservation or security or safety %}
+&lt;h2&gt;Technical&lt;/h2&gt;
+{% with section_pages=sections.1.elements %}
+  {% comment %}
+      Pages:
+      0. code
+      1. components 
+      2. infrastructure
+      3. preservation
+      4. security
+  {% endcomment %}
+
+  {% check_element section_pages.0 project=project as code_page_result %}
+  {% if code_page_result %}
+    {% if programming_languages|length or versioning %}
+    &lt;h3&gt;Code&lt;/h3&gt;
+    {% with page_questions=section_pages.0.elements %}
+        {% comment %}
+          Questions:
+          0. language
+          1. versioning
+        {% endcomment %}
+      
+        {% check_element page_questions.0 project=project as language_question_result %}
+        {% if language_question_result %}
+          {% if programming_languages|length %}
+          &lt;p&gt;Programming language{{ programming_languages|pluralize }}: {% if programming_languages|length == 1 %}{{ programming_languages.0.value }}
+            {% elif programming_languages|length &gt; 1 %}
+            &lt;ul&gt;
+            {% for language in programming_languages %}
+              &lt;li&gt;{{ language.value }}&lt;/li&gt;
+            {% endfor %}
+            &lt;/ul&gt;
+            {% endif %}
+          &lt;/p&gt;
+          {% endif %}
+        {% endif %}
+  
+        {% check_element page_questions.1 project=project as versioning_question_result %}
+        {% if versioning_question_result %}
+          {% if versioning %}
+          &lt;p&gt;Technology or process used for versioning:&lt;/p&gt;
+          &lt;div class="textarea"&gt;{{ versioning.value|linebreaks }}&lt;/div&gt;
+          {% endif %}
+        {% endif %}
+
+    {% endwith %}
+    {% endif %}
+    
+  {% endif %}
+
+  {% check_element section_pages.1 project=project as components_page_result %}
+  {% if components_page_result %}
+    {% if external_components or third_party_licenses or track_external_software or web_services or qualified_references %}
+    &lt;h3&gt;Third-Party Components and Libraries&lt;/h3&gt;
+    {% with page_questions=section_pages.1.elements %}
+        {% comment %}
+          Questions:
+          0. external-components
+          1. third-party-licenses
+          2. track-external-software
+          3. web-services
+          4. qualified-references
+        {% endcomment %}
+      
+        {% check_element page_questions.0 project=project as ec_question_result %}
+        {% if ec_question_result %}
+          {% if external_components %}
+          &lt;p&gt;Dependencies and documentation of used third-party software components and libraries:&lt;/p&gt;
+          &lt;div class="textarea"&gt;{{ external_components.value|linebreaks }}&lt;/div&gt;
+          {% endif %}
+        {% endif %}
+
+        {% check_element page_questions.1 project=project as tpl_question_result %}
+        {% if tpl_question_result %}
+          {% if third_party_licenses %}
+          &lt;p&gt;Licenses of used third-party software components:&lt;/p&gt;
+          &lt;div class="textarea"&gt;{{ third_party_licenses.value|linebreaks }}&lt;/div&gt;
+          {% endif %}
+        {% endif %}
+
+        {% check_element page_questions.2 project=project as tes_question_result %}
+        {% if tes_question_result %}
+          {% if track_external_software %}
+          &lt;p&gt;Tracking of external software components and dependency mitigation/elimination:&lt;/p&gt;
+          &lt;div class="textarea"&gt;{{ track_external_software.value|linebreaks }}&lt;/div&gt;
+          {% endif %}
+        {% endif %}
+
+        {% check_element page_questions.3 project=project as ws_question_result %}
+        {% if ws_question_result %}
+          {% if web_services %}
+          &lt;p&gt;Planned use of third-party web services:&lt;/p&gt;
+          &lt;div class="textarea"&gt;{{ web_services.value|linebreaks }}&lt;/div&gt;
+          {% endif %}
+        {% endif %}
+
+        {% check_element page_questions.4 project=project as qr_question_result %}
+        {% if qr_question_result %}
+          {% if qualified_references %}
+          &lt;p&gt;Reference to other software or objects:&lt;/p&gt;
+          &lt;div class="textarea"&gt;{{ qualified_references.value|linebreaks }}&lt;/div&gt;
+          {% endif %}
+        {% endif %}
+
+    {% endwith %}
+    {% endif %}
+
+  {% endif %}
+
+  {% check_element section_pages.2 project=project as infrastructure_page_result %}
+  {% if infrastructure_page_result %}
+    {% if infrastructure_required or infrastructure_existing or technical_support %}
+    &lt;h3&gt;Infrastructure&lt;/h3&gt;
+    {% with page_questions=section_pages.2.elements %}
+        {% comment %}
+          Questions:
+          0. infrastructure-required
+          1. infrastructure-existing
+          2. technical-support
+        {% endcomment %}
+      
+        {% check_element page_questions.0 project=project as ir_question_result %}
+        {% if ir_question_result %}
+          {% if infrastructure_required %}
+          &lt;p&gt;Needed infrastructure resources:&lt;/p&gt;
+          &lt;div class="textarea"&gt;{{ infrastructure_required.value|linebreaks }}&lt;/div&gt;
+          {% endif %}
+        {% endif %}
+
+        {% check_element page_questions.1 project=project as ie_question_result %}
+        {% if ie_question_result %}
+          {% if infrastructure_existing %}
+          &lt;p&gt;Existing infrastructure for the software development:&lt;/p&gt;
+          &lt;div class="textarea"&gt;{{ infrastructure_existing.value|linebreaks }}&lt;/div&gt;
+          {% endif %}
+        {% endif %}
+
+        {% check_element page_questions.2 project=project as ts_question_result %}
+        {% if ts_question_result %}
+          {% if technical_support %}
+          &lt;p&gt;Needed technical training or code-reviewing process:&lt;/p&gt;
+          &lt;div class="textarea"&gt;{{ technical_support.value|linebreaks }}&lt;/div&gt;
+          {% endif %}
+        {% endif %}
+    
+    {% endwith %}
+    {% endif %}
+
+  {% endif %}
+
+  {% check_element section_pages.3 project=project as preservation_page_result %}
+  {% if preservation_page_result %}
+    {% if reusable or preservation %}
+    &lt;h3&gt;Preservation&lt;/h3&gt;
+    {% with page_questions=section_pages.3.elements %}
+        {% comment %}
+          Questions:
+          0. re-usable
+          1. preservation
+        {% endcomment %}
+      
+        {% check_element page_questions.0 project=project as reusable_question_result %}
+        {% if reusable_question_result %}
+          {% if reusable %}
+          &lt;p&gt;Time horizon and taken measures for software reusability: &lt;/p&gt;
+          &lt;div class="textarea"&gt;{{ reusable.value|linebreaks }}&lt;/div&gt;
+          {% endif %}
+        {% endif %}
+
+        {% check_element page_questions.1 project=project as preservation_question_result %}
+        {% if preservation_question_result %}
+          {% if preservation %}
+          &lt;p&gt;Time horizon for software preservation:&lt;/p&gt;
+          &lt;div class="textarea"&gt;{{ preservation.value|linebreaks }}&lt;/div&gt;
+          {% endif %}
+        {% endif %}
+
+    {% endwith %}
+    {% endif %}
+
+  {% endif %}
+  
+  {% check_element section_pages.4 project=project as security_page_result %}
+  {% if security_page_result %}
+    {% if security or safety %}
+    &lt;h3&gt;Security&lt;/h3&gt;
+    {% with page_questions=section_pages.4.elements %}
+      {% comment %}
+        Questions:
+        0. security
+        1. safety
+      {% endcomment %}
+    
+      {% check_element page_questions.0 project=project as security_question_result %}
+      {% if security_question_result %}
+        {% if security %}
+        &lt;p&gt;Measures or provisions in place to ensure software IT security:&lt;/p&gt;
+        &lt;div class="textarea"&gt;{{ security.value|linebreaks }}&lt;/div&gt;
+        {% endif %}
+      {% endif %}
+
+      {% check_element page_questions.1 project=project as safety_question_result %}
+      {% if safety_question_result %}
+        {% if safety %}
+        &lt;p&gt;Measures to minimise risks in relation to software development:&lt;/p&gt;
+        &lt;div class="textarea"&gt;{{ safety.value|linebreaks }}&lt;/div&gt;
+        {% endif %}
+      {% endif %}
+
+    {% endwith %}
+    {% endif %}
+
+  {% endif %}
+
+{% endwith %}
+{% endif %}
+
+{# ############################################################################################# #}
+{# ######################### #}
+{# SECTION QUALITY ASSURANCE #}
+{# ######################### #}
+{% comment %}
+    0. governance
+        0. governance-model
+        1. coding-standards
+    1. documentation
+        0. who-is-responsible
+        1. documentation-stored
+    2. testing
+        0. test-strategy
+        1. test-documentation
+{% endcomment %}
+
+{# VALUES OF SECTION QUALITY ASSURANCE #}
+
+{# governance #}
+{% get_value 'smp/governance-model' as governance_model %}
+{% get_values 'smp/coding-standards' as coding_standards %}
+
+{# documentation #}
+{% get_value 'smp/documentation/who-is-responsible' as who_is_responsible %}
+{% get_value 'smp/documentation/documentation-stored' as documentation_stored %}
+
+{# testing #}
+{% get_values 'smp/test-strategy' as test_strategies %}
+{% get_value 'smp/test-documentation' as test_documentation %}
+
+{% if governance_model or coding_standards or who_is_responsible or documentation_stored or test_strategies or test_documentation %}
+&lt;h2&gt;Quality Assurance&lt;/h2&gt;
+{% with section_pages=sections.2.elements %}
+  {% comment %}
+    Pages:
+    0. governance
+    1. documentation 
+    2. testing
+  {% endcomment %}
+
+  {% check_element section_pages.0 project=project as governance_page_result %}
+  {% if governance_page_result %}
+    {% if governance_model or coding_standards %}
+    &lt;h3&gt;Governance and Defined Processes&lt;/h3&gt;
+    {% with page_questions=section_pages.0.elements %}
+      {% comment %}
+        Questions:
+        0. governance-model
+        1. coding-standards
+      {% endcomment %}
+    
+      {% check_element page_questions.0 project=project as gm_question_result %}
+      {% if gm_question_result %}
+        {% if governance_model %}
+        &lt;p&gt;Governance model for software development:&lt;/p&gt;
+        &lt;div class="textarea"&gt;{{ governance_model.value|linebreaks }}&lt;/div&gt;
+        {% endif %}
+      {% endif %}
+
+      {% check_element page_questions.1 project=project as cs_question_result %}
+      {% if cs_question_result %}
+        {% if coding_standards %}
+        &lt;p&gt;Coding standard{{ coding_standards|pluralize }} and quality control{{ coding_standards|pluralize }}: {% if coding_standards|length == 1 %}{% if coding_standards.0.text %}{{ coding_standards.0.text }}{% else %}{{ coding_standards.0.value }}{% endif %}
+          {% elif coding_standards|length &gt; 1 %}
+          &lt;ul&gt;
+          {% for cs in coding_standards %}
+            &lt;li&gt;{% if cs.text %}{{ cs.text }}{% else %}{{ cs.value }}{% endif %}&lt;/li&gt;
+          {% endfor %}
+          &lt;/ul&gt;
+          {% endif %}
+        &lt;/p&gt;
+        {% endif %}
+      {% endif %}
+
+    {% endwith %}
+    {% endif %}
+
+  {% endif %}
+
+  {% check_element section_pages.1 project=project as documentation_page_result %}
+  {% if documentation_page_result %}
+    {% if who_is_responsible or documentation_stored %}
+    &lt;h3&gt;Documentation&lt;/h3&gt;
+    {% with page_questions=section_pages.1.elements %}
+      {% comment %}
+        Questions:
+        0. who-is-responsible
+        1. documentation-stored
+      {% endcomment %}
+    
+      {% check_element page_questions.0 project=project as wir_question_result %}
+      {% if wir_question_result %}
+        {% if who_is_responsible %}
+        &lt;p&gt;Software documentation:&lt;/p&gt;
+        &lt;div class="textarea"&gt;{{ who_is_responsible.value|linebreaks }}&lt;/div&gt;
+        {% endif %}
+      {% endif %}
+
+      {% check_element page_questions.1 project=project as ds_question_result %}
+      {% if ds_question_result %}
+        {% if documentation_stored %}
+        &lt;p&gt;Documentation storage and language:&lt;/p&gt;
+        &lt;div class="textarea"&gt;{{ documentation_stored.value|linebreaks }}&lt;/div&gt;
+        {% endif %}
+      {% endif %}
+
+    {% endwith %}
+    {% endif %}
+
+  {% endif %}
+
+  {% check_element section_pages.2 project=project as testing_page_result %}
+  {% if testing_page_result %}
+    {% if test_strategies or test_documentation %}
+    &lt;h3&gt;Testing&lt;/h3&gt;
+    {% with page_questions=section_pages.2.elements %}
+      {% comment %}
+        Questions:
+        0. test-strategy
+        1. test-documentation
+      {% endcomment %}
+    
+      {% check_element page_questions.0 project=project as ts_question_result %}
+      {% if ts_question_result %}
+        {% if test_strategies %}
+        &lt;p&gt;Test strateg{{ test_strategies|pluralize:'y,ies' }}: {% if test_strategies|length == 1 %}{% if test_strategies.0.text %}{{ test_strategies.0.text }}{% else %}{{ test_strategies.0.value }}{% endif %}
+          {% elif test_strategies|length &gt; 1 %}
+          &lt;ul&gt;
+          {% for ts in test_strategies %}
+            &lt;li&gt;{% if ts.text %}{{ ts.text }}{% else %}{{ ts.value }}{% endif %}&lt;/li&gt;
+          {% endfor %}
+          &lt;/ul&gt;
+          {% endif %}
+        &lt;/p&gt;
+        {% endif %}
+      {% endif %}
+
+      {% check_element page_questions.1 project=project as td_question_result %}
+      {% if td_question_result %}
+        {% if test_documentation %}
+        &lt;p&gt;Test documentation:&lt;/p&gt;
+        &lt;div class="textarea"&gt;{{ test_documentation.value|linebreaks }}&lt;/div&gt;
+        {% endif %}
+      {% endif %}
+
+    {% endwith %}
+    {% endif %}
+
+  {% endif %}
+
+{% endwith %}
+{% endif %}
+
+
+{# ############################################################################################# #}
+{# ########################### #}
+{# SECTION RELEASE AND PUBLISH #}
+{# ########################### #}
+{% comment %}
+    0. releasing
+        0. releasing-who
+        1. decision-releasing
+        2. store-software
+    1. publicly-available
+        0. software-sharing
+        1. software-repository
+        2. contribute-software
+        3. peer-review
+    2. metadata
+        0. assign-metadata
+        1. software-pid
+    3. support
+        0. support-for-software
+        1. feedback-process
+        2. relation-SMP-DMP
+        3. publish-smp
+{% endcomment %}
+
+{# VALUES OF SECTION RELEASE AND PUBLISH #}
+
+{# releasing #}
+{% get_value 'smp/releasing-who' as releasing_who %}
+{% get_value 'smp/decision-releasing' as decision_releasing %}
+{% get_value 'smp/store-software' as store_software %}
+
+{# publicly-available #}
+{% get_value 'smp/software-sharing' as software_sharing %}
+{% get_value 'smp/software-repository' as software_repository %}
+{% get_value 'smp/contribute-software' as contribute_software %}
+{% get_value 'smp/peer-review' as peer_review %}
+
+{# metadata #}
+{% get_value 'smp/software-metadata' as software_metadata %}
+{% get_values 'smp/software-pid' as software_pids %}
+
+{# support #}
+{% get_value 'smp/support-for-software' as sfs %}
+{% get_value 'smp/feedback-process' as feedback_process %}
+{% get_value 'smp/relation-SMP-DMP' as relation_smp_dmp %}
+{% get_value 'smp/publish-smp' as ps %}
+
+
+{% if releasing_who or decision_releasing or store_software or software_sharing or software_repository or contribute_software or peer_review or software_metadata or software_pids|length or sfs or feedback_process or relation_smp_dmp or ps %}
+&lt;h2&gt;Release and Publish&lt;/h2&gt;
+{% with section_pages=sections.3.elements %}
+  {% comment %}
+    Pages:
+    0. releasing
+    1. publicly-available 
+    2. metadata
+    3. support
+  {% endcomment %}
+
+  {% check_element section_pages.0 project=project as releasing_page_result %}
+  {% if releasing_page_result %}
+    {% if releasing_who or decision_releasing or store_software %}
+    &lt;h3&gt;Releasing&lt;/h3&gt;
+    {% with page_questions=section_pages.0.elements %}
+      {% comment %}
+        Questions:
+        0. releasing-who
+        1. decision-releasing
+        2. store-software
+      {% endcomment %}
+    
+      {% check_element page_questions.0 project=project as rw_question_result %}
+      {% if rw_question_result %}
+        {% if releasing_who %}
+        &lt;p&gt;Release process:&lt;/p&gt;
+        &lt;div class="textarea"&gt;{{ releasing_who.value|linebreaks }}&lt;/div&gt;
+        {% endif %}
+      {% endif %}
+
+      {% check_element page_questions.1 project=project as dr_question_result %}
+      {% if dr_question_result %}
+        {% if decision_releasing %}
+        &lt;p&gt;Decision process for releasing and releasing frequency:&lt;/p&gt;
+        &lt;div class="textarea"&gt;{{ decision_releasing.value|linebreaks }}&lt;/div&gt;
+        {% endif %}
+      {% endif %}
+
+      {% check_element page_questions.2 project=project as ss_question_result %}
+      {% if ss_question_result %}
+        {% if store_software %}
+        &lt;p&gt;Software storage and preservation policy:&lt;/p&gt;
+        &lt;div class="textarea"&gt;{{ store_software.value|linebreaks }}&lt;/div&gt;
+        {% endif %}
+      {% endif %}
+
+    {% endwith %}
+    {% endif %}
+
+  {% endif %}
+
+  {% check_element section_pages.1 project=project as pa_page_result %}
+  {% if pa_page_result %}
+    {% if software_sharing or software_repository or contribute_software or peer_review %}
+    &lt;h3&gt;Publicly Availability&lt;/h3&gt;
+    {% with page_questions=section_pages.1.elements %}
+      {% comment %}
+        Questions:
+        0. software-sharing
+        1. software-repository
+        2. contribute-software
+        3. peer-review
+      {% endcomment %}
+    
+      {% check_element page_questions.0 project=project as ss_question_result %}
+      {% if ss_question_result %}
+        {% if software_sharing %}
+        &lt;p&gt;{% if software_sharing.is_true %}The software will be publicly available.
+        {% else %}The software will not be publicly available.
+        {% endif %}
+        &lt;/p&gt;
+        {% endif %}
+      {% endif %}
+
+      {% check_element page_questions.1 project=project as sr_question_result %}
+      {% if sr_question_result %}
+        {% if software_repository %}
+        &lt;p&gt;Software repository or archive, findability and usability:&lt;/p&gt;
+        &lt;div class="textarea"&gt;{{ software_repository.value|linebreaks }}&lt;/div&gt;
+        {% endif %}
+      {% endif %}
+
+      {% check_element page_questions.2 project=project as cs_question_result %}
+      {% if cs_question_result %}
+        {% if contribute_software %}
+        &lt;p&gt;Software contributions from the community:&lt;/p&gt;
+        &lt;div class="textarea"&gt;{{ contribute_software.value|linebreaks }}&lt;/div&gt;
+        {% endif %}
+      {% endif %}
+
+      {% check_element page_questions.3 project=project as pr_question_result %}
+      {% if pr_question_result %}
+        {% if peer_review %}
+        &lt;p&gt;Planned (Open) Peer Review for the software:&lt;/p&gt;
+        &lt;div class="textarea"&gt;{{ peer_review.value|linebreaks }}&lt;/div&gt;
+        {% endif %}
+      {% endif %}
+    
+    {% endwith %}
+    {% endif %}
+
+  {% endif %}
+
+  {% check_element section_pages.2 project=project as metadata_page_result %}
+  {% if metadata_page_result %}
+    {% if software_metadata or software_pids|length %}
+    &lt;h3&gt;Metadata&lt;/h3&gt;
+    {% with page_questions=section_pages.2.elements %}
+      {% comment %}
+        Questions:
+        0. assign-metadata
+        1. software-pid
+      {% endcomment %}
+    
+      {% check_element page_questions.0 project=project as am_question_result %}
+      {% if am_question_result %}
+        {% if software_metadata %}
+        &lt;p&gt;Software's metadata assignment:&lt;/p&gt;
+        &lt;div class="textarea"&gt;{{ software_metadata.value|linebreaks }}&lt;/div&gt;
+        {% endif %}
+      {% endif %}
+
+      {% check_element page_questions.1 project=project as sp_question_result %}
+      {% if sp_question_result %}
+        {% if software_pids|length %}
+        &lt;p&gt;Software's persistent identifier{{ software_pids|pluralize }}: {% if software_pids|length == 1 %}{{ software_pids.0.value }}
+        {% elif software_pids|length &gt; 1 %}
+        &lt;ul&gt;
+          {% for sp in software_pids %}
+            &lt;li&gt;{{ sp.value }}&lt;/li&gt;
+          {% endfor %}
+        &lt;/ul&gt;
+        {% endif %}
+        &lt;/p&gt;
+        {% endif %}
+      {% endif %}
+
+    {% endwith %}
+    {% endif %}
+
+  {% endif %}
+
+  {% check_element section_pages.3 project=project as support_page_result %}
+  {% if support_page_result %}
+    {% if sfs or feedback_process or relation_smp_dmp or ps %}
+    &lt;h3&gt;Support&lt;/h3&gt;
+    {% with page_questions=section_pages.3.elements %}
+      {% comment %}
+        Questions:
+        0. support-for-software
+        1. feedback-process
+        2. relation-SMP-DMP
+        3. publish-smp
+      {% endcomment %}
+    
+      {% check_element page_questions.0 project=project as sfs_question_result %}
+      {% if sfs_question_result %}
+        {% if sfs %}
+        &lt;p&gt;{% if sfs.is_true %}There will be support and help to re-users of the software.
+        {% else %}There will not be support for the software.
+        {% endif %}
+        &lt;/p&gt;
+        {% endif %}
+      {% endif %}
+
+      {% check_element page_questions.1 project=project as fp_question_result %}
+      {% if fp_question_result %}
+        {% if feedback_process %}
+        &lt;p&gt;Support and feedback process with users:&lt;/p&gt;
+        &lt;div class="textarea"&gt;{{ feedback_process.value|linebreaks }}&lt;/div&gt;
+        {% endif %}
+      {% endif %}
+
+      {% check_element page_questions.2 project=project as rsmpdmp_question_result %}
+      {% if rsmpdmp_question_result %}
+        {% if relation_smp_dmp %}
+        &lt;p&gt;Relation of this Software Management Plan to other Software or Data Management Plan(s):&lt;/p&gt;
+        &lt;div class="textarea"&gt;{{ relation_smp_dmp.value|linebreaks }}&lt;/div&gt;
+        {% endif %}
+      {% endif %}
+
+      {% check_element page_questions.3 project=project as ps_question_result %}
+      {% if ps_question_result %}
+        {% if ps %}
+        &lt;p&gt;{% if ps.text %}This Software Management Plan will be publicly available in {{ ps.text }}.
+        {% else %}This Software Management Plan will not be publicly available. 
+        {% endif %}
+        &lt;/p&gt;
+        {% endif %}
+      {% endif %}
+
+    {% endwith %}
+    {% endif %}
+
+  {% endif %}
+   
+{% endwith %}
+{% endif %}
+
+{# ############################################################################################# #}
+{# ######################## #}
+{# SECTION LEGAL AND ETHICS #}
+{# ######################## #}
+{% comment %}
+    0. intellectual-rights
+        0. software-property-rights
+        1. external-software-rights
+    1. license
+        0. software-license
+    2. dual-use
+        0. dual-use-software
+  {% endcomment %}
+
+{# VALUES OF SECTION LEGAL AND ETHICS #}
+
+{# intellectual-rights #}
+{% get_value 'smp/software-property-rights' as property_rights %}
+{% get_value 'smp/external-software-rights' as external_software_rights %}
+
+{# license #}
+{% get_values 'smp/software-license' as software_licenses %}
+
+{# dual-use #}
+{% get_value 'smp/dual-use' as dual_use %}
+
+{% if property_rights or external_software_rights or software_licenses|length or dual_use %}
+&lt;h2&gt;Legal and Ethics&lt;/h2&gt;
+{% with section_pages=sections.4.elements %}
+  {% comment %}
+    Pages:
+    0. intellectual-rights
+    1. license
+    2. dual-use
+  {% endcomment %}
+
+  {% check_element section_pages.0 project=project as ir_page_result %}
+  {% if ir_page_result %}
+    {% if property_rights or external_software_rights %}
+    &lt;h3&gt;Intellectual Property Rights&lt;/h3&gt;
+    {% with page_questions=section_pages.0.elements %}
+      {% comment %}
+        Questions:
+        0. software-property-rights
+        1. external-software-rights
+      {% endcomment %}
+    
+      {% check_element page_questions.0 project=project as spr_question_result %}
+      {% if spr_question_result %}
+        {% if property_rights %}
+        &lt;p&gt;Legal ownership of the software:&lt;/p&gt;
+        &lt;div class="textarea"&gt;{{ property_rights.value|linebreaks }}&lt;/div&gt;
+        {% endif %}
+      {% endif %}
+
+      {% check_element page_questions.1 project=project as esr_question_result %}
+      {% if esr_question_result %}
+        {% if external_software_rights %}
+        &lt;p&gt;Third-party intellectual or industrial property rights:&lt;/p&gt;
+        &lt;div class="textarea"&gt;{{ external_software_rights.value|linebreaks }}&lt;/div&gt;
+        {% endif %}
+      {% endif %}
+
+    {% endwith %}
+    {% endif %}
+
+  {% endif %}
+
+  {% check_element section_pages.1 project=project as license_page_result %}
+  {% if license_page_result %}
+    {% if software_licenses|length %}
+    &lt;h3&gt;License&lt;/h3&gt;
+    {% with page_questions=section_pages.1.elements %}
+      {% comment %}
+        Questions:
+        0. software-license
+      {% endcomment %}
+    
+      {% check_element page_questions.0 project=project as sl_question_result %}
+      {% if sl_question_result %}
+        {% if software_licenses|length %}
+        &lt;p&gt;The software will be published under {{ software_licenses|pluralize:'this,these' }} license{{ software_licenses|pluralize }}: {% if software_licenses|length == 1 %}{% if software_licenses.0.text %}{{ software_licenses.0.text }}{% else %}{{ software_licenses.0.option_text }}{% endif %}
+        {% elif software_licenses|length &gt; 1 %}
+        &lt;ul&gt;
+          {% for sl in software_licenses %}
+            &lt;li&gt;{% if sl.text %}{{ sl.text }}{% else %}{{ sl.option_text }}{% endif %}&lt;/li&gt;
+          {% endfor %}
+        &lt;/ul&gt;
+        {% endif %}
+        &lt;/p&gt;
+        {% endif %}
+      {% endif %}
+
+    {% endwith %}
+    {% endif %}
+
+  {% endif %}
+
+  {% check_element section_pages.2 project=project as du_page_result %}
+  {% if du_page_result %}
+    {% if dual_use %}
+    &lt;h3&gt;Dual Use&lt;/h3&gt;
+    {% with page_questions=section_pages.2.elements %}
+      {% comment %}
+        Questions:
+        0. dual-use-software
+      {% endcomment %}
+    
+      {% check_element page_questions.0 project=project as dus_question_result %}
+      {% if dus_question_result %}
+        {% if dual_use %}
+        &lt;p&gt;Software's use for military purposes:&lt;/p&gt;
+        &lt;div class="textarea"&gt;{{ dual_use.value|linebreaks }}&lt;/div&gt;
+        {% endif %}
+      {% endif %}
+
+    {% endwith %}
+    {% endif %}
+
+  {% endif %}
+
+{% endwith %}
+{% endif %}
+
+
+
+{# sections #}
+{% endwith %}
+
+{# project.catalog.uri #}
+{% endif %}
+
+&lt;style&gt;
+  .textarea{
+    margin: 0 30px 0;
+  }
+&lt;/style&gt;</template>
+	</view>
+</rdmo>


### PR DESCRIPTION
As part of our [MAUS project](https://github.com/MPDL/MAUS), we updated the SMP catalog and added 4 views for it.

## Updates to SMP catalog

- We are including:
    - our current version of the whole SMP catalog, i.e. an updated version of `questions-smp.xml` of this repo
    - a subset of `questions-smp.xml` (`questions-smp-subset.xml`) containing only updated or added catalog elements. We also included the parent element, so that it is clear where the updated / element belongs (for example, if a new question was added, we also included the new question's page)

- The main modifications were:
    - the structuring of the project contributors (before: Software Project Partner(s))
    - the inclusion of 2 option set providers: ORCID and ROR

## New Views

We added 4 views for the SMP catalog:
    - `view-smp-citation.xml`
    - `view-smp-codemeta.xml`
    - `view-smp-readme.xml`
    - `view-smp-report.xml`

The first 3 views are templates for the corresponding metadata files. `view-smp-report.xml` is a template that displays the answers in the SMP project as a continuous-text report.










