### PR TITLE
Deutsche Titel für Kataloge und Seiten

### DIFF
--- a/rdmorganiser/questions/questions-fhpshort.xml
+++ b/rdmorganiser/questions/questions-fhpshort.xml
@@ -3,18 +3,18 @@
 	<catalog dc:uri="https://rdmo.fh-potsdam.de/terms/questions/fhpshort">
 		<uri_prefix>https://rdmo.fh-potsdam.de/terms</uri_prefix>
 		<uri_path>fhpshort</uri_path>
-		<dc:comment>Ein kurzer Fragenkatalog für die FH Potsdam mit den wichtigstens Fragen</dc:comment>
+		<dc:comment>/>
 		<order>1</order>
 		<title lang="en">Brief questionaire</title>
-		<help lang="en"/>
+		<help lang="en">A short question catalogue for the FH Potsdam with the most important questions</help>
 		<title lang="de">Kurzer Fragenkatalog</title>
-		<help lang="de"/>
+		<help lang="de">Ein kurzer Fragenkatalog für die FH Potsdam mit den wichtigstens Fragen</help>
 		<title lang="fr">Questionnaire bref</title>
-		<help lang="fr"/>
+		<help lang="fr">Un catalogue raccourci pour la FH Potsdam avec les questions les plus importantes</help>
 		<title lang="it">Questionario breve</title>
-		<help lang="it"/>
+		<help lang="it">Un catalogo corto per la FH Potsdam con le domande più importanti</help>
 		<title lang="es">Cuestionario breve</title>
-		<help lang="es"/>
+		<help lang="es">Un catálogo corto para la FH Potsdam con las preguntas más importantes</help>
 		<sections>
 			<section dc:uri="https://rdmo.fh-potsdam.de/terms/questions/fhpshort/general" order="0"/>
 			<section dc:uri="https://rdmo.fh-potsdam.de/terms/questions/fhpshort/content-classification" order="1"/>

--- a/rdmorganiser/questions/questions-snf.xml
+++ b/rdmorganiser/questions/questions-snf.xml
@@ -3,18 +3,18 @@
 	<catalog dc:uri="https://rdmorganiser.github.io/terms/questions/snf">
 		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
 		<uri_path>snf</uri_path>
-		<dc:comment>Fragenkatalog für den Schweizer Nationalfonds</dc:comment>
+		<dc:comment/>
 		<order>2</order>
 		<title lang="en">SNF</title>
-		<help lang="en"/>
+		<help lang="en">Catalogue for the Swiss national science foundation</help>
 		<title lang="de">SNF</title>
-		<help lang="de"/>
+		<help lang="de">Fragenkatalog für den Schweizerischer Nationalfonds</help>
 		<title lang="fr">SNF</title>
-		<help lang="fr"/>
+		<help lang="fr">Catalogue pour le Fonds national suisse</help>
 		<title lang="it">SNF</title>
-		<help lang="it"/>
+		<help lang="it">Catalogo per il Fondo nazionale svizzero</help>
 		<title lang="es">SNF</title>
-		<help lang="es"/>
+		<help lang="es">Catálogo para el Fondo nacional suizo</help>
 		<sections>
 			<section dc:uri="https://rdmorganiser.github.io/terms/questions/snf/general" order="0"/>
 			<section dc:uri="https://rdmorganiser.github.io/terms/questions/snf/content-classification" order="1"/>

--- a/rdmorganiser/views/view-variable_check.xml
+++ b/rdmorganiser/views/view-variable_check.xml
@@ -8,7 +8,7 @@
 		<title lang="en">List of all variables</title>
 		<help lang="en">for internal control</help>
 		<title lang="de">Liste aller Variablen</title>
-		<help lang="de">für interne Kontrolle</help>
+		<help lang="de">für die interne Kontrolle</help>
 		<title lang="fr">Liste de toutes les variables</title>
 		<help lang="fr">pour le contrôle intérieur</help>
 		<title lang="it">Lista di tutte le variabili</title>

