### PR TITLE
Neue Attribute: Partner und Contributor

### DIFF
--- a/rdmorganiser/domain/attributes.xml
+++ b/rdmorganiser/domain/attributes.xml
@@ -1932,6 +1932,27 @@
 		<dc:comment/>
 		<parent dc:uri="https://rdmorganiser.github.io/terms/domain/project/partner"/>
 	</attribute>
+	<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/partner/ror">
+		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
+		<key>ror</key>
+		<path>project/partner/ror</path>
+		<comment>Introduced to enable interoperability with different maDMP approaches. Equivalent to rda:dmp/project/partner/ror.</comment>
+		<parent dc:uri="https://rdmorganiser.github.io/terms/domain/project/partner"/>
+	</attribute>
+	<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/partner/url">
+		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
+		<key>url</key>
+		<path>project/partner/url</path>
+		<comment>Introduced to enable interoperability with different maDMP approaches. Equivalent to rda:dmp/project/partner/url.</comment>
+		<parent dc:uri="https://rdmorganiser.github.io/terms/domain/project/partner"/>
+	</attribute>
+	<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/partner/address">
+		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
+		<key>address</key>
+		<path>project/partner/address</path>
+		<comment>Introduced to enable interoperability with different maDMP approaches. Equivalent to rda:dmp/project/partner/address.</comment>
+		<parent dc:uri="https://rdmorganiser.github.io/terms/domain/project/partner"/>
+	</attribute>
 	<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/physical_objects">
 		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
 		<key>physical_objects</key>

--- a/rdmorganiser/domain/attributes.xml
+++ b/rdmorganiser/domain/attributes.xml
@@ -35,6 +35,167 @@
 		<dc:comment/>
 		<parent dc:uri="https://rdmorganiser.github.io/terms/domain/project/additional_rdm_policy"/>
 	</attribute>