--- a/shared/Mathmet-QAT/mathmet_qat_data.xml
+++ b/shared/Mathmet-QAT/mathmet_qat_data.xml
@@ -9,14 +9,22 @@
 		<help lang="en">Mathmet quality assurance tools (QAT) plans support the documentation of the people, procedures and activities performed to fulfil predefined quality objectives during the development and maintenance of a specific dataset or meaningful group of datasets, within the metrology community and wider scientific domains, in which quality and trustworthiness are essential. Based on version 19 of PDF template.
 
 A completed data quality assurance plan facilitates the auditing of datasets, particularly with respect to the ISO 8000 series of standards.</help>
-		<title lang="de"/>
-		<help lang="de"/>
-		<title lang="fr"/>
-		<help lang="fr"/>
-		<title lang="it"/>
-		<help lang="it"/>
-		<title lang="es"/>
-		<help lang="es"/>
+		<title lang="de">Mathmet Data Quality Assurance Plan</title>
+		<help lang="de">Die Qualitätssicherungs-Tools (QAT) von Mathmet unterstützen die Dokumentation der beteiligten Personen, Verfahren und Aktivitäten, die zur Erreichung vordefinierter Qualitätsziele bei der Entwicklung und Pflege eines bestimmten Datensatzes oder einer aussagekräftigen Gruppe von Datensätzen erforderlich sind – sowohl innerhalb der Metrologie-Community als auch in weiteren wissenschaftlichen Bereichen, in denen Qualität und Zuverlässigkeit von entscheidender Bedeutung sind. Basierend auf Version 19 der PDF-Vorlage.
+
+Ein ausgefüllter Datenqualitätssicherungsplan erleichtert die Prüfung von Datensätzen, insbesondere im Hinblick auf die Normenreihe ISO 8000.</help>
+		<title lang="fr">Mathmet Data Quality Assurance Plan</title>
+		<help lang="fr">Les plans relatifs aux outils d’assurance qualité (QAT) de Mathmet permettent de documenter les personnes, les procédures et les activités mises en œuvre pour atteindre des objectifs de qualité prédéfinis lors du développement et de la maintenance d’un ensemble de données spécifique ou d’un groupe significatif d’ensembles de données, au sein de la communauté métrologique et dans des domaines scientifiques plus larges, où la qualité et la fiabilité sont essentielles. Basé sur la version 19 du modèle PDF.
+
+Un plan d’assurance qualité des données dûment rempli facilite l’audit des ensembles de données, notamment au regard de la série de normes ISO 8000.</help>
+		<title lang="it">Mathmet Data Quality Assurance Plan</title>
+		<help lang="it">I piani relativi agli strumenti di garanzia della qualità (QAT) di Mathmet supportano la documentazione delle persone, delle procedure e delle attività svolte per soddisfare obiettivi di qualità predefiniti durante lo sviluppo e la manutenzione di un specifico set di dati o di un gruppo significativo di set di dati, nell’ambito della comunità metrologica e in settori scientifici più ampi, in cui la qualità e l’affidabilità sono essenziali. Basato sulla versione 19 del modello PDF.
+
+Un piano di garanzia della qualità dei dati completato facilita la verifica dei set di dati, in particolare per quanto riguarda la serie di norme ISO 8000.</help>
+		<title lang="es">Mathmet Data Quality Assurance Plan</title>
+		<help lang="es">Los planes de herramientas de garantía de calidad (QAT) de Mathmet facilitan la documentación del personal, los procedimientos y las actividades llevadas a cabo para cumplir los objetivos de calidad predefinidos durante el desarrollo y el mantenimiento de un conjunto de datos específico o de un grupo significativo de conjuntos de datos, tanto en el ámbito de la metrología como en otros ámbitos científicos más amplios, en los que la calidad y la fiabilidad son esenciales. Basado en la versión 19 de la plantilla PDF.
+
+Un plan de garantía de calidad de datos debidamente cumplimentado facilita la auditoría de los conjuntos de datos, especialmente en lo que respecta a la serie de normas ISO 8000.</help>
 		<sections>
 			<section dc:uri="https://rdmo.mathmet.eu/questions/mathmet_qat_data/general_information" order="0"/>
 			<section dc:uri="https://rdmo.mathmet.eu/questions/mathmet_qat_data/data_integrity_level" order="1"/>

--- a/shared/Mathmet-QAT/mathmet_qat_software.xml
+++ b/shared/Mathmet-QAT/mathmet_qat_software.xml
@@ -8,14 +8,14 @@ v0.1.0 01/09/2024 Initial release of catalog. Developer Keith Lines, Data Scienc
 		<order>0</order>
 		<title lang="en">Mathmet Software Quality Assurance Plan: Version 0.2.0</title>
 		<help lang="en">This catalog is for developing plans that document quality requirements for developing software for mathematics and statistics in metrology. It is based on the &lt;a href=&quot;https://www.euramet.org/european-metrology-networks/mathmet/activities/quality-assurance-tools&quot; target=&quot;_blank&quot;&gt;Quality Assurance Tools&lt;/a&gt; developed by the &lt;a href=&quot;https://www.euramet.org/european-metrology-networks/mathmet&quot; target=&quot;_blank&quot;&gt;European Metrology Network for Mathematics and Statistics.&lt;/a&gt;</help>
-		<title lang="de"/>
-		<help lang="de"/>
-		<title lang="fr"/>
-		<help lang="fr"/>
-		<title lang="it"/>
-		<help lang="it"/>
-		<title lang="es"/>
-		<help lang="es"/>
+		<title lang="de">Mathmet Software Quality Assurance Plan: Version 0.2.0</title>
+		<help lang="de">Dieser Katalog dient der Erstellung von Plänen zur Dokumentation der Qualitätsanforderungen für die Entwicklung von Software für Mathematik und Statistik in der Messtechnik. Er basiert auf den &lt;a href=&quot;https://www.euramet.org/european-metrology-networks/mathmet/activities/quality-assurance-tools&quot; target=&quot;_blank&quot;&gt;Qualitätssicherungswerkzeugen&lt;/a&gt; , die vom &lt;a href=&quot;https://www.euramet.org/european-metrology-networks/mathmet&quot; target=&quot;_blank&quot;&gt;Europäischen Metrologienetzwerk für Mathematik und Statistik&lt;/a&gt; entwickelt wurden.&lt;/a&gt;</help>
+		<title lang="fr">Mathmet Software Quality Assurance Plan: version 0.2.0</title>
+		<help lang="fr">Ce catalogue sert à élaborer des plans définissant les exigences de qualité relatives au développement de logiciels destinés aux mathématiques et aux statistiques en métrologie. Il s'appuie sur les &lt;a href=&quot;https://www.euramet.org/european-metrology-networks/mathmet/activities/quality-assurance-tools&quot; target=&quot;_blank&quot;&gt;outils d'assurance qualité&lt;/a&gt; développés par le &lt;a href=&quot;https://www.euramet.org/european-metrology-networks/mathmet&quot; target=&quot;_blank&quot;&gt;Réseau européen de métrologie pour les mathématiques et les statistiques.&lt;/a&gt;</help>
+		<title lang="it">Mathmet Software Quality Assurance Plan: versione 0.2.0</title>
+		<help lang="it">Il presente catalogo è destinato all’elaborazione di piani che documentino i requisiti di qualità per lo sviluppo di software per la matematica e la statistica nel campo della metrologia. Si basa sugli &lt;a href=&quot;https://www.euramet.org/european-metrology-networks/mathmet/activities/quality-assurance-tools&quot; target=&quot;_blank&quot;&gt;Strumenti di garanzia della qualità&lt;/a&gt; sviluppati dal &lt;a href=&quot;https://www.euramet.org/european-metrology-networks/mathmet&quot; target=&quot;_blank&quot;&gt;Rete europea di metrologia per la matematica e la statistica.&lt;/a&gt;</help>
+		<title lang="es">Mathmet Software Quality Assurance Plan: versión 0.2.0</title>
+		<help lang="es">Este catálogo está destinado a la elaboración de planes que recojan los requisitos de calidad para el desarrollo de software destinado a las matemáticas y la estadística en el ámbito de la metrología. Se basa en las &lt;a href=&quot;https://www.euramet.org/european-metrology-networks/mathmet/activities/quality-assurance-tools&quot; target=&quot;_blank&quot;&gt;Herramientas de garantía de calidad&lt;/a&gt; desarrolladas por la &lt;a href=&quot;https://www.euramet.org/european-metrology-networks/mathmet&quot; target=&quot;_blank&quot;&gt;Red Europea de Metrología para las Matemáticas y la Estadística.&lt;/a&gt;</help>
 		<sections>
 			<section dc:uri="https://rdmo.mathmet.eu/questions/mathmet_qat_software/general_information" order="1"/>
 			<section dc:uri="https://rdmo.mathmet.eu/questions/mathmet_qat_software/sw_integrity_level" order="2"/>