+	<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/contributor">
+		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
+		<key>contributor</key>
+		<path>project/contributor</path>
+		<dc:comment>Introduced to enable interoperability with different maDMP approaches.</dc:comment>
+		<parent dc:uri="https://rdmorganiser.github.io/terms/domain/project"/>
+	</attribute>
+	<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/contributor/id">
+		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
+		<key>id</key>
+		<path>project/contributor/id</path>
+		<dc:comment>Introduced to enable interoperability with different maDMP approaches.</dc:comment>
+		<parent dc:uri="https://rdmorganiser.github.io/terms/domain/project/contributor"/>
+	</attribute>
+	<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/contributor/person_or_entity">
+		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
+		<key>person_or_entity</key>
+		<path>project/contributor/person_or_entity</path>
+		<dc:comment>Introduced to enable interoperability with different maDMP approaches. Equivalent to rda:dmp/contributor/person_or_entity.</dc:comment>
+		<parent dc:uri="https://rdmorganiser.github.io/terms/domain/project/contributor"/>
+	</attribute>
+	<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/contributor/task">
+		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
+		<key>task</key>
+		<path>project/contributor/task</path>
+		<dc:comment>Introduced to enable interoperability with different maDMP approaches. Equivalent to rda:dmp/contributor/task.</dc:comment>
+		<parent dc:uri="https://rdmorganiser.github.io/terms/domain/project/contributor"/>
+	</attribute>
+	<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/contributor/email">
+		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
+		<key>email</key>
+		<path>project/contributor/email</path>
+		<dc:comment>Introduced to enable interoperability with different maDMP approaches. Equivalent to rda:dmp/contributor/mbox.</dc:comment>
+		<parent dc:uri="https://rdmorganiser.github.io/terms/domain/project/contributor"/>
+	</attribute>
+	<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/contributor/name">
+		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
+		<key>name</key>
+		<path>project/contributor/name</path>
+		<dc:comment>Introduced to enable interoperability with different maDMP approaches. Equivalent to rda:dmp/contributor/name.</dc:comment>
+		<parent dc:uri="https://rdmorganiser.github.io/terms/domain/project/contributor"/>
+	</attribute>
+	<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/contributor/role">
+		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
+		<key>role</key>
+		<path>project/contributor/role</path>
+		<dc:comment>Introduced to enable interoperability with different maDMP approaches. Equivalent to rda:dmp/contributor/role.</dc:comment>
+		<parent dc:uri="https://rdmorganiser.github.io/terms/domain/project/contributor"/>
+	</attribute>
+	<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/contributor/identifier">
+		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
+		<key>identifier</key>
+		<path>project/contributor/identifier</path>
+		<dc:comment>Introduced to enable interoperability with different maDMP approaches. Equivalent to rda:dmp/contributor/contributor_id.</dc:comment>
+		<parent dc:uri="https://rdmorganiser.github.io/terms/domain/project/contributor"/>
+	</attribute>
+	<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/contributor/identifier/value">
+		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
+		<key>value</key>
+		<path>project/contributor/identifier/value</path>
+		<dc:comment>Introduced to enable interoperability with different maDMP approaches. Equivalent to rda:dmp/contributor/contributor_id/identifier.</dc:comment>
+		<parent dc:uri="https://rdmorganiser.github.io/terms/domain/project/contributor/identifier"/>
+	</attribute>
+	<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/contributor/identifier/type">
+		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
+		<key>type</key>
+		<path>project/contributor/identifier/type</path>
+		<dc:comment>Introduced to enable interoperability with different maDMP approaches. Equivalent to rda:dmp/contributor/contributor_id/type.</dc:comment>
+		<parent dc:uri="https://rdmorganiser.github.io/terms/domain/project/contributor/identifier"/>
+	</attribute>
+	<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/contributor/organization">
+		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
+		<key>organization</key>
+		<path>project/contributor/organization</path>
+		<dc:comment>Introduced to enable interoperability with different maDMP approaches. Equivalent to rda:dmp/contributor/affiliation.</dc:comment>
+		<parent dc:uri="https://rdmorganiser.github.io/terms/domain/project/contributor"/>
+	</attribute>
+	<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/contributor/organization/name">
+		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
+		<key>name</key>
+		<path>project/contributor/organization/name</path>
+		<dc:comment>Introduced to enable interoperability with different maDMP approaches. Equivalent to rda:dmp/contributor/affiliation/name.</dc:comment>
+		<parent dc:uri="https://rdmorganiser.github.io/terms/domain/project/contributor/organization"/>
+	</attribute>
+	<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/contributor/organization/identifier">
+		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
+		<key>identifier</key>
+		<path>project/contributor/organization/identifier</path>
+		<dc:comment>Introduced to enable interoperability with different maDMP approaches. Equivalent to rda:dmp/contributor/affiliation/affiliation_id.</dc:comment>
+		<parent dc:uri="https://rdmorganiser.github.io/terms/domain/project/contributor/organization"/>
+	</attribute>
+	<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/contributor/organization/identifier/value">
+		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
+		<key>value</key>
+		<path>project/contributor/organization/identifier/value</path>
+		<dc:comment>Introduced to enable interoperability with different maDMP approaches. Equivalent to rda:dmp/contributor/affiliation/affiliation_id/identifier.</dc:comment>
+		<parent dc:uri="https://rdmorganiser.github.io/terms/domain/project/contributor/organization/identifier"/>
+	</attribute>
+	<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/contributor/organization/identifier/type">
+		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
+		<key>type</key>
+		<path>project/contributor/organization/identifier/type</path>
+		<dc:comment>Introduced to enable interoperability with different maDMP approaches. Equivalent to rda:dmp/contributor/affiliation/affiliation_id/type.</dc:comment>
+		<parent dc:uri="https://rdmorganiser.github.io/terms/domain/project/contributor/organization/identifier"/>
+	</attribute>
+	<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/contributor/organization/address">
+		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
+		<key>address</key>
+		<path>project/contributor/organization/address</path>
+		<dc:comment>Introduced to enable interoperability with different maDMP approaches. Equivalent to rda:dmp/contributor/affiliation/address.</dc:comment>
+		<parent dc:uri="https://rdmorganiser.github.io/terms/domain/project/contributor/organization"/>
+	</attribute>
+	<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/contributor/organization/url">
+		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
+		<key>url</key>
+		<path>project/contributor/organization/url</path>
+		<dc:comment>Introduced to enable interoperability with different maDMP approaches. Equivalent to rda:dmp/contributor/affiliation/url.</dc:comment>
+		<parent dc:uri="https://rdmorganiser.github.io/terms/domain/project/contributor/organization"/>
+	</attribute>
+	<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/contributor/organization/ror">
+		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
+		<key>ror</key>
+		<path>project/contributor/organization/ror</path>
+		<dc:comment>Introduced to enable interoperability with different maDMP approaches. Equivalent to rda:dmp/contributor/affiliation/ror.</dc:comment>
+		<parent dc:uri="https://rdmorganiser.github.io/terms/domain/project/contributor/organization"/>
+	</attribute>
+	<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/contributor/organization/ror-autocomplete">
+		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
+		<key>ror-autocomplete</key>
+		<path>project/contributor/organization/ror-autocomplete</path>
+		<dc:comment>Introduced to enable interoperability with the RDMO ROR plugin.</dc:comment>
+		<parent dc:uri="https://rdmorganiser.github.io/terms/domain/project/contributor/organization"/>
+	</attribute>
+	<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/contributor/given_name">
+		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
+		<key>given_name</key>
+		<path>project/contributor/given_name</path>
+		<dc:comment>Introduced to enable interoperability with different maDMP approaches. Equivalent to rda:dmp/contributor/given_name.</dc:comment>
+		<parent dc:uri="https://rdmorganiser.github.io/terms/domain/project/contributor"/>
+	</attribute>
+	<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/contributor/family_name">
+		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
+		<key>family_name</key>
+		<path>project/contributor/family_name</path>
+		<dc:comment>Introduced to enable interoperability with different maDMP approaches. Equivalent to rda:dmp/contributor/family_name.</dc:comment>
+		<parent dc:uri="https://rdmorganiser.github.io/terms/domain/project/contributor"/>
+	</attribute>
+	<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/contributor/orcid">
+		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
+		<key>orcid</key>
+		<path>project/contributor/orcid</path>
+		<dc:comment>Introduced to enable interoperability with different maDMP approaches. Equivalent to rda:dmp/contributor/orcid.</dc:comment>
+		<parent dc:uri="https://rdmorganiser.github.io/terms/domain/project/contributor"/>
+	</attribute>
+	<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/contributor/orcid-autocomplete">
+		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
+		<key>orcid-autocomplete</key>
+		<path>project/contributor/orcid-autocomplete</path>
+		<dc:comment>Introduced to enable interoperability with the RDMO ORCID plugin.</dc:comment>
+		<parent dc:uri="https://rdmorganiser.github.io/terms/domain/project/contributor"/>
+	</attribute>
 	<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/coordination">
 		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
 		<key>coordination</key>