--- a/shared/metrology-rdm/epm-questions.xml
+++ b/shared/metrology-rdm/epm-questions.xml
@@ -290,9 +290,9 @@ At the end of the procedure the platform produces an export (&quot;view&quot;) o
 		<short_title lang="en">Data origin (general)</short_title>
 		<help lang="en">In the initial DMP a number of details may not yet be known (such as persistent identifiers). However, the plans and intentions should be considered and explained in the following questions.</help>
 		<verbose_name lang="en">dataset group</verbose_name>
-		<title lang="de"/>
-		<short_title lang="de"/>
-		<help lang="de"/>
+		<title lang="de">Anfangs-DMP: Ursprung der Daten (Datensatz-unabhängige Antworte)</title>
+		<short_title lang="de">Datenursprung (allgemein)</short_title>
+		<help lang="de">Im ersten DMP sind möglicherweise noch nicht alle Einzelheiten bekannt (wie z. B. persistente Identifikatoren). Die Pläne und Absichten sollten jedoch berücksichtigt und in den folgenden Fragen erläutert werden.</help>
 		<verbose_name lang="de"/>
 		<questionsets/>
 		<questions>
@@ -468,8 +468,8 @@ List the datasets that your project will generate or use. We recommend grouping 
 
 The datasets and the group they belong to should be given succinct, descriptive names. The list of datasets can be updated during the project.</help>
 		<verbose_name lang="en">dataset group</verbose_name>
-		<title lang="de"/>
-		<short_title lang="de"/>
+		<title lang="de">Mitte- oder End-DMP: Datenursprung (Datensatz-spezifische Antworte)</title>
+		<short_title lang="de">Datenursprung (Datensatz-spezifisch)</short_title>
 		<help lang="de">Dies ist die Version des Fragebogens, die für ein mittelfristiges oder endgültiges DMP verwendet wird. Im Gegensatz zum ersten DMP müssen hier einige Fragen für einzelne Datensätze oder für Gruppen ähnlicher Datensätze beantwortet werden.
 
 Listen Sie die Datensätze auf, die Ihr Projekt erzeugen oder verwenden wird. Wir empfehlen, Daten zu gruppieren, die ähnlich verwaltet werden, z. B. gemeinsam veröffentlicht werden, mit denselben Einschränkungen für die Wiederverwendung gemeinsam genutzt werden, dieselben Sicherheitsprobleme aufweisen, mit denselben Schlüsselwörtern gekennzeichnet sind usw.