### PR DESCRIPTION
Wie besprochen, hier werden folgende Attribute definiert, die im TF und/oder im SMP-Update aus dem Projekts MAUS (#348) vorkommen:

`project/partner/ror`  
`project/partner/url`  
`project/partner/address`  
`project/contributor/id`  
`project/contributor/person_or_entity`  
`project/contributor/task`  
`project/contributor/email`  
`project/contributor/name`  
`project/contributor/role`  
`project/contributor/identifier`  
`project/contributor/identifier/value`  
`project/contributor/identifier/type`  
`project/contributor/organization`  
`project/contributor/organization/name`  
`project/contributor/organization/identifier`  
`project/contributor/organization/identifier/value`  
`project/contributor/organization/identifier/type`  
`project/contributor/organization/address`  
`project/contributor/organization/url`  
`project/contributor/organization/ror`  
`project/contributor/organization/ror-autocomplete`  
`project/contributor/given_name`  
`project/contributor/family_name`  
`project/contributor/orcid`  
`project/contributor/orcid-autocomplete`  

fast alle mit einer Konkordanz zum NFDI DMP Template Framework (TF), ausgenommen drei: `project/contributor/id` (RDMO-interner Index), `project/contributor/organization/ror-autocomplete` und `project/contributor/orcid-autocomplete` (Zielattribute für die jeweiligen Plugins).