@@ -1594,8 +1594,8 @@ _Begünstigte von Horizon Europe müssen einen offenen Zugang zu Forschungsdaten
 		<dc:comment/>
 		<title lang="en">Data description and documentation</title>
 		<short_title lang="en">Description and documentation</short_title>
-		<title lang="de"/>
-		<short_title lang="de"/>
+		<title lang="de">Datenbeschreibung und -dokumentation</title>
+		<short_title lang="de">Beschreibung und Dokumentation</short_title>
 		<pages>
 			<page dc:uri="https://dmp.metrology-rdm.eu/terms/questions/epm/documentation/description" order="1"/>
 			<page dc:uri="https://dmp.metrology-rdm.eu/terms/questions/epm/documentation/documentation" order="2"/>
@@ -2602,8 +2602,8 @@ gdpr.eu/gdpr-consent-requirements: Informed consent means the data subject knows
 		<short_title lang="en">Other outputs (general)</short_title>
 		<help lang="en"/>
 		<verbose_name lang="en"/>
-		<title lang="de"/>
-		<short_title lang="de"/>
+		<title lang="de">Sonstiger Forschungs-Output: allgemeine Information</title>
+		<short_title lang="de">Sonstiger Output (allgemein)</short_title>
 		<help lang="de">&lt;a href=&quot;https://ec.europa.eu/info/funding-tenders/opportunities/docs/2021-2027/horizon/temp-form/report/data-management-plan_he_en.docx&quot; target=_blank&gt;Originalfragen:&lt;/a&gt;
 
 - &lt;i&gt;In addition to the management of data, beneficiaries should also consider and plan for the management of other research outputs that may be generated or re-used throughout their projects. Such outputs can be either digital (e.g. software, workflows, protocols, models, etc.) or physical (e.g. new materials, antibodies, reagents, samples, etc.).&lt;/i&gt;
@@ -2712,8 +2712,8 @@ gdpr.eu/gdpr-consent-requirements: Informed consent means the data subject knows
 		<short_title lang="en">Other outputs (format-specific)</short_title>
 		<help lang="en"/>
 		<verbose_name lang="en"/>
-		<title lang="de"/>
-		<short_title lang="de"/>
+		<title lang="de">Sonstiger Forschungs-Output: Format-spezifische Information</title>
+		<short_title lang="de">Sonstiger Output (formatspezifisch)</short_title>
 		<help lang="de">&lt;a href=&quot;https://ec.europa.eu/info/funding-tenders/opportunities/docs/2021-2027/horizon/temp-form/report/data-management-plan_he_en.docx&quot; target=_blank&gt;Originalfragen:&lt;/a&gt;
 
 - &lt;i&gt;In addition to the management of data, beneficiaries should also consider and plan for the management of other research outputs that may be generated or re-used throughout their projects. Such outputs can be either digital (e.g. software, workflows, protocols, models, etc.) or physical (e.g. new materials, antibodies, reagents, samples, etc.).&lt;/i&gt;


### PR DESCRIPTION
Betroffen sind die Kataloge:
* [shared/Mathmet-QAT/mathmet_qat_data.xml](https://github.com/rdmorganiser/rdmo-catalog/compare/Lokalisierung?expand=1#diff-4a0b12ebe1d32ac9faf5e8c92df101f156da4fc21821ebdc1d17620ac3409bca),
* [shared/Mathmet-QAT/mathmet_qat_software.xml](https://github.com/rdmorganiser/rdmo-catalog/compare/Lokalisierung?expand=1#diff-d107b1241f3520ee55607989c35899aef2da3303020f2ede97ed1c3ae9c8afa4),
* [shared/metrology-rdm/epm-questions.xml](https://github.com/rdmorganiser/rdmo-catalog/compare/Lokalisierung?expand=1#diff-f5d4512292fa9748516f3a4492f63cfa744ef9909bbab688114d061327e25b86),
* FHPshort,
* SNF.

Es wäre schön, perspektivisch auch die respektiven Optionen zu lokalisieren, zumindest ins Deutsche